### PR TITLE
Add bridge to New Relic

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,42 @@ gb.push()
 gb.start(10.0)
 ```
 
+### New Relic
+
+In order to expose your metrics to New Relic, you need to register a custom data source with the
+[New Relic agent](https://docs.newrelic.com/docs/agents/python-agent):
+
+```python
+import newrelic.agent
+from prometheus_client.bridge.newrelic import PrometheusDataSource
+newrelic.agent.register_data_source(PrometheusDataSource)
+```
+
+Alternatively you can add the following to your `newrelic.ini` configuration file:
+
+```ini
+[data-source:prometheus]
+enabled = true
+function = prometheus_client.bridge.newrelic:PrometheusDataSource
+```
+
+This will export all of your metrics with names like `Custom/metric_name`. By defining settings for the data source as
+shown below, it is also possible to add a prefix to all metric names.
+
+```python
+newrelic.agent.register_data_source(PrometheusDataSource, settings={'prefix': 'some.prefix'})
+```
+
+```ini
+[data-source:prometheus]
+enabled = true
+function = prometheus_client.bridge.newrelic:PrometheusDataSource
+settings = prometheus
+
+[prometheus]
+prefix = some.prefix
+```
+
 ## Custom Collectors
 
 Sometimes it is not possible to directly instrument code, as it is not

--- a/prometheus_client/bridge/newrelic.py
+++ b/prometheus_client/bridge/newrelic.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+import newrelic.agent
+
+from .. import core
+
+
+@newrelic.agent.data_source_factory(name='Prometheus')
+class PrometheusDataSource(object):
+    def __init__(self, settings, environ):
+        self.registry = settings.get('registry', core.REGISTRY)
+        self.prefix = settings.get('prefix', '')
+
+    def __call__(self):
+        prefixstr = ''
+        if self.prefix:
+            prefixstr = self.prefix + '.'
+
+        for metric in self.registry.collect():
+            for name, labels, value in metric.samples:
+                if labels:
+                    labelstr = '.' + '.'.join(['{0}.{1}'.format(k, v) for k, v in sorted(labels.items())])
+                else:
+                    labelstr = ''
+
+                metric_name = 'Custom/{0}{1}{2}'.format(prefixstr, name, labelstr)
+                yield (metric_name, value)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setup(
     url = "https://github.com/prometheus/client_python",
     packages=['prometheus_client', 'prometheus_client.bridge'],
     test_suite="tests",
+    extras_require={
+        "bridge.newrelic": ["newrelic"]
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/tests/test_newrelic_bridge.py
+++ b/tests/test_newrelic_bridge.py
@@ -1,0 +1,40 @@
+import unittest
+
+from prometheus_client import Counter, CollectorRegistry
+from prometheus_client.bridge.newrelic import PrometheusDataSource
+
+
+class TestPrometheusDataSource(unittest.TestCase):
+    def setUp(self):
+        self.registry = CollectorRegistry()
+
+    def get_metrics(self, additional_settings=None):
+        settings = {'registry': self.registry}
+        if additional_settings:
+            settings.update(additional_settings)
+
+        wrapped_data_source = PrometheusDataSource(settings=settings)
+        factory = wrapped_data_source['factory']
+        data_source = factory(environ={})
+        return list(data_source())
+
+    def test_nolabels(self):
+        counter = Counter('c', 'help', registry=self.registry)
+        counter.inc()
+
+        metrics = self.get_metrics()
+        self.assertEqual([('Custom/c', 1.0)], metrics)
+
+    def test_labels(self):
+        labels = Counter('labels', 'help', ['a', 'b'], registry=self.registry)
+        labels.labels('c', 'd').inc()
+
+        metrics = self.get_metrics()
+        self.assertEqual([('Custom/labels.a.c.b.d', 1.0)], metrics)
+
+    def test_prefix(self):
+        labels = Counter('labels', 'help', ['a', 'b'], registry=self.registry)
+        labels.labels('c', 'd').inc()
+
+        metrics = self.get_metrics(additional_settings={'prefix': 'pre.fix'})
+        self.assertEqual([('Custom/pre.fix.labels.a.c.b.d', 1.0)], metrics)


### PR DESCRIPTION
This adds a `PrometheusDataSource` class which can be used for exporting metrics to New Relic, as detailed in the additions to the README. Although I started by creating something similar to the Graphite bridge, this ended up being quite different, as it seemed more convenient to have the New Relic agent gather metrics from the registry whenever it is collecting all of them, rather than calling `record_custom_metric` manually or in another background thread. Especially the fact that you can configure the custom data source from code or from a configuration file is quite neat. However it would probably not be much work to implement something more like the Graphite bridge's manual push / background thread if you wanted to support both.

Unfortunately the tests for the custom data source are quite tied to the way that the `@newrelic.agent.data_source_factory` decorator works. I think the only way to avoid this would be to have the data source class without the decorator for testing, and then have a method that adds the decorator and returns an instance of the class.

Let me know what you think.
