### PR TITLE
WIP: uWSGI Multiprocess Support

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -257,27 +257,46 @@ def _MultiProcessValue(__pid=os.getpid()):
                     file_prefix = typ + '_' +  multiprocess_mode
                 else:
                     file_prefix = typ
+
                 if file_prefix not in samples:
                     filename = os.path.join(os.environ['prometheus_multiproc_dir'], '{0}_{1}.db'.format(file_prefix, pid))
-                    samples[file_prefix] = shelve.open(filename)
-            self._samples = samples[file_prefix]
-            self._key = json.dumps((metric_name, name, labelnames, labelvalues))
-            self._value = self._samples.get(self._key, 0.0)
-            self._samples[self._key] = self._value
-            self._samples.sync()
-            self._lock = Lock()
+                    self._samples_filename = filename
+                    db = shelve.open(filename)
+                    self._key = json.dumps((metric_name, name, labelnames, labelvalues))
+                    self._value = db.get(self._key, 0.0)
+                    db[self._key] = self._value
+                    db.close()
+                else:
+                    self._samples = {}
+                    self._key = json.dumps((metric_name, name, labelnames, labelvalues))
+                    self._value = self._samples.get(self._key, 0.0)
+                    self._samples[self._key] = self._value
+
+                self._lock = Lock()
 
         def inc(self, amount):
             with self._lock:
                 self._value += amount
-                self._samples[self._key] = self._value
-                self._samples.sync()
+
+                if hasattr(self, "_samples"):
+                    self._samples[self._key] = self._value
+                else:
+                    db = shelve.open(self._samples_filename)
+                    db[self._key] = self._value
+                    db.sync()
+                    db.close()
 
         def set(self, value):
             with self._lock:
                 self._value = value
-                self._samples[self._key] = self._value
-                self._samples.sync()
+
+                if hasattr(self, "_samples"):
+                    self._samples[self._key] = self._value
+                else:
+                    db = shelve.open(self._samples_filename)
+                    db[self._key] = self._value
+                    db.sync()
+                    db.close()
 
         def get(self):
             with self._lock:

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -310,17 +310,8 @@ def _ShelveValue(__pid=os.getpid()):
 
 
 def _UWSGIValue(pid=os.getpid()):
-    import uwsgidecorators
-
     samples = {}
     samples_lock = Lock()
-
-    @uwsgidecorators.postfork
-    @uwsgidecorators.lock
-    def register():
-        existing_workers = uwsgi.cache_get("prometheus_workers")
-        workers = "{}.{}".format(existing_workers, pid)
-        uwsgi.cache_update("prometheus_workers", workers)
 
     class UWSGIValue(_PartitionedValue):
 

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -9,71 +9,267 @@ import shelve
 
 from . import core
 
