### PR TITLE
Support for namespace in graphite bridge

### DIFF
--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -49,9 +49,14 @@ class GraphiteBridge(object):
         self._timeout = timeout_seconds
         self._time = _time
 
-    def push(self):
+    def push(self, prefix=''):
         now = int(self._time.time())
         output = []
+
+        prefixstr = ''
+        if prefix:
+            prefixstr = prefix + '.'
+
         for metric in self._registry.collect():
             for name, labels, value in metric._samples:
                 if labels:
@@ -61,8 +66,8 @@ class GraphiteBridge(object):
                          for k, v in sorted(labels.items())])
                 else:
                     labelstr = ''
-                output.append('{0}{1} {2} {3}\n'.format(
-                    _sanitize(name), labelstr, float(value), now))
+                output.append('{0}{1}{2} {3} {4}\n'.format(
+                    prefixstr, _sanitize(name), labelstr, float(value), now))
 
         conn = socket.create_connection(self._address, self._timeout)
         conn.sendall(''.join(output).encode('ascii'))

--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -19,10 +19,11 @@ def _sanitize(s):
 
 
 class _RegularPush(threading.Thread):
-    def __init__(self, pusher, interval):
+    def __init__(self, pusher, interval, prefix):
         super(_RegularPush, self).__init__()
         self._pusher = pusher
         self._interval = interval
+        self._prefix = prefix
 
     def run(self):
         wait_until = time.time()
@@ -37,7 +38,7 @@ class _RegularPush(threading.Thread):
                 # time.sleep can return early.
                 time.sleep(wait_until - now)
             try:
-                self._pusher.push()
+                self._pusher.push(prefix=self._prefix)
             except IOError:
                 logging.exception("Push failed")
 
@@ -73,7 +74,7 @@ class GraphiteBridge(object):
         conn.sendall(''.join(output).encode('ascii'))
         conn.close()
 
-    def start(self, interval=60.0):
-        t = _RegularPush(self, interval)
+    def start(self, interval=60.0, prefix=''):
+        t = _RegularPush(self, interval, prefix)
         t.daemon = True
         t.start()

--- a/tests/graphite_bridge.py
+++ b/tests/graphite_bridge.py
@@ -50,6 +50,15 @@ class TestGraphiteBridge(unittest.TestCase):
 
         self.assertEqual(b'labels.a.c.b.d 1.0 1434898897\n', self.data)
 
+    def test_prefix(self):
+        labels = Counter('labels', 'help', ['a', 'b'], registry=self.registry)
+        labels.labels('c', 'd').inc()
+
+        self.gb.push(prefix = 'pre.fix')
+        self.t.join()
+
+        self.assertEqual(b'pre.fix.labels.a.c.b.d 1.0 1434898897\n', self.data)
+
     def test_sanitizing(self):
         labels = Counter('labels', 'help', ['a'], registry=self.registry)
         labels.labels('c.:8').inc()


### PR DESCRIPTION
1. An optional `prefix` parameter in `bridge.graphite.GraphiteBridge.push()`.
2. `prefix` is prepended to metrics name before sending to graphite server.
3. Unit test.

Issue #49 