### PR TITLE
Add multi-process support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,22 @@ cache:
   directories:
     - $HOME/.cache/pip
 
+# Pending https://github.com/travis-ci/travis-ci/issues/5027
+before_install:
+  - |
+      if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
+        export PYENV_ROOT="$HOME/.pyenv"
+        if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+          cd "$PYENV_ROOT" && git pull
+        else
+          rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+        fi
+        export PYPY_VERSION="4.0.1"
+        "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
+        virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
+        source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
+      fi
+
 language: python
 
 matrix:

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -3,11 +3,12 @@
 from __future__ import unicode_literals
 
 import copy
-import math
 import json
+import math
+import mmap
 import os
 import re
-import shelve
+import struct
 import types
 from timeit import default_timer
 
@@ -26,6 +27,7 @@ _METRIC_LABEL_NAME_RE = re.compile(r'^[a-zA-Z_:][a-zA-Z0-9_:]*$')
 _RESERVED_METRIC_LABEL_NAME_RE = re.compile(r'^__.*$')
 _INF = float("inf")
 _MINUS_INF = float("-inf")
+_INITIAL_MMAP_SIZE = 1024*1024
 
 
 class CollectorRegistry(object):
@@ -241,50 +243,129 @@ class _MutexValue(object):
       with self._lock:
           return self._value
 
+class _MmapedDict(object):
+    """A dict of doubles, backed by an mmapped file.
+
+    The file starts with a 4 byte int, indicating how much of it is used.
+    Then 4 bytes of padding.
+    There's then a number of entries, consisting of a 4 byte int which is the
+    side of the next field, a utf-8 encoded string key, padding to a 8 byte
+    alignment, and then a 8 byte float which is the value.
+    """
+    def __init__(self, filename):
+        self._lock = Lock()
+        self._f = open(filename, 'a+b')
+        if os.fstat(self._f.fileno()).st_size == 0:
+            self._f.truncate(_INITIAL_MMAP_SIZE)
+        self._capacity = os.fstat(self._f.fileno()).st_size
+        self._m = mmap.mmap(self._f.fileno(), self._capacity)
+
+        self._positions = {}
+        self._used = struct.unpack_from(b'i', self._m, 0)[0]
+        if self._used == 0:
+            self._used = 8
+            struct.pack_into(b'i', self._m, 0, self._used)
+        else:
+            for key, _, pos in self._read_all_values():
+                self._positions[key] = pos
+
+    def _init_value(self, key):
+        """Initilize a value. Lock must be held by caller."""
+        encoded = key.encode('utf-8')
+        # Pad to be 8-byte aligned.
+        padded = encoded + (b' ' * (8 - (len(encoded) + 4) % 8))
+        value = struct.pack('i{0}sd'.format(len(padded)).encode(), len(encoded), padded, 0.0)
+        while self._used + len(value) > self._capacity:
+            self._capacity *= 2
+            self._f.truncate(self._capacity * 2)
+            self._m = mmap.mmap(self._f.fileno(), self._capacity)
+        self._m[self._used:self._used + len(value)] = value
+
+        # Update how much space we've used.
+        self._used += len(value)
+        struct.pack_into(b'i', self._m, 0, self._used)
+        self._positions[key] = self._used - 8
+
+    def _read_all_values(self):
+        """Yield (key, value, pos). No locking is performed."""
+        pos = 8
+        while pos < self._used:
+            encoded_len = struct.unpack_from(b'i', self._m, pos)[0]
+            pos += 4
+            encoded = struct.unpack_from('{0}s'.format(encoded_len).encode(), self._m, pos)[0]
+            padded_len = encoded_len + (8 - (encoded_len + 4) % 8)
+            pos += padded_len
+            value = struct.unpack_from(b'd', self._m, pos)[0]
+            yield encoded.decode('utf-8'), value, pos
+            pos += 8
+
+    def read_all_values(self):
+        """Yield (key, value, pos). No locking is performed."""
+        for k, v, _ in self._read_all_values():
+            yield k, v
+
+    def read_value(self, key):
+        with self._lock:
+            if key not in self._positions:
+                self._init_value(key)
+        pos = self._positions[key]
+        # We assume that reading from an 8 byte aligned value is atomic
+        return struct.unpack_from(b'd', self._m, pos)[0]
+
+    def write_value(self, key, value):
+        with self._lock:
+            if key not in self._positions:
+                self._init_value(key)
+        pos = self._positions[key]
+        # We assume that writing to an 8 byte aligned value is atomic
+        struct.pack_into(b'd', self._m, pos, value)
+
+    def close(self):
+        if self._f:
+            self._f.close()
+            self._f = None
+
 
 def _MultiProcessValue(__pid=os.getpid()):
     pid = __pid