-class MultiProcessCollector(object):
-    """Collector for files for multi-process mode."""
-    def __init__(self, registry, path=os.environ.get('prometheus_multiproc_dir')):
-        self._path = path
+
+class Submetric(object):
+    """Simple submetric with a parent and value.
+    """
+
+    def __init__(self, name, parent_name, value=None, labels=None, kind=None):
+        self.name = name
+        self.parent_name = parent_name
+        self.value = value
+        self.labels = labels
+        self.kind = kind
+        self.meta = None
+
+    def __repr__(self):
+        return "Submetric('{}', '{}', value={}, labels={}, kind='{}')".format(
+            self.name,
+            self.parent_name,
+            self.value,
+            self.labels,
+            self.kind
+        )
+
+    @classmethod
+    def from_key(cls, key, kind, value=None):
+        """Generates a ``Submetric`` from a legacy encoded key.
+        """
+        parent_name, name, label_names, label_values = json.loads(key)
+
+        return cls(
+            name,
+            parent_name,
+            value=value,
+            labels=zip(label_names, label_values),
+            kind=kind
+        )
+
+
+class Metric(object):
+    """Full metric that groups submetrics.
+    """
+
+    def __init__(self, name=None, kind=None, labels=None):
+        self.name = name
+        self.kind = kind
+        self.labels = labels or []
+
+        self._samples = []
+        self._submetrics = []
+
+    def add_submetric(self, submetric):
+        """Merges in a new submetric, given it is of the same type.
+
+        :param SingleMetric single_metric:
+        """
+        if not isinstance(submetric, Submetric):
+            raise ValueError(
+                "Cannot add item of type '%r', expected 'Submetric'" % type(submetric)
+            )
+
+        if self.name != submetric.parent_name:
+            raise ValueError("Cannot add submetric with different parent")
+
+        if self.kind != submetric.kind:
+            raise ValueError("Cannot add submetrics of different kinds")
+
+        self._submetrics.append(submetric)
+
+    def materialize(self):
+        """Express the Metric as a fully-formed Prometheus metric with samples.
+        """
+        metric = core.Metric(self.name, "Multiprocess metric", self.kind)
+        metric.samples = [
+            (name, dict(labels), value) for (name, labels), value in self._samples.iteritems()
+        ]
+        return metric
+
+    @classmethod
+    def from_submetric(cls, submetric):
+        """Build a new ``Metric`` from an initial ``Submetric``.
+        """
+        if not isinstance(submetric, Submetric):
+            raise ValueError(
+                "Cannot create metric from '%r', expected one of 'Submetric'" % type(submetric)
+            )
+
+        metric = cls(
+            name=submetric.parent_name,
+            kind=submetric.kind,
+            labels=submetric.labels
+        )
+        metric._submetrics = [submetric]
+        return metric
+
+
+class MergeMetric(object):
+    """Metric intended to be merged against others during collection.
+    """
+    pass
+
+
+class GaugeMergeMetric(MergeMetric):
+
+    @classmethod
+    def build(cls, submetric, samples):
+        """Generate samples for this submetric.
+        """
+        labels_without_partition = tuple([l for l in submetric.labels if l[0] != "partition"])
+        key = (submetric.name, labels_without_partition)
+        mode = submetric.meta["collect_mode"]
+
+        if mode == "min":
+            sample = samples.get(key)
+            if sample is None or sample > submetric.value:
+                samples[key] = submetric.value
+        elif mode == "max":
+            sample = samples.get(key)
+            if sample is None or sample < submetric.value:
+                samples[key] = submetric.value
+        elif mode == "livesum":
+            sample = samples.get(key, 0.0)
+            samples[key] = sample + submetric.value
+        else:
+            all_key = (submetric.name, tuple(submetric.labels))
+            samples[all_key] = submetric.value
+
+        return samples
+
+
+class HistogramMergeMetric(MergeMetric):
+
+    @classmethod
+    def build(cls, submetric, samples, buckets):
+        """Generate samples and buckets for this submetric.
+        """
+        # TODO: This is a weird way to determind if this is a bucket or sum
+        # sample...
+        bucket = [float(l[1]) for l in submetric.labels if l[0] == 'le']
+        if bucket:
+            bucket = bucket[0]
+
+        if bucket:
+            key = tuple([l for l in submetric.labels if l[0] != 'le'])
+            histogram = buckets.get(key, {})
+            measurement = histogram.get(bucket, 0.0)
+            histogram[bucket] = measurement + submetric.value
+            buckets[key] = histogram
+        else:
+            key = (submetric.name, tuple(submetric.labels))
+            sample = samples.get(key, 0.0)
+            samples[key] = sample + submetric.value
+
+        return samples, buckets
+
+
+class PartitionedCollector(object):
+    """Joins disparate metrics samples as one.
+
+    This is particularly useful with multiprocess setups in which there is no
+    shared state. In those cases the shared state can be simulated by having
+    each independent process collect its own metrics, then join these metrics
+    into a snapshot of all processes' metrics at collect time.
+    """
+
+    def __init__(self, registry):
+        self.metrics = {}
         if registry:
-          registry.register(self)
+            registry.register(self)
+
+    def gather(self):
+        """Gather metrics prior to collection.
+
+        This method must gather the necessary metrics and set them as a dict
+        of a JSON-encoded key to another dict of (at least) value and kind:
+
+        {
+            '["h", "h_sum", [], []]': {
+                'kind': 'gauge',
+                'value': 0.5,
+                'partition': '123'
+            }
+        }
+        """
+        raise NotImplementedError
+
+    def post_gather(self, raw):
+        for data in raw:
+            submetric = Submetric.from_key(data["key"], data["kind"], value=data["value"])
+            submetric.meta = data.get("meta")
+
+            if data.get("partition") is not None:
+                submetric.labels += (("partition", data["partition"]), )
+
+            if submetric.parent_name in self.metrics:
+                self.metrics[submetric.parent_name].add_submetric(submetric)
+            else:
+                self.metrics[submetric.parent_name] = Metric.from_submetric(submetric)
 
     def collect(self):
