### PR TITLE
Google AppEngine Compatibility

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import copy
 import json
 import math
-import mmap
 import os
 import re
 import struct
@@ -253,12 +252,13 @@ class _MmapedDict(object):
     alignment, and then a 8 byte float which is the value.
     """
     def __init__(self, filename):
+        self.mmap = __import__('mmap')
         self._lock = Lock()
         self._f = open(filename, 'a+b')
         if os.fstat(self._f.fileno()).st_size == 0:
             self._f.truncate(_INITIAL_MMAP_SIZE)
         self._capacity = os.fstat(self._f.fileno()).st_size
-        self._m = mmap.mmap(self._f.fileno(), self._capacity)
+        self._m = self.mmap.mmap(self._f.fileno(), self._capacity)
 
         self._positions = {}
         self._used = struct.unpack_from(b'i', self._m, 0)[0]
@@ -278,7 +278,7 @@ class _MmapedDict(object):
         while self._used + len(value) > self._capacity:
             self._capacity *= 2
             self._f.truncate(self._capacity * 2)
-            self._m = mmap.mmap(self._f.fileno(), self._capacity)
+            self._m = self.mmap.mmap(self._f.fileno(), self._capacity)
         self._m[self._used:self._used + len(value)] = value
 
         # Update how much space we've used.

--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -26,7 +26,7 @@ class ProcessCollector(object):
         self._ticks = 100.0
         try:
             self._ticks = os.sysconf('SC_CLK_TCK')
-        except (ValueError, TypeError, AttributeError):
+        except (ValueError, TypeError, AttributeError, OSError):
             pass
 
         # This is used to test if we can access /proc.


### PR DESCRIPTION
The `mmap` package is being imported at the top-level, even if we're not opting for multiprocess support. This causes failures in Google AppEngine, where `mmap` is blacklisted.