-    samples = {}
-    samples_lock = Lock()
+    files = {}
+    files_lock = Lock()
 
-    class _ShelveValue(object):
-        '''A float protected by a mutex backed by a per-process shelve.'''
+    class _MmapedValue(object):
+        '''A float protected by a mutex backed by a per-process mmaped file.'''
 
         _multiprocess = True
 
         def __init__(self, typ, metric_name, name, labelnames, labelvalues, multiprocess_mode='', **kwargs):
-            with samples_lock:
-                if typ == 'gauge':
-                    file_prefix = typ + '_' +  multiprocess_mode
-                else:
-                    file_prefix = typ
-                if file_prefix not in samples:
-                    filename = os.path.join(os.environ['prometheus_multiproc_dir'], '{0}_{1}.db'.format(file_prefix, pid))
-                    samples[file_prefix] = shelve.open(filename)
-            self._samples = samples[file_prefix]
+            if typ == 'gauge':
+                file_prefix = typ + '_' +  multiprocess_mode
+            else:
+                file_prefix = typ
+            with files_lock:
+                if file_prefix not in files:
+                    filename = os.path.join(
+                            os.environ['prometheus_multiproc_dir'], '{0}_{1}.db'.format(file_prefix, pid))
+                    files[file_prefix] = _MmapedDict(filename)
+            self._file = files[file_prefix]
             self._key = json.dumps((metric_name, name, labelnames, labelvalues))
-            self._value = self._samples.get(self._key, 0.0)
-            self._samples[self._key] = self._value
-            self._samples.sync()
+            self._value = self._file.read_value(self._key)
             self._lock = Lock()
 
         def inc(self, amount):
             with self._lock:
                 self._value += amount
-                self._samples[self._key] = self._value
-                self._samples.sync()
+                self._file.write_value(self._key, self._value)
 
         def set(self, value):
             with self._lock:
                 self._value = value
-                self._samples[self._key] = self._value
-                self._samples.sync()
+                self._file.write_value(self._key, self._value)
 
         def get(self):
             with self._lock:
                 return self._value
 
-    return _ShelveValue
+    return _MmapedValue
 
 
 # Should we enable multi-process mode?

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 
 import copy
 import math
+import json
+import os
 import re
+import shelve
 import types
 from timeit import default_timer
 
@@ -220,7 +223,9 @@ class HistogramMetricFamily(Metric):
 class _MutexValue(object):
     '''A float protected by a mutex.'''
 
-    def __init__(self, name, labelnames, labelvalues):
+    _multiprocess = False
+
+    def __init__(self, typ, metric_name, name, labelnames, labelvalues, **kwargs):
       self._value = 0.0
       self._lock = Lock()
 
@@ -236,7 +241,60 @@ class _MutexValue(object):
       with self._lock:
           return self._value
 
