### PR TITLE
Update help text to match client_golang

### DIFF
--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -62,8 +62,8 @@ class ProcessCollector(object):
             with open(os.path.join(pid, 'stat')) as stat:
                 parts = (stat.read().split(')')[-1].split())
             vmem = core.GaugeMetricFamily(self._prefix + 'virtual_memory_bytes',
-                    'Virtual memory size in bytes', value=float(parts[20]))
-            rss = core.GaugeMetricFamily(self._prefix + 'resident_memory_bytes', 'Resident memory size in bytes', value=float(parts[21]) * _PAGESIZE)
+                    'Virtual memory size in bytes.', value=float(parts[20]))
+            rss = core.GaugeMetricFamily(self._prefix + 'resident_memory_bytes', 'Resident memory size in bytes.', value=float(parts[21]) * _PAGESIZE)
             start_time_secs = float(parts[19]) / self._ticks
             start_time = core.GaugeMetricFamily(self._prefix + 'start_time_seconds',
                     'Start time of the process since unix epoch in seconds.', value=start_time_secs + self._btime)


### PR DESCRIPTION
Good Afternoon!
This  change is to start standardizing the help text between client libraries.

Equivalent in [client_golang](https://github.com/prometheus/client_golang/blob/fcd2986466589bcf7a411ec3b52d85a8df9dcc8b/prometheus/process_collector.go#L69)

Related to: https://github.com/prometheus/client_golang/issues/171

Take care,
Nicholas