### PR TITLE
Fix error when initializing histogram with empty labels list

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -536,7 +536,7 @@ def _MetricWrapper(cls):
                     raise ValueError('Reserved label metric name: ' + l)
             collector = _LabelWrapper(cls, name, labelnames, **kwargs)
         else:
-            collector = cls(name, labelnames, (), **kwargs)
+            collector = cls(name, (), (), **kwargs)
 
         if not _METRIC_NAME_RE.match(full_name):
             raise ValueError('Invalid metric name: ' + full_name)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -303,6 +303,10 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertRaises(ValueError, Counter, 'c', '', labelnames=['__reserved'])
         self.assertRaises(ValueError, Summary, 'c', '', labelnames=['quantile'])
 
+    def test_empty_labels_list(self):
+        h = Histogram('h', 'help', [], registry=self.registry)
+        self.assertEqual(0, self.registry.get_sample_value('h_sum'))
+
 
 class TestMetricFamilies(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Docs demonstrate initializing a metric's labels with a list, but `labelnames` is internally represented as a tuple. If `labelnames` is truthy, it gets cast to a tuple (and a reasonable error is thrown if it can't be cast), but `_MetricWrapper` simply forwards `labelnames` as-is if it is falsy.

This is normally not a problem, but when initializing a histogram with an empty labels list:
```
from prometheus_client import Histogram
Histogram('h', 'help', [])
```

this error occurs:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/prometheus_client/core.py", line 539, in init
    collector = cls(name, labelnames, (), **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/prometheus_client/core.py", line 835, in __init__
    bucket_labelnames = labelnames + ('le',)
TypeError: can only concatenate list (not "tuple") to list
```

I see no reason why any iterable that can be cast to a tuple shouldn't reasonably be expected to work here (use case for the empty list: building up a list of labels conditionally; it's inconvenient/inconsistent to check if empty, or to cast to tuple when lists are used for all other cases).

I think a reasonable fix is to set `labelnames` to an empty tuple if it evaluates to falsy. (Possible alternative: casting even the falsy value to tuple, in case you would like to throw a clear error if someone calls the function with a falsy non-iterable?)

The added test might be a bit simplistic, but it passes with this change and fails without it.