-_ValueClass = _MutexValue
+
+def _MultiProcessValue(__pid=os.getpid()):
+    pid = __pid
+    samples = {}
+    samples_lock = Lock()
+
+    class _ShelveValue(object):
+        '''A float protected by a mutex backed by a per-process shelve.'''
+
+        _multiprocess = True
+
+        def __init__(self, typ, metric_name, name, labelnames, labelvalues, multiprocess_mode='', **kwargs):
+            with samples_lock:
+                if typ == 'gauge':
+                    file_prefix = typ + '_' +  multiprocess_mode
+                else:
+                    file_prefix = typ
+                if file_prefix not in samples:
+                    filename = os.path.join(os.environ['prometheus_multiproc_dir'], '{0}_{1}.db'.format(file_prefix, pid))
+                    samples[file_prefix] = shelve.open(filename)
+            self._samples = samples[file_prefix]
+            self._key = json.dumps((metric_name, name, labelnames, labelvalues))
+            self._value = self._samples.get(self._key, 0.0)
+            self._samples[self._key] = self._value
+            self._samples.sync()
+            self._lock = Lock()
+
+        def inc(self, amount):
+            with self._lock:
+                self._value += amount
+                self._samples[self._key] = self._value
+                self._samples.sync()
+
+        def set(self, value):
+            with self._lock:
+                self._value = value
+                self._samples[self._key] = self._value
+                self._samples.sync()
+
+        def get(self):
+            with self._lock:
+                return self._value
+
+    return _ShelveValue
+
+
+# Should we enable multi-process mode?
+# This needs to be chosen before the first metric is constructed,
+# and as that may be in some arbitrary library the user/admin has
+# no control over we use an enviroment variable.
+if 'prometheus_multiproc_dir' in os.environ:
+    _ValueClass = _MultiProcessValue()
+else:
+    _ValueClass = _MutexValue
 
 
 class _LabelWrapper(object):
@@ -387,7 +445,7 @@ class Counter(object):
     _reserved_labelnames = []
 
     def __init__(self, name, labelnames, labelvalues):
-        self._value = _ValueClass(name, labelnames, labelvalues)
+        self._value = _ValueClass(self._type, name, name, labelnames, labelvalues)
 
     def inc(self, amount=1):
         '''Increment counter by the given amount.'''
@@ -449,8 +507,12 @@ class Gauge(object):
     _type = 'gauge'
     _reserved_labelnames = []
 
-    def __init__(self, name, labelnames, labelvalues):
-        self._value = _ValueClass(name, labelnames, labelvalues)
+    def __init__(self, name, labelnames, labelvalues, multiprocess_mode='all'):
+        if (_ValueClass._multiprocess
+                and multiprocess_mode not in ['min', 'max', 'livesum', 'liveall', 'all']):
+            raise ValueError('Invalid multiprocess mode: ' + multiprocess_mode)
+        self._value = _ValueClass(self._type, name, name, labelnames,
+                labelvalues, multiprocess_mode=multiprocess_mode)
 
     def inc(self, amount=1):
         '''Increment gauge by the given amount.'''
@@ -533,8 +595,8 @@ class Summary(object):
     _reserved_labelnames = ['quantile']
 
     def __init__(self, name, labelnames, labelvalues):
-        self._count = _ValueClass(name + '_count', labelnames, labelvalues)
-        self._sum = _ValueClass(name + '_sum', labelnames, labelvalues)
+        self._count = _ValueClass(self._type, name, name + '_count', labelnames, labelvalues)
+        self._sum = _ValueClass(self._type, name, name + '_sum', labelnames, labelvalues)
 
     def observe(self, amount):
         '''Observe the given amount.'''
@@ -607,7 +669,7 @@ class Histogram(object):
     _reserved_labelnames = ['histogram']
 
     def __init__(self, name, labelnames, labelvalues, buckets=(.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0, _INF)):
-        self._sum = _ValueClass(name + '_sum', labelnames, labelvalues)
+        self._sum = _ValueClass(self._type, name, name + '_sum', labelnames, labelvalues)
         buckets = [float(b) for b in buckets]
         if buckets != sorted(buckets):
             # This is probably an error on the part of the user,
@@ -621,7 +683,7 @@ class Histogram(object):
         self._buckets = []
         bucket_labelnames = labelnames + ('le',)
         for b in buckets:
