### PR TITLE
Added default registry to write_to_file

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -67,7 +67,7 @@ def start_http_server(port, addr=''):
     t.start()
 
 
-def write_to_textfile(path, registry):
+def write_to_textfile(path, registry=core.REGISTRY):
     '''Write metrics to the given path.
 
     This is intended for use with the Node exporter textfile collector.


### PR DESCRIPTION
@brian-brazil: This is needed to use the default registry with the write_to_file function. I have tested this locally.