### PR TITLE
Several small test fixes

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -126,5 +126,5 @@ def _use_gateway(method, gateway, job, registry, grouping_key, timeout):
 def instance_ip_grouping_key():
     '''Grouping key with instance set to the IP Address of this host.'''
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(('', 0))
+    s.connect(('localhost', 0))
     return {'instance': s.getsockname()[0]}

--- a/tests/graphite_bridge.py
+++ b/tests/graphite_bridge.py
@@ -28,7 +28,9 @@ class TestGraphiteBridge(unittest.TestCase):
         self.t = ServingThread()
         self.t.start()
         
-        self.gb = GraphiteBridge(server.server_address, self.registry, _time=FakeTime())
+        # Explicitly use localhost as the target host, since connecting to 0.0.0.0 fails on Windows
+        address = ('localhost', server.server_address[1])
+        self.gb = GraphiteBridge(address, self.registry, _time=FakeTime())
 
     def test_nolabels(self):
         counter = Counter('c', 'help', registry=self.registry)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -408,15 +408,16 @@ class TestPushGateway(unittest.TestCase):
         self.requests = requests = []
         class TestHandler(BaseHTTPRequestHandler):
             def do_PUT(self):
-                self.send_response(201)
                 length = int(self.headers['content-length'])
                 requests.append((self, self.rfile.read(length)))
+                self.send_response(201)
+                self.end_headers()
 
             do_POST = do_PUT
             do_DELETE = do_PUT
 
         httpd = HTTPServer(('', 0), TestHandler)
-        self.address = ':'.join([str(x) for x in httpd.server_address])
+        self.address = 'localhost:' + str(httpd.server_address[1])
         class TestServer(threading.Thread):
             def run(self):
                 httpd.handle_request()
@@ -466,7 +467,7 @@ class TestPushGateway(unittest.TestCase):
         self.assertEqual(self.requests[0][0].headers.get('content-type'), CONTENT_TYPE_LATEST)
         self.assertEqual(self.requests[0][1], b'')
 
-    def test_pushadd_with_groupingkey(self):
+    def test_delete_with_groupingkey(self):
         delete_from_gateway(self.address, "my_job", {'a': 9})
         self.assertEqual(self.requests[0][0].command, 'DELETE')
         self.assertEqual(self.requests[0][0].path, '/job/my_job/a/9')


### PR DESCRIPTION
@brian-brazil: This bundles together a few small fixes for the tests. Please let me know if you would prefer them as separate pull requests.

- First of all, `test_client.py` contained two tests with the same name (`test_pushadd_with_groupingkey`), so I renamed the second one to the more appropriate `test_delete_with_groupingkey`.

- I also noticed a race condition in the tests, where the assertions that check the received request could be run just before the requests are stored. I fixed this by calling `send_response` after the request is stored, instead of before.

- I then looked at issue #46. It seems there are some small differences in either the HTTP server or client between Python 2.7 and 3.4, which means a call to `end_headers` is required in the HTTP handler for Python 3.4.

- Finally, I ran into some issues running the tests on my Windows machine. It turns out that `socket.connect` throws an error on Windows when using '0.0.0.0' or the empty string as the target host (although either seems to work fine on Linux). I therefore changed the tests to use 'localhost' as the target host instead. This does also affect the `instance_ip_grouping_key` function exposed in the client module, but from some quick testing on my Linux machine there seems to be no difference between the old and new way.

Let me know if you have any questions or comments.