### PR TITLE
start_http_server for any given registry or the default registry

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -18,7 +18,7 @@ Histogram = core.Histogram
 
 CONTENT_TYPE_LATEST = exposition.CONTENT_TYPE_LATEST
 generate_latest = exposition.generate_latest
-MetricsHandler = exposition.MetricsHandler
+MetricsHandler = exposition.generate_metrics_handler(REGISTRY)
 make_wsgi_app = exposition.make_wsgi_app
 start_http_server = exposition.start_http_server
 start_wsgi_server = exposition.start_wsgi_server


### PR DESCRIPTION
I'm using start_http_server, but unfortunately it only exposes the default registry, all other exposition methods have a registry parameter.

@brian-brazil 