-        metrics = {}
+        """Entry point that must collect and return from multiple ``Metric``s.
+        """
+        raise NotImplementedError
+
+
+class ShelveCollector(PartitionedCollector):
+    def __init__(self, registry, path=os.environ.get("prometheus_multiproc_dir")):
+        super(ShelveCollector, self).__init__(registry)
+        self._path = path
+
+    def gather(self):
+        raw = []
         for f in glob.glob(os.path.join(self._path, '*.db')):
             parts = os.path.basename(f).split('_')
-            typ = parts[0]
+            kind = parts[0]
             db = shelve.open(f)
-            for key, value in db.items():
-                metric_name, name, labelnames, labelvalues = json.loads(key)
-                metrics.setdefault(metric_name, core.Metric(metric_name, 'Multiprocess metric', typ))
-                metric = metrics[metric_name]
-                if typ == 'gauge':
-                    pid = parts[2][:-3]
-                    metric._multiprocess_mode = parts[1]
-                    metric.add_sample(name, tuple(zip(labelnames, labelvalues)) + (('pid', pid), ), value)
-                else:
-                    # The deplucates and labels are fixed in the next for.
-                    metric.add_sample(name, tuple(zip(labelnames, labelvalues)), value)
-            db.close()
 
-        for metric in metrics.values():
+            for encoded_key, value in db.items():
+                payload = dict(
+                    key=encoded_key,
+                    kind=kind,
+                    value=value
+                )
+
+                if kind == "gauge":
+                    payload["partition"] = parts[2][:-3]  # pid
+                    payload["meta"] = dict(
+                        collect_mode=parts[1]
+                    )
+
+                raw.append(payload)
+            db.close()
+        return raw
+
+    def collect(self):
+        """Fold up all metrics properly by kind.
+        """
+        self.metrics = {}
+        raw = self.gather()
+        self.post_gather(raw)
+            
+        results = []
+        for metric_key, metric in self.metrics.iteritems():
             samples = {}
             buckets = {}
-            for name, labels, value in metric.samples:
-                if metric.type == 'gauge':
-                    without_pid = tuple([l for l in labels if l[0] != 'pid'])
-                    if metric._multiprocess_mode == 'min':
-                        samples.setdefault((name, without_pid), value)
-                        if samples[(name, without_pid)] > value:
-                            samples[(name, without_pid)] = value
-                    elif metric._multiprocess_mode == 'max':
-                        samples.setdefault((name, without_pid), value)
-                        if samples[(name, without_pid)] < value:
-                            samples[(name, without_pid)] = value
-                    elif metric._multiprocess_mode == 'livesum':
-                        samples.setdefault((name, without_pid), 0.0)
-                        samples[(name, without_pid)] += value
-                    else:  # all/liveall
-                        samples[(name, labels)] = value
-                elif metric.type == 'histogram':
-                    bucket = [float(l[1]) for l in labels if l[0] == 'le']
-                    if bucket:
-                        # _bucket
-                        without_le = tuple([l for l in labels if l[0] != 'le'])
-                        buckets.setdefault(without_le, {})
-                        buckets[without_le].setdefault(bucket[0], 0.0)
-                        buckets[without_le][bucket[0]] += value
-                    else:
-                        # _sum
-                        samples.setdefault((name, labels), 0.0)
-                        samples[(name, labels)] += value
+
+            for submetric in metric._submetrics:
+                if submetric.kind == "gauge":
+                    samples = GaugeMergeMetric.build(submetric, samples)
+                elif submetric.kind == "histogram":
+                    samples, buckets = HistogramMergeMetric.build(
+                        submetric,
+                        samples,
+                        buckets
+                    )
                 else:
                     # Counter and Summary.
-                    samples.setdefault((name, labels), 0.0)
-                    samples[(name, labels)] += value
-
+                    key = (submetric.name, tuple(submetric.labels))
+                    sample = samples.get(key, 0.0)
+                    samples[key] = sample + submetric.value
 
             # Accumulate bucket values.
-            if metric.type == 'histogram':
+            if metric.kind == "histogram":
                 for labels, values in buckets.items():
                     acc = 0.0
                     for bucket, value in sorted(values.items()):
@@ -81,9 +277,9 @@ class MultiProcessCollector(object):
                         samples[(metric.name + '_bucket', labels + (('le', core._floatToGoString(bucket)), ))] = acc
                     samples[(metric.name + '_count', labels)] = acc
 
-            # Convert to correct sample format.
-            metric.samples = [(name, dict(labels), value) for (name, labels), value in samples.items()]
-        return metrics.values()
+            metric._samples = samples
+            results.append(metric.materialize())
+        return results
 
 
 def mark_process_dead(pid, path=os.environ.get('prometheus_multiproc_dir')):

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -21,7 +21,8 @@ class MultiProcessCollector(object):
         for f in glob.glob(os.path.join(self._path, '*.db')):
             parts = os.path.basename(f).split('_')
             typ = parts[0]
-            for key, value in shelve.open(f).items():
+            db = shelve.open(f)
+            for key, value in db.items():
                 metric_name, name, labelnames, labelvalues = json.loads(key)
                 metrics.setdefault(metric_name, core.Metric(metric_name, 'Multiprocess metric', typ))
                 metric = metrics[metric_name]
@@ -32,6 +33,7 @@ class MultiProcessCollector(object):
                 else:
                     # The deplucates and labels are fixed in the next for.
                     metric.add_sample(name, tuple(zip(labelnames, labelvalues)), value)
+            db.close()
 
         for metric in metrics.values():
             samples = {}

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -314,23 +314,14 @@ class UWSGICollector(PartitionedCollector):
 
     def gather(self):
         import uwsgi
-        import uwsgidecorators
 
-        # Get the magic worker listing from cache
-        @uwsgidecorators.lock
-        def cache_get_workers():
-            workers = uwsgi.cache_get("prometheus_workers")
-            return workers.split(".")
-
-        #workers = cache_get_workers()
         workers = uwsgi.workers()
         resolution = 1000000
 
         raw = []
-        #for w in workers:
         keys = uwsgi.cache_keys()
         for key in keys:
-            if key.startswith("prometheus_") and key != "prometheus_workers":
+            if key.startswith("prometheus_"):
                 key_body = key.replace("prometheus_", "")
                 key_prefix, encoded_key = key_body.split("-")
 

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -316,7 +316,7 @@ class UWSGICollector(PartitionedCollector):
         import uwsgi
 
         workers = uwsgi.workers()
-        resolution = 1000000
+        resolution = 100000000000000.0
 
         raw = []
         keys = uwsgi.cache_keys()

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -15,7 +15,7 @@ class TestMultiProcess(unittest.TestCase):
         os.environ['prometheus_multiproc_dir'] = self.tempdir
         prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(123)
         self.registry = CollectorRegistry()
-        MultiProcessCollector(self.registry, self.tempdir)
+        ShelveCollector(self.registry, self.tempdir)
 
     def tearDown(self):
         del os.environ['prometheus_multiproc_dir']
@@ -59,27 +59,27 @@ class TestMultiProcess(unittest.TestCase):
         g1 = Gauge('g', 'help', registry=None)
         prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
         g2 = Gauge('g', 'help', registry=None)
-        self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '123'}))
-        self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
+        self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '456'}))
         g1.set(1)
         g2.set(2)
         mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
-        self.assertEqual(1, self.registry.get_sample_value('g', {'pid': '123'}))
-        self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
+        self.assertEqual(1, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'partition': '456'}))
 
     def test_gauge_liveall(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
         prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
-        self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '123'}))
-        self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
+        self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '456'}))
         g1.set(1)
         g2.set(2)
-        self.assertEqual(1, self.registry.get_sample_value('g', {'pid': '123'}))
-        self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
+        self.assertEqual(1, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'partition': '456'}))
         mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
-        self.assertEqual(None, self.registry.get_sample_value('g', {'pid': '123'}))
-        self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
+        self.assertEqual(None, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'partition': '456'}))
 
     def test_gauge_min(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='min')

--- a/tests/test_shelve.py
+++ b/tests/test_shelve.py
@@ -13,7 +13,7 @@ class TestMultiProcess(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         os.environ['prometheus_multiproc_dir'] = self.tempdir
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(123)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(123)
         self.registry = CollectorRegistry()
         ShelveCollector(self.registry, self.tempdir)
 
@@ -24,7 +24,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_counter_adds(self):
         c1 = Counter('c', 'help', registry=None)
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(456)
         c2 = Counter('c', 'help', registry=None)
         self.assertEqual(0, self.registry.get_sample_value('c'))
         c1.inc(1)
@@ -33,7 +33,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_summary_adds(self):
         s1 = Summary('s', 'help', registry=None)
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(456)
         s2 = Summary('s', 'help', registry=None)
         self.assertEqual(0, self.registry.get_sample_value('s_count'))
         self.assertEqual(0, self.registry.get_sample_value('s_sum'))
@@ -44,7 +44,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_histogram_adds(self):
         h1 = Histogram('h', 'help', registry=None)
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(456)
         h2 = Histogram('h', 'help', registry=None)
         self.assertEqual(0, self.registry.get_sample_value('h_count'))
         self.assertEqual(0, self.registry.get_sample_value('h_sum'))
@@ -57,7 +57,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_all(self):
         g1 = Gauge('g', 'help', registry=None)
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(456)
         g2 = Gauge('g', 'help', registry=None)
         self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '123'}))
         self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '456'}))
