### PR TITLE
Add optional scheme support for push gateway urls

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -106,7 +106,13 @@ def write_to_textfile(path, registry):
 def push_to_gateway(gateway, job, registry, grouping_key=None, timeout=None):
     '''Push metrics to the given pushgateway.
 
-    `gateway` is a url, but will assume http if no other scheme is provided.
+    `gateway` is a url. Scheme defaults to 'http' if none is provided
+    `job` is the name of the local routine pushing metrics
+    `registry` is an instance of CollectorRegistry
+    `grouping_key` please see the pushgateway documentation for details.
+                   Defaults to None
+    `timeout` is how long push will attempt to connect before giving up.
+              Defaults to None
 
     This overwrites all metrics with the same job and grouping_key.
     This uses the PUT HTTP method.'''
@@ -116,7 +122,13 @@ def push_to_gateway(gateway, job, registry, grouping_key=None, timeout=None):
 def pushadd_to_gateway(gateway, job, registry, grouping_key=None, timeout=None):
     '''PushAdd metrics to the given pushgateway.
 
-    `gateway` is a url, but will assume http if no other scheme is provided.
+    `gateway` is a url. Scheme defaults to 'http' if none is provided
+    `job` is the name of the local routine pushing metrics
+    `registry` is an instance of CollectorRegistry
+    `grouping_key` please see the pushgateway documentation for details.
+                   Defaults to None
+    `timeout` is how long push will attempt to connect before giving up.
+              Defaults to None
 
     This replaces metrics with the same name, job and grouping_key.
     This uses the POST HTTP method.'''
@@ -126,7 +138,12 @@ def pushadd_to_gateway(gateway, job, registry, grouping_key=None, timeout=None):
 def delete_from_gateway(gateway, job, grouping_key=None, timeout=None):
     '''Delete metrics from the given pushgateway.
 
-    `gateway` is a url, but will assume http if no other scheme is provided.
+    `gateway` is a url. Scheme defaults to 'http' if none is provided
+    `job` is the name of the local routine pushing metrics
+    `grouping_key` please see the pushgateway documentation for details.
+                   Defaults to None
+    `timeout` is how long delete will attempt to connect before giving up.
+              Defaults to None
 
     This deletes metrics with the given job and grouping_key.
     This uses the DELETE HTTP method.'''

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -15,14 +15,13 @@ try:
     from BaseHTTPServer import HTTPServer
     from urllib2 import build_opener, Request, HTTPHandler
     from urllib import quote_plus
-    from urlparse import urlparse
 except ImportError:
     # Python 3
     unicode = str
     from http.server import BaseHTTPRequestHandler
     from http.server import HTTPServer
     from urllib.request import build_opener, Request, HTTPHandler
-    from urllib.parse import quote_plus, urlparse
+    from urllib.parse import quote_plus
 
 
 CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -106,8 +106,10 @@ def write_to_textfile(path, registry):
 def push_to_gateway(gateway, job, registry, grouping_key=None, timeout=None):
     '''Push metrics to the given pushgateway.
 
-    `gateway` is a url. Scheme defaults to 'http' if none is provided
-    `job` is the name of the local routine pushing metrics
+    `gateway` the url for your push gateway. Either of the form
+              'http://pushgateway.local', or 'pushgateway.local'.
+              Scheme defaults to 'http' if none is provided
+    `job` is the job label to be attached to all pushed metrics
     `registry` is an instance of CollectorRegistry
     `grouping_key` please see the pushgateway documentation for details.
                    Defaults to None
@@ -122,8 +124,10 @@ def push_to_gateway(gateway, job, registry, grouping_key=None, timeout=None):
 def pushadd_to_gateway(gateway, job, registry, grouping_key=None, timeout=None):
     '''PushAdd metrics to the given pushgateway.
 
-    `gateway` is a url. Scheme defaults to 'http' if none is provided
-    `job` is the name of the local routine pushing metrics
+    `gateway` the url for your push gateway. Either of the form
+              'http://pushgateway.local', or 'pushgateway.local'.
+              Scheme defaults to 'http' if none is provided
+    `job` is the job label to be attached to all pushed metrics
     `registry` is an instance of CollectorRegistry
     `grouping_key` please see the pushgateway documentation for details.
                    Defaults to None
@@ -138,8 +142,10 @@ def pushadd_to_gateway(gateway, job, registry, grouping_key=None, timeout=None):
 def delete_from_gateway(gateway, job, grouping_key=None, timeout=None):
     '''Delete metrics from the given pushgateway.
 
-    `gateway` is a url. Scheme defaults to 'http' if none is provided
-    `job` is the name of the local routine pushing metrics
+    `gateway` the url for your push gateway. Either of the form
+              'http://pushgateway.local', or 'pushgateway.local'.
+              Scheme defaults to 'http' if none is provided
+    `job` is the job label to be attached to all pushed metrics
     `grouping_key` please see the pushgateway documentation for details.
                    Defaults to None
     `timeout` is how long delete will attempt to connect before giving up.
@@ -151,7 +157,7 @@ def delete_from_gateway(gateway, job, grouping_key=None, timeout=None):
 
 
 def _use_gateway(method, gateway, job, registry, grouping_key, timeout):
-    if len(urlparse(gateway).scheme) == 0:
+    if not (gateway.startswith('http://') or gateway.startswith('https://')):
         gateway = 'http://{0}'.format(gateway)
     url = '{0}/metrics/job/{1}'.format(gateway, quote_plus(job))
 


### PR DESCRIPTION
We are using a push gateway behind an https reverse proxy. `push_gateway` and related functions previously assumed http and prepended the scheme no matter the circumstances. This patch checks to see if the user has specified a scheme. And, if not, it defaults to http.

I ran the tests on both python 2.7.10 and 3.5.2 and they pass just fine. So we've got backward-compatibility. But I didn't see a very obvious way to get an https server into the test.

Thanks @brian-brazil 