### PR TITLE
Add describe and limiting of http expostion

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,19 @@ REGISTRY.register(CustomCollector())
 
 `SummaryMetricFamily` and `HistogramMetricFamily` work similarly.
 
+A collector may implement a `describe` method which returns metrics in the same
+format as `collect` (though you don't have to include the samples). This is
+used to predetermine the names of time series a `CollectorRegistry` exposes and
+thus to detect collisions and duplicate registrations.
+
+Usually custom collectors do not have to implement `describe`. If `describe` is
+not implemented and the CollectorRegistry was created with `auto_desribe=True`
+(which is the case for the default registry) then `collect` will be called at
+registration time instead of `describe`. If this could cause problems, either
+implement a proper `describe`, or if that's not practical have `describe`
+return an empty list.
+
+
 ## Multiprocess Mode (Gunicorn)
 
 **Experimental: This feature is new and has rough edges.**

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -38,25 +38,61 @@ class CollectorRegistry(object):
     Metric objects. The returned metrics should be consistent with the Prometheus
     exposition formats.
     '''
-    def __init__(self):
-        self._collectors = set()
+    def __init__(self, auto_describe=False):
+        self._collector_to_names = {}
+        self._names_to_collectors = {}
+        self._auto_describe = auto_describe
         self._lock = Lock()
 
     def register(self, collector):
         '''Add a collector to the registry.'''
         with self._lock:
-            self._collectors.add(collector)
+            names = self._get_names(collector)
+            for name in names:
+                if name in self._names_to_collectors:
+                    raise ValueError('Timeseries already present '
+                            'in CollectorRegistry: ' + name)
+            for name in names:
+                self._names_to_collectors[name] = collector
+            self._collector_to_names[collector] = names
 
     def unregister(self, collector):
         '''Remove a collector from the registry.'''
         with self._lock:
-            self._collectors.remove(collector)
+            for name in self._collector_to_names[collector]:
+                del self._names_to_collectors[name]
+            del self._collector_to_names[collector]
+
+    def _get_names(self, collector):
+        '''Get names of timeseries the collector produces.'''
+        desc_func = None
+        # If there's a describe function, use it.
+        try:
+            desc_func = collector.describe
+        except AttributeError:
+            pass
+        # Otherwise, if auto describe is enabled use the collect function.
+        if not desc_func and self._auto_describe:
+            desc_func = collector.collect
+
+        if not desc_func:
+            return []
+
+        result = []
+        type_suffixes = {
+            'summary': ['', '_sum', '_count'],
+            'histogram': ['_bucket', '_sum', '_count']
+        }
+        for metric in desc_func():
+            for suffix in type_suffixes.get(metric.type, ['']):
+                result.append(metric.name + suffix)
+        return result
 
     def collect(self):
         '''Yields metrics from the collectors in the registry.'''
         collectors = None
         with self._lock:
-            collectors = copy.copy(self._collectors)
+            collectors = copy.copy(self._collector_to_names)
         for collector in collectors:
             for metric in collector.collect():
                 yield metric
@@ -75,7 +111,7 @@ class CollectorRegistry(object):
         return None
 
 
-REGISTRY = CollectorRegistry()
+REGISTRY = CollectorRegistry(auto_describe=True)
 '''The default registry.'''
 
 _METRIC_TYPES = ('counter', 'gauge', 'summary', 'histogram', 'untyped')
@@ -475,6 +511,10 @@ def _MetricWrapper(cls):
 
         if not _METRIC_NAME_RE.match(full_name):
             raise ValueError('Invalid metric name: ' + full_name)
+
+        def describe():
+            return [Metric(full_name, documentation, cls._type)]
+        collector.describe = describe
 
         def collect():
             metric = Metric(full_name, documentation, cls._type)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -431,6 +431,15 @@ class TestCollectorRegistry(unittest.TestCase):
         self.custom_collector(CounterMetricFamily('c', 'help', value=1), registry)
         self.assertRaises(ValueError, self.custom_collector, CounterMetricFamily('c', 'help', value=1), registry)
 
+    def test_restricted_registry(self):
+        registry = CollectorRegistry()
+        Counter('c', 'help', registry=registry)
+        Summary('s', 'help', registry=registry).observe(7)
+
+        m = Metric('s', 'help', 'summary')
+        m.samples = [('s_sum', {}, 7)]
+        self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is the first pass on limiting what's returned over http exposition via a url parameter. We'll likely need to support POST also in future to get around URL length limits.

@juliusv @fabxc @beorn7 @SuperQ 

Fixes #97