### PR TITLE
Use timeit.default_timer instead of time.time

### DIFF
--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -6,6 +6,7 @@ import re
 import socket
 import time
 import threading
+from timeit import default_timer
 
 from .. import core
 
@@ -26,10 +27,10 @@ class _RegularPush(threading.Thread):
         self._prefix = prefix
 
     def run(self):
-        wait_until = time.time()
+        wait_until = default_timer()
         while True:
             while True:
-                now = time.time()
+                now = default_timer()
                 if now >= wait_until:
                     # May need to skip some pushes.
                     while wait_until < now:
@@ -44,14 +45,14 @@ class _RegularPush(threading.Thread):
 
 
 class GraphiteBridge(object):
-    def __init__(self, address, registry=core.REGISTRY, timeout_seconds=30, _time=time):
+    def __init__(self, address, registry=core.REGISTRY, timeout_seconds=30, _timer=default_timer):
         self._address = address
         self._registry = registry
         self._timeout = timeout_seconds
-        self._time = _time
+        self._timer = _timer
 
     def push(self, prefix=''):
-        now = int(self._time.time())
+        now = int(self._timer())
         output = []
 
         prefixstr = ''

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 import copy
 import math
 import re
-import time
 import types
+from timeit import default_timer
 
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler
@@ -466,7 +466,7 @@ class Gauge(object):
 
     def set_to_current_time(self):
         '''Set gauge to the current unixtime.'''
-        self.set(time.time())
+        self.set(default_timer())
 
     def track_inprogress(self):
         '''Track inprogress blocks of code or functions.
@@ -654,11 +654,11 @@ class _HistogramTimer(object):
         self._histogram = histogram
 
     def __enter__(self):
-        self._start = time.time()
+        self._start = default_timer()
 
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
-        self._histogram.observe(max(time.time() - self._start, 0))
+        self._histogram.observe(max(default_timer() - self._start, 0))
 
     def __call__(self, f):
         def wrapped(func, *args, **kwargs):
@@ -708,11 +708,11 @@ class _SummaryTimer(object):
         self._summary = summary
 
     def __enter__(self):
-        self._start = time.time()
+        self._start = default_timer()
 
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
-        self._summary.observe(max(time.time() - self._start, 0))
+        self._summary.observe(max(default_timer() - self._start, 0))
 
     def __call__(self, f):
         def wrapped(func, *args, **kwargs):
@@ -726,11 +726,11 @@ class _GaugeTimer(object):
         self._gauge = gauge
 
     def __enter__(self):
-        self._start = time.time()
+        self._start = default_timer()
 
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
-        self._gauge.set(max(time.time() - self._start, 0))
+        self._gauge.set(max(default_timer() - self._start, 0))
 
     def __call__(self, f):
         def wrapped(func, *args, **kwargs):

--- a/tests/test_graphite_bridge.py
+++ b/tests/test_graphite_bridge.py
@@ -8,9 +8,8 @@ except ImportError:
 from prometheus_client import Counter, CollectorRegistry
 from prometheus_client.bridge.graphite import GraphiteBridge
 
-class FakeTime(object):
-    def time(self):
-        return 1434898897.5
+def fake_timer():
+    return 1434898897.5
 
 class TestGraphiteBridge(unittest.TestCase):
     def setUp(self):
@@ -27,10 +26,10 @@ class TestGraphiteBridge(unittest.TestCase):
                 server.socket.close()
         self.t = ServingThread()
         self.t.start()
-        
+
         # Explicitly use localhost as the target host, since connecting to 0.0.0.0 fails on Windows
         address = ('localhost', server.server_address[1])
-        self.gb = GraphiteBridge(address, self.registry, _time=FakeTime())
+        self.gb = GraphiteBridge(address, self.registry, _timer=fake_timer)
 
     def test_nolabels(self):
         counter = Counter('c', 'help', registry=self.registry)


### PR DESCRIPTION
On Python 3, this uses `time.perf_counter` on all platforms.

On Python 2, it will use `time.clock` on Windows and `time.time` everywhere else