### PR TITLE
Provide robust Gunicorn config in multiprocess docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,9 @@ between Gunicorn runs (before startup is recommended).
 
 Put the following in the config file:
 ```python
-def worker_exit(server, worker):
-    from prometheus_client import multiprocess
+from prometheus_client import multiprocess
+
+def child_exit(server, worker):
     multiprocess.mark_process_dead(worker.pid)
 ```
 


### PR DESCRIPTION
We need to use the recently added Gunicorn `child_exited` callback in order to
correctly clean up after a segfaulted or OOM-killed worker (for details, see
https://github.com/benoitc/gunicorn/pull/1394 and #115).

The try catch is necessary to guard against unexpected race conditions and
errors in the cleanup logic. I have seen this twice, crippling the master
process in a cascading failure scenario.