-          self._buckets.append(_ValueClass(name + '_bucket', bucket_labelnames, labelvalues + (_floatToGoString(b),)))
+          self._buckets.append(_ValueClass(self._type, name, name + '_bucket', bucket_labelnames, labelvalues + (_floatToGoString(b),)))
 
     def observe(self, amount):
         '''Observe the given amount.'''

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+from __future__ import unicode_literals
+
+import glob
+import json
+import os
+import shelve
+
+from . import core
+
+class MultiProcessCollector(object):
+    """Collector for files for multi-process mode."""
+    def __init__(self, registry, path=os.environ.get('prometheus_multiproc_dir')):
+        self._path = path
+        if registry:
+          registry.register(self)
+
+    def collect(self):
+        metrics = {}
+        for f in glob.glob(os.path.join(self._path, '*.db')):
+            parts = os.path.basename(f).split('_')
+            typ = parts[0]
+            for key, value in shelve.open(f).items():
+                metric_name, name, labelnames, labelvalues = json.loads(key)
+                metrics.setdefault(metric_name, core.Metric(metric_name, 'Multiprocess metric', typ))
+                metric = metrics[metric_name]
+                if typ == 'gauge':
+                    pid = parts[2][:-3]
+                    metric._multiprocess_mode = parts[1]
+                    metric.add_sample(name, tuple(zip(labelnames, labelvalues)) + (('pid', pid), ), value)
+                else:
+                    # The deplucates and labels are fixed in the next for.
+                    metric.add_sample(name, tuple(zip(labelnames, labelvalues)), value)
+
+        for metric in metrics.values():
+            samples = {}
+            buckets = {}
+            for name, labels, value in metric.samples:
+                if metric.type == 'gauge':
+                    without_pid = tuple([l for l in labels if l[0] != 'pid'])
+                    if metric._multiprocess_mode == 'min':
+                        samples.setdefault((name, without_pid), value)
+                        if samples[(name, without_pid)] > value:
+                            samples[(name, without_pid)] = value
+                    elif metric._multiprocess_mode == 'max':
+                        samples.setdefault((name, without_pid), value)
+                        if samples[(name, without_pid)] < value:
+                            samples[(name, without_pid)] = value
+                    elif metric._multiprocess_mode == 'livesum':
+                        samples.setdefault((name, without_pid), 0.0)
+                        samples[(name, without_pid)] += value
+                    else:  # all/liveall
+                        samples[(name, labels)] = value
+                elif metric.type == 'histogram':
+                    bucket = [float(l[1]) for l in labels if l[0] == 'le']
+                    if bucket:
+                        # _bucket
+                        without_le = tuple([l for l in labels if l[0] != 'le'])
+                        buckets.setdefault(without_le, {})
+                        buckets[without_le].setdefault(bucket[0], 0.0)
+                        buckets[without_le][bucket[0]] += value
+                    else:
+                        # _sum/_count
+                        samples.setdefault((name, labels), 0.0)
+                        samples[(name, labels)] += value
+                else:
+                    # Counter and Summary.
+                    samples.setdefault((name, labels), 0.0)
+                    samples[(name, labels)] += value
+
+
+            # Accumulate bucket values.
+            if metric.type == 'histogram':
+                for labels, values in buckets.items():
+                    acc = 0.0
+                    for bucket, value in sorted(values.items()):
+                        acc += value
+                        samples[(metric.name + '_bucket', labels + (('le', core._floatToGoString(bucket)), ))] = acc
+                    samples[(metric.name + '_count', labels)] = acc
+
+            # Convert to correct sample format.
+            metric.samples = [(name, dict(labels), value) for (name, labels), value in samples.items()]
+        return metrics.values()
+
+
+def mark_process_dead(pid, path=os.environ.get('prometheus_multiproc_dir')):
+    """Do bookkeeping for when one process dies in a multi-process setup."""
+    for f in glob.glob(os.path.join(path, 'gauge_livesum_{0}.db'.format(pid))):
+        os.remove(f)
+    for f in glob.glob(os.path.join(path, 'gauge_liveall_{0}.db'.format(pid))):
+        os.remove(f)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -109,3 +109,32 @@ class TestMultiProcess(unittest.TestCase):
         self.assertEqual(3, self.registry.get_sample_value('g'))
         mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
         self.assertEqual(2, self.registry.get_sample_value('g'))
