### PR TITLE
Add support for exporting metrics to a pushgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,19 @@ write_to_textfile('/configured/textfile/path/raid.prom', registry)
 ```
 
 A separate registry is used, as the default registry may contain other metrics.
+
+## Exporting to a Pushgateway
+
+The [Pushgateway](https://github.com/prometheus/pushgateway)
+allows ephemeral and batch jobs to expose their metrics to Prometheus.
+
+```python
+from prometheus_client import CollectorRegistry,Gauge,build_pushgateway_url,push_to_gateway
+registry = CollectorRegistry()
+g = Gauge('raid_status', '1 if raid array is okay', registry=registry)
+g.set(1)
+url = build_pushgateway_url(job='cooljob', host='pushgateway.mydomain')
+push_to_gateway(url, registry)
+```
+
+A separate registry is used, as the default registry may contain other metrics.

--- a/README.md
+++ b/README.md
@@ -188,12 +188,11 @@ The [Pushgateway](https://github.com/prometheus/pushgateway)
 allows ephemeral and batch jobs to expose their metrics to Prometheus.
 
 ```python
-from prometheus_client import CollectorRegistry,Gauge,build_pushgateway_url,push_to_gateway
+from prometheus_client import CollectorRegistry,Gauge,push_to_gateway
 registry = CollectorRegistry()
 g = Gauge('raid_status', '1 if raid array is okay', registry=registry)
 g.set(1)
-url = build_pushgateway_url(job='cooljob', host='pushgateway.mydomain')
-push_to_gateway(url, registry)
+push_to_gateway(registry, job='somejob', host='pushgateway.mydomain')
 ```
 
 A separate registry is used, as the default registry may contain other metrics.

--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ allows ephemeral and batch jobs to expose their metrics to Prometheus.
 ```python
 from prometheus_client import CollectorRegistry,Gauge,push_to_gateway
 registry = CollectorRegistry()
-g = Gauge('raid_status', '1 if raid array is okay', registry=registry)
-g.set(1)
-push_to_gateway(registry, job='somejob', host='pushgateway.mydomain')
+g = Gauge('job_finished_ok_at', 'last time a batch job successfully finished', registry=registry)
+g.set_to_current_time()
+push_to_gateway(registry, job='batchA', host='pushgateway.mydomain')
 ```
 
 A separate registry is used, as the default registry may contain other metrics.

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -7,7 +7,14 @@ import re
 import os
 import time
 import threading
-import urllib2
+
+try:
+    from urllib2 import urlopen, quote
+except ImportError:
+    # Python 3
+    from urllib.request import urlopen
+    from urllib.parse import quote
+
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler
 except ImportError:
@@ -447,15 +454,15 @@ def build_pushgateway_url(job, instance=None, host='localhost', port=9091):
         instancestr = ''
 
     url = 'http://{}:{}/metrics/jobs/{}{}'.format(host, port,
-                                                  urllib2.quote(job),
-                                                  urllib2.quote(instancestr))
+                                                  quote(job),
+                                                  quote(instancestr))
     return url
 
 
 def push_to_gateway_url(url, registry, timeout=None):
     '''Push metrics to the given url'''
 
-    resp = urllib2.urlopen(url, data=generate_latest(registry), timeout=timeout)
+    resp = urlopen(url, data=generate_latest(registry), timeout=timeout)
     if resp.code >= 400:
         raise IOError("error pushing to pushgateway: {0} {1}".format(
             resp.code, resp.msg))

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -446,7 +446,9 @@ def build_pushgateway_url(job, instance=None, host='localhost', port=9091):
     else:
         instancestr = ''
 
-    url = 'http://{}:{}/metrics/jobs/{}{}'.format(host, port, job, instancestr)
+    url = 'http://{}:{}/metrics/jobs/{}{}'.format(host, port,
+                                                  urllib2.quote(job),
+                                                  urllib2.quote(instancestr))
     return url
 
 

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -450,13 +450,20 @@ def build_pushgateway_url(job, instance=None, host='localhost', port=9091):
     return url
 
 
-def push_to_gateway(url, registry, timeout=None):
+def push_to_gateway_url(url, registry, timeout=None):
     '''Push metrics to the given url'''
 
     resp = urllib2.urlopen(url, data=generate_latest(registry), timeout=timeout)
     if resp.code >= 400:
         raise IOError("error pushing to pushgateway: {0} {1}".format(
             resp.code, resp.msg))
+
+
+def push_to_gateway(registry, job, instance=None, host='localhost', port=9091, timeout=None):
+    '''Push metrics to a pushgateway'''
+
+    url = build_pushgateway_url(job, instance, host, port)
+    push_to_gateway_url(url, registry, timeout)
 
 
 def write_to_textfile(path, registry):

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import copy
 import re
 import os
-import socket
 import time
 import threading
 import urllib2
@@ -437,14 +436,10 @@ class MetricsHandler(BaseHTTPRequestHandler):
         self.wfile.write(generate_latest(REGISTRY))
 
 
-def build_pushgateway_url(job, instance=None, host='localhost', port=9091,
-                          use_fqdn_as_instance=True):
+def build_pushgateway_url(job, instance=None, host='localhost', port=9091):
     '''
     Build a valid pushgateway url
     '''
-
-    if instance is None and use_fqdn_as_instance:
-        instance = socket.getfqdn()
 
     if instance:
         instancestr = '/instances/{}'.format(instance)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-import socket
 import unittest
 
 from prometheus_client import Gauge, Counter, Summary, Histogram
@@ -278,21 +277,7 @@ class TestBuildPushgatewayUrl(unittest.TestCase):
     def test_host_port(self):
         expected = 'http://foohost:9092/metrics/jobs/foojob'
 
-        url = build_pushgateway_url('foojob', host='foohost', port=9092,
-                             use_fqdn_as_instance=False)
-        self.assertEqual(url, expected)
-
-    def test_no_fqdn(self):
-        expected = 'http://localhost:9091/metrics/jobs/foojob'
-
-        url = build_pushgateway_url(job='foojob', use_fqdn_as_instance=False)
-        self.assertEqual(url, expected)
-
-    def test_fqdn(self):
-        fqdn = socket.getfqdn()
-        expected = 'http://localhost:9091/metrics/jobs/foojob/instances/' + fqdn
-
-        url = build_pushgateway_url(job='foojob')
+        url = build_pushgateway_url('foojob', host='foohost', port=9092)
         self.assertEqual(url, expected)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -280,6 +280,13 @@ class TestBuildPushgatewayUrl(unittest.TestCase):
         url = build_pushgateway_url('foojob', host='foohost', port=9092)
         self.assertEqual(url, expected)
 
+    def test_url_escaping(self):
+        expected = 'http://localhost:9091/metrics/jobs/foo%20job'
+
+        url = build_pushgateway_url('foo job')
+        self.assertEqual(url, expected)
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add support for exporting metrics to a pushgateway. By default the fqdn is sent is _instance_ wasn't provided. 