### PR TITLE
Fixes Histogram decorator usage (#140)

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -875,7 +875,7 @@ class _HistogramTimer(object):
 
     def __call__(self, f):
         def wrapped(func, *args, **kwargs):
-            with self:
+            with _HistogramTimer(self._histogram):
                 return func(*args, **kwargs)
         return decorate(f, wrapped)
 


### PR DESCRIPTION
Without creating a new instance of `_HistogramTimer` for each call, the internal timer is reused across executions of the instrumented function.  This results in erroneous timings.  The solution is to create a new `_HistogramTimer` for each execution of the decorated function.  This provides the same behavior as using the `Histogram.time()` as a decorator within the instrumented function.