+
+class TestMmapedDict(unittest.TestCase):
+    def setUp(self):
+        fd, self.tempfile = tempfile.mkstemp()
+        os.close(fd)
+        self.d = core._MmapedDict(self.tempfile)
+
+    def test_process_restart(self):
+        self.d.write_value('abc', 123.0)
+        self.d.close()
+        self.d = core._MmapedDict(self.tempfile)
+        self.assertEqual(123, self.d.read_value('abc'))
+        self.assertEqual([('abc', 123.0)], list(self.d.read_all_values()))
+
+    def test_expansion(self):
+        key = 'a' * core._INITIAL_MMAP_SIZE
+        self.d.write_value(key, 123.0)
+        self.assertEqual([(key, 123.0)], list(self.d.read_all_values()))
+
+    def test_multi_expansion(self):
+        key = 'a' * core._INITIAL_MMAP_SIZE * 4
+        self.d.write_value('abc', 42.0)
+        self.d.write_value(key, 123.0)
+        self.d.write_value('def', 17.0)
+        self.assertEqual([('abc', 42.0), (key, 123.0), ('def', 17.0)],
+                list(self.d.read_all_values()))
+
+    def tearDown(self):
+        os.unlink(self.tempfile)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -1,0 +1,111 @@
+from __future__ import unicode_literals
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+import prometheus_client
+from prometheus_client.core import *
+from prometheus_client.multiprocess import *
+
+class TestMultiProcess(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        os.environ['prometheus_multiproc_dir'] = self.tempdir
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(123)
+        self.registry = CollectorRegistry()
+        MultiProcessCollector(self.registry, self.tempdir)
+
+    def tearDown(self):
+        del os.environ['prometheus_multiproc_dir']
+        shutil.rmtree(self.tempdir)
+        prometheus_client.core._ValueClass = prometheus_client.core._MutexValue
+
+    def test_counter_adds(self):
+        c1 = Counter('c', 'help', registry=None)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        c2 = Counter('c', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('c'))
+        c1.inc(1)
+        c2.inc(2)
+        self.assertEqual(3, self.registry.get_sample_value('c'))
+
+    def test_summary_adds(self):
+        s1 = Summary('s', 'help', registry=None)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        s2 = Summary('s', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('s_count'))
+        self.assertEqual(0, self.registry.get_sample_value('s_sum'))
+        s1.observe(1)
+        s2.observe(2)
+        self.assertEqual(2, self.registry.get_sample_value('s_count'))
+        self.assertEqual(3, self.registry.get_sample_value('s_sum'))
+
+    def test_histogram_adds(self):
+        h1 = Histogram('h', 'help', registry=None)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        h2 = Histogram('h', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('h_count'))
+        self.assertEqual(0, self.registry.get_sample_value('h_sum'))
+        self.assertEqual(0, self.registry.get_sample_value('h_bucket', {'le': '5.0'}))
+        h1.observe(1)
+        h2.observe(2)
+        self.assertEqual(2, self.registry.get_sample_value('h_count'))
+        self.assertEqual(3, self.registry.get_sample_value('h_sum'))
+        self.assertEqual(2, self.registry.get_sample_value('h_bucket', {'le': '5.0'}))
+
+    def test_gauge_all(self):
+        g1 = Gauge('g', 'help', registry=None)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        g2 = Gauge('g', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '123'}))
+        self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
+        g1.set(1)
+        g2.set(2)
+        mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
+        self.assertEqual(1, self.registry.get_sample_value('g', {'pid': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
+
+    def test_gauge_liveall(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
+        self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '123'}))
+        self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value('g', {'pid': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
+        mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
+        self.assertEqual(None, self.registry.get_sample_value('g', {'pid': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
+
+    def test_gauge_min(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='min')
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='min')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value('g'))
+
+    def test_gauge_max(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(2, self.registry.get_sample_value('g'))
+
+    def test_gauge_livesum(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(3, self.registry.get_sample_value('g'))
+        mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
+        self.assertEqual(2, self.registry.get_sample_value('g'))


### PR DESCRIPTION
This works by having a shelve per process that are continously updated
with metrics, and a collector that reads from them.

Histogram buckets need accumulation and special handling for _count,
and for gauges we need to offer a number of options.

Fixes #30 