@@ -69,7 +69,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_liveall(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
         self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '123'}))
         self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '456'}))
@@ -83,7 +83,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_min(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='min')
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='min')
         self.assertEqual(0, self.registry.get_sample_value('g'))
         g1.set(1)
@@ -92,7 +92,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_max(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
         self.assertEqual(0, self.registry.get_sample_value('g'))
         g1.set(1)
@@ -101,7 +101,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_livesum(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._ShelveValue(456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')
         self.assertEqual(0, self.registry.get_sample_value('g'))
         g1.set(1)

--- a/tests/test_uwsgi.py
+++ b/tests/test_uwsgi.py
@@ -1,0 +1,179 @@
+from __future__ import unicode_literals
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+from mock import patch
+
+import prometheus_client
+from prometheus_client.core import *
+from prometheus_client.multiprocess import *
+
+class TestMultiProcess(unittest.TestCase):
+    def setUp(self):
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(123)
+        self.registry = CollectorRegistry()
+        UWSGICollector(self.registry)
+
+        import uwsgi
+        uwsgi.cache_clear()
+
+    def tearDown(self):
+        prometheus_client.core._ValueClass = prometheus_client.core._MutexValue
+
+    def test_pid_alive(self):
+        ws = (
+            {
+                "pid": 123,
+                "status": "idle"
+            },
+        )
+        self.assertFalse(UWSGICollector._pid_dead(123, ws))
+
+    def test_pid_dead(self):
+        ws = (
+            {
+                "pid": 456,
+                "status": "cheap"
+            },
+        )
+        self.assertTrue(UWSGICollector._pid_dead(456, ws))
+
+    def test_pid_not_in_workers(self):
+        ws = (
+            {
+                "pid": 789,
+                "status": "cheap"
+            },
+        )
+        self.assertTrue(UWSGICollector._pid_dead(200, ws))
+
+    def test_counter_adds(self):
+        c1 = Counter('c', 'help', registry=None)
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(456)
+        c2 = Counter('c', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('c'))
+        c1.inc(1)
+        c2.inc(2)
+        self.assertEqual(3, self.registry.get_sample_value('c'))
+
+    def test_summary_adds(self):
+        s1 = Summary('s', 'help', registry=None)
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(456)
+        s2 = Summary('s', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('s_count'))
+        self.assertEqual(0, self.registry.get_sample_value('s_sum'))
+        s1.observe(1)
+        s2.observe(2)
+        self.assertEqual(2, self.registry.get_sample_value('s_count'))
+        self.assertEqual(3, self.registry.get_sample_value('s_sum'))
+
+    def test_histogram_adds(self):
+        h1 = Histogram('h', 'help', registry=None)
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(456)
+        h2 = Histogram('h', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('h_count'))
+        self.assertEqual(0, self.registry.get_sample_value('h_sum'))
+        self.assertEqual(0, self.registry.get_sample_value('h_bucket', {'le': '5.0'}))
+        h1.observe(1)
+        h2.observe(2)
+        self.assertEqual(2, self.registry.get_sample_value('h_count'))
+        self.assertEqual(3, self.registry.get_sample_value('h_sum'))
+        self.assertEqual(2, self.registry.get_sample_value('h_bucket', {'le': '5.0'}))
+
+    @patch("uwsgi.workers")
+    def test_gauge_all(self, workers_):
+        workers_.return_value = (
+            dict(pid="123", status="idle"),
+            dict(pid="456", status="idle")
+        )
+
+        g1 = Gauge('g', 'help', registry=None)
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(456)
+        g2 = Gauge('g', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '456'}))
+        g1.set(1)
+        g2.set(2)
+
+        workers_.return_value = (
+            dict(pid="123", status="cheap"),
+            dict(pid="456", status="busy")
+        )
+
+        self.assertEqual(1, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'partition': '456'}))
+
+    @patch("uwsgi.workers")
+    def test_gauge_liveall(self, workers_):
+        workers_.return_value = (
+            dict(pid="123", status="idle"),
+            dict(pid="456", status="idle")
+        )
+
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
+        self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(0, self.registry.get_sample_value('g', {'partition': '456'}))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'partition': '456'}))
+
+        workers_.return_value = (
+            dict(pid=123, status="cheap"),
+            dict(pid=456, status="busy")
+        )
+
+        self.assertEqual(None, self.registry.get_sample_value('g', {'partition': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g', {'partition': '456'}))
+
+    def test_gauge_min(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='min')
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='min')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value('g'))
+
+    def test_gauge_max(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(2, self.registry.get_sample_value('g'))
+
+    @patch("uwsgi.workers")
+    def test_gauge_livesum(self, workers_):
+        workers_.return_value = (
+            dict(pid=123, status="idle"),
+            dict(pid=456, status="idle")
+        )
+
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')
+        prometheus_client.core._ValueClass = prometheus_client.core._UWSGIValue(456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(3, self.registry.get_sample_value('g'))
+
+        workers_.return_value = (
+            dict(pid=123, status="cheap"),
+            dict(pid=456, status="busy")
+        )
+
+        self.assertEqual(2, self.registry.get_sample_value('g'))
+
+def application(env, start_response):
+    import uwsgi
+    import pytest
+    pytest.main("tests/test_uwsgi.py")
+    start_response('200 OK', [('Content-Type','text/html')])
+    return [b""]


### PR DESCRIPTION
We've been looking into Prometheus and were almost immediately bit by #30. We brainstormed some solutions and I've made some major changes on top of @brian-brazil's work in the multiproc branch that are pretty large, so I'm opening now, unfinished, to gather feedback and (hopefully) finish this out.

High-level list of changes:
- `MultiProcess` has been swapped for `Partitioned`, like `PartitionedCollector` for example.
- Formalized `Metric` and `Submetric` as classes that know how to recreate themselves from otherwise mushy data (the key JSON, for example). I'm still unhappy with these, as they confound the `Metric` in the main part of the library, and I think the two should be merged into a single kind, but in trying to limit scope, I held off.
- Broke out the heavily loop-based logic for samples into a bit more object-based structure, where `PartitionedMetric`s hold the logic for building their list of samples, rather than having branches and further inner loops to handle each case. I think there is more that can be done here.
- Perhaps most importantly, this breaks out the logic for merging samples in "partitions" (separated by the process boundary walls) from collecting that data from `shelve` so that it is more generic. This opens the door to...
- uWSGI cache subsystem-backed values, which are still divided by process, but should be significantly faster than `shelve`. There are numerous sticky things about this implementation still, and I think this is more of a POC than anything, but I'm now convinced it will work. See the uWSGI notes at the bottom for more...

Minor changes:
- The shelve files are explicitly opened and closed now. Tests were failing under OS X as the files were in use.
- Split out similar constants into enum-like classes, which should be less fragile in the long term. Have not reflected this out into the other modules yet, but I think that should happen outside this PR.

Still left to do:
- [ ] Revise docs
- [ ] Further test coverage
- [ ] Clean up and refine semantics
- [ ] Review/rework key format (see `UWSGIValue` constructor)

So, again, I'm hoping for feedback on the direction this is going, other ideas, critiques, and nits. I do apologize for the huge PR, but I hope it's welcome!

uWSGI notes:
- The cache subsystem deals in integers, so I used a terrible trick (multiply by a sufficiently large number, truncate decimal places) to smash a float into it. Would love ideas on a more rigorous way to do this. It's also pretty space-expensive, but the cache block sizes are fixed anyway.
- The cache subsystem can atomically increment and decrement but "set" is unimplemented. If it were available, it might be that a partitioned strategy isn't needed at all as the cache is global and IPC-safe.
- The **metrics** subsystem would be an ideal fit but the metrics one collects must be defined up front, and cannot be specified at runtime, which I think is against the philosophy of Prometheus and would also just not work with the library as-is.
- I'm still not happy with the uWSGI test "harness" which involves installing uWSGI, pytest, and the client in a virtualenv, then running pytest, which will at some point spawn and app running the test file under uWSGI, make an HTTP request to that app, and either succeed or fail based on the response code. There's no insight into which tests failed at that point and it's very hacky. This is because uWSGI's Python API seems to only be available when uWSGI is running. Still brainstorming; might be best to mock out the uWSGI cache interface, for example.