### PR TITLE
Expose original metric classes via __wrapped__ attribute

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -556,6 +556,7 @@ def _MetricWrapper(cls):
             registry.register(collector)
         return collector
 
+    init.__wrapped__ = cls
     return init
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -307,6 +307,9 @@ class TestMetricWrapper(unittest.TestCase):
         h = Histogram('h', 'help', [], registry=self.registry)
         self.assertEqual(0, self.registry.get_sample_value('h_sum'))
 
+    def test_wrapped_original_class(self):
+        self.assertEqual(Counter.__wrapped__, Counter('foo', 'bar').__class__)
+
 
 class TestMetricFamilies(unittest.TestCase):
     def setUp(self):
@@ -385,6 +388,7 @@ class TestMetricFamilies(unittest.TestCase):
         self.assertRaises(ValueError, HistogramMetricFamily, 'h', 'help', buckets={}, labels=['a'])
         self.assertRaises(ValueError, HistogramMetricFamily, 'h', 'help', buckets={}, sum_value=1, labels=['a'])
         self.assertRaises(KeyError, HistogramMetricFamily, 'h', 'help', buckets={}, sum_value=1)
+
 
 class TestCollectorRegistry(unittest.TestCase):
     def test_duplicate_metrics_raises(self):


### PR DESCRIPTION
Related to issue #150