### PR TITLE
Return thread object from start_http_server

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -97,13 +97,17 @@ class MetricsHandler(BaseHTTPRequestHandler):
 
 def start_http_server(port, addr=''):
     """Starts a HTTP server for prometheus metrics as a daemon thread."""
+    e = threading.Event()
     class PrometheusMetricsServer(threading.Thread):
         def run(self):
-            httpd = HTTPServer((addr, port), MetricsHandler)
-            httpd.serve_forever()
+            self.httpd = HTTPServer((addr, port), MetricsHandler)
+            e.set()
+            self.httpd.serve_forever()
     t = PrometheusMetricsServer()
     t.daemon = True
     t.start()
+    e.wait()
+    return t
 
 
 def write_to_textfile(path, registry):


### PR DESCRIPTION
When starting a server using port 0 (to allow the OS to choose an open port), one needs to retrieve the selected port after HTTPServer creation. This PR allows doing so through:
```
t = start_http_server(0)
port = t.httpd.server_port
```