### PR TITLE
Make tests pass on Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ language: python
 
 matrix:
   include:
+    - python: "2.6"
+      env: TOXENV=py26
     - python: "2.7"
       env: TOXENV=py27
     - python: "2.7"

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "Intended Audience :: System Administrators",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -1,10 +1,13 @@
 from __future__ import unicode_literals
-import os
+
 import sys
 import threading
-import time
-import unittest
 
+if sys.version_info < (2, 7):
+    # We need the skip decorators from unittest2 on Python 2.6.
+    import unittest2 as unittest
+else:
+    import unittest
 
 from prometheus_client import Gauge, Counter, Summary, Histogram, Metric
 from prometheus_client import CollectorRegistry, generate_latest
@@ -39,6 +42,7 @@ class TestGenerateText(unittest.TestCase):
         s.labels('c', 'd').observe(17)
         self.assertEqual(b'# HELP ss A summary\n# TYPE ss summary\nss_count{a="c",b="d"} 1.0\nss_sum{a="c",b="d"} 17.0\n', generate_latest(self.registry))
 
+    @unittest.skipIf(sys.version_info < (2, 7), "Test requires Python 2.7+.")
     def test_histogram(self):
         s = Histogram('hh', 'A histogram', registry=self.registry)
         s.observe(0.05)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,12 @@
 from __future__ import unicode_literals
 
-import unittest
+import sys
+
+if sys.version_info < (2, 7):
+    # We need the skip decorators from unittest2 on Python 2.6.
+    import unittest2 as unittest
+else:
+    import unittest
 
 from prometheus_client.core import *
 from prometheus_client.exposition import *
@@ -36,7 +42,7 @@ a_sum 2
 a_count 1
 a_sum 2
 a{quantile="0.5"} 0.7
-""")    
+""")
         # The Python client doesn't support quantiles, but we
         # still need to be able to parse them.
         metric_family = SummaryMetricFamily("a", "help", count_value=1, sum_value=2)
@@ -131,6 +137,7 @@ a{foo="b\\\\a\\z"} 2
         metric_family.add_metric(["b\\a\\z"], 2)
         self.assertEqual([metric_family], list(families))
 
+    @unittest.skipIf(sys.version_info < (2, 7), "Test requires Python 2.7+.")
     def test_roundtrip(self):
         text = """# HELP go_gc_duration_seconds A summary of the GC invocation durations.
 # TYPE go_gc_duration_seconds summary

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
-from unittest import skipUnless
+import sys
+
+if sys.version_info < (2, 7):
+    from unittest2 import skipUnless
+else:
+    from unittest import skipUnless
 
 from prometheus_client import Counter
 from prometheus_client import CollectorRegistry, generate_latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py27,py34,py35,pypy,{py27,py35}-nooptionals,coverage-report
+envlist = coverage-clean,py26,py27,py34,py35,pypy,{py27,py35}-nooptionals,coverage-report
 
 
 [base]
@@ -10,7 +10,9 @@ deps =
 [testenv]
 deps =
     {[base]deps}
-    twisted
+    py26: unittest2
+    ; Twisted does not support Python 2.6.
+    {py27,py34,py35,pypy}: twisted
 commands = coverage run --parallel -m pytest {posargs}
 
 


### PR DESCRIPTION
As discussed in #86, this adds Python 2.6 support for the tests and CI.

Since 2.6’s stdlib doesn’t support test skipping, we have to resort to using the back port unittest2.

There are a few ways to make it less ugly:

- use unittest2 unconditionally everywhere.  has also the benefit of a consistent test environment.
- do the dance once in a helper module (say `tests/utils.py`) and then just import unittest from there.
- use pytest for skipping