### PR TITLE
Return an explicit 500 if there's an exception generating metrics

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import logging
 import os
 import socket
 import time
@@ -70,10 +71,18 @@ def generate_latest(registry=core.REGISTRY):
 
 class MetricsHandler(BaseHTTPRequestHandler):
     def do_GET(self):
+        try:
+            content = generate_latest(core.REGISTRY)
+        except:
+            logging.exception('error generating response')
+            self.send_error(500, 'error generating metrics')
+            self.end_headers()
+            return
+
         self.send_response(200)
         self.send_header('Content-Type', CONTENT_TYPE_LATEST)
         self.end_headers()
-        self.wfile.write(generate_latest(core.REGISTRY))
+        self.wfile.write(content)
 
     def log_message(self, format, *args):
         return


### PR DESCRIPTION
The current behaviour observed in #84 is pretty bad. This implements the simplest possible fix: if there's any exception of any kind generating metrics, log it as we are now, but change the response code to a 500.

`send_error` is used, which dumps a random bit of html into the response, which doesn't seem like a problem. `send_response(500)` could be used instead, to get a 500 with a blank body.
