### PR TITLE
Add PlatformCollector to collect information about the platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ ProcessCollector(namespace='mydaemon', pid=lambda: open('/var/run/daemon.pid').r
 
 ### Platform Collector
 
-The client also automatically exports some metadata about python. If using Jython,
+The client also automatically exports some metadata about Python. If using Jython,
 metadata about the JVM in use is also included. This information is available as 
 labels on the `python_info` metric. The value of the metric is 1, since it is the 
 labels that carry information.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ other processes, for example:
 ProcessCollector(namespace='mydaemon', pid=lambda: open('/var/run/daemon.pid').read())
 ```
 
+### Platform Collector
+
+The client also automatically exports some metadata about the platform, such
+as versions of python, operating system, kernel and important system libraries,
+implementation details, and hardware details. This information is available as 
+labels on the `python_info`, `machine_info` and `system_info` metrics. These all 
+have the value 1, since it is the labels that carry information.
+
 ## Exporting
 
 There are several options for exporting metrics.

--- a/README.md
+++ b/README.md
@@ -208,11 +208,10 @@ ProcessCollector(namespace='mydaemon', pid=lambda: open('/var/run/daemon.pid').r
 
 ### Platform Collector
 
-The client also automatically exports some metadata about the platform, such
-as versions of python, operating system, kernel and important system libraries,
-implementation details, and hardware details. This information is available as 
-labels on the `python_info`, `machine_info` and `system_info` metrics. These all 
-have the value 1, since it is the labels that carry information.
+The client also automatically exports some metadata about python. If using Jython,
+metadata about the JVM in use is also included. This information is available as 
+labels on the `python_info` metric. The value of the metric is 1, since it is the 
+labels that carry information.
 
 ## Exporting
 

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -3,6 +3,7 @@
 from . import core
 from . import exposition
 from . import process_collector
+from . import platform_collector
 
 __all__ = ['Counter', 'Gauge', 'Summary', 'Histogram']
 # http://stackoverflow.com/questions/19913653/no-unicode-in-all-for-a-packages-init
@@ -30,6 +31,9 @@ instance_ip_grouping_key = exposition.instance_ip_grouping_key
 
 ProcessCollector = process_collector.ProcessCollector
 PROCESS_COLLECTOR = process_collector.PROCESS_COLLECTOR
+
+PlatformCollector = platform_collector.PlatformCollector
+PLATFORM_COLLECTOR = platform_collector.PLATFORM_COLLECTOR
 
 
 if __name__ == '__main__':

--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+from __future__ import unicode_literals
+
+import platform as pf
+
+from . import core
+
+
+class PlatformCollector(object):
+    """Collector for platform information"""
+
+    def __init__(self, registry=core.REGISTRY, platform=None):
+        self._platform = pf if platform is None else platform
+        self._metrics = [
+            self._add_metric(*self._python()),
+            self._add_metric(*self._machine()),
+            self._add_metric(*self._system())
+        ]
+        if registry:
+            registry.register(self)
+
+    def collect(self):
+        return self._metrics
+
+    @staticmethod
+    def _add_metric(name, documentation, data):
+        labels = data.keys()
+        values = [data[k] for k in labels]
+        g = core.GaugeMetricFamily(name, documentation, labels=labels)
+        g.add_metric(values, 1)
+        return g
+
+    def _python(self):
+        major, minor, patchlevel = self._platform.python_version_tuple()
+        return "python_info", "Python information", {
+            "version": self._platform.python_version(),
+            "implementation": self._platform.python_implementation(),
+            "major": major,
+            "minor": minor,
+            "patchlevel": patchlevel
+        }
+
+    def _machine(self):
+        _, _, _, _, machine, processor = self._platform.uname()
+        bits, linkage = self._platform.architecture()
+        return "machine_info", "Machine information", {
+            "bits": bits,
+            "linkage": linkage,
+            "machine": machine,
+            "processor": processor
+        }
+
+    def _system(self):
+        system = self._platform.system()
+        return {
+            "Linux": self._linux,
+            "Windows": self._win32,
+            "Java": self._java,
+            "Darwin": self._mac,
+        }.get(system, self._system_other)()
+
+    def _system_other(self):
+        system, _, release, version, _, _ = self._platform.uname()
+        return "system_info", "System information", {
+            "system": system,
+            "kernel": release,
+            "version": version
+        }
+
+    def _java(self):
+        java_version, _, vminfo, osinfo = self._platform.java_ver()
+        vm_name, vm_release, vm_vendor = vminfo
+        system, kernel, _ = osinfo
+        return "system_info", "System information (Java)", {
+            "system": system,
+            "name": "Java",
+            "kernel": kernel,
+            "java_version": java_version,
+            "vm_release": vm_release,
+            "vm_vendor": vm_vendor,
+            "vm_name": vm_name
+        }
+
+    def _win32(self):
+        release, version, csd, ptype = self._platform.win32_ver()
+        return "system_info", "System information (Windows)", {
+            "system": "Windows",
+            "name": "Windows {}".format(release),
+            "kernel": version,
+            "version": version,
+            "csd": csd,
+            "ptype": ptype
+        }
+
+    def _mac(self):
+        release, _, machine = self._platform.mac_ver()
+        _, _, kernel, _, _, _ = self._platform.uname()
+        return "system_info", "System information (Darwin)", {
+            "system": "Darwin",
+            "name": "Mac OS {}".format(release),
+            "kernel": kernel,
+            "version": release
+        }
+
+    def _linux(self):
+        name, version, dist_id = self._platform.linux_distribution()
+        libc, libc_version = self._platform.libc_ver()
+        _, _, kernel, _, _, _ = self._platform.uname()
+        return "system_info", "System information (Linux)", {
+            "system": "Linux",
+            "name": name.strip(),
+            "kernel": kernel,
+            "version": version,
+            "dist_id": dist_id,
+            "libc": libc,
+            "libc_version": libc_version
+        }
+
+
+PLATFORM_COLLECTOR = PlatformCollector()
+"""PlatfprmCollector in default Registry REGISTRY"""

--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -8,7 +8,7 @@ from . import core
 
 
 class PlatformCollector(object):
-    """Collector for platform information"""
+    """Collector for python platform information"""
 
     def __init__(self, registry=core.REGISTRY, platform=None):
         self._platform = pf if platform is None else platform
@@ -17,7 +17,7 @@ class PlatformCollector(object):
         if system == "Java":
             info.update(self._java())
         self._metrics = [
-            self._add_metric("python_info", "Python information", info)
+            self._add_metric("python_info", "Python platform information", info)
         ]
         if registry:
             registry.register(self)
@@ -46,7 +46,6 @@ class PlatformCollector(object):
     def _java(self):
         java_version, _, vminfo, osinfo = self._platform.java_ver()
         vm_name, vm_release, vm_vendor = vminfo
-        system, kernel, _ = osinfo
         return {
             "jvm_version": java_version,
             "jvm_release": vm_release,

--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -86,7 +86,7 @@ class PlatformCollector(object):
         release, version, csd, ptype = self._platform.win32_ver()
         return "system_info", "System information (Windows)", {
             "system": "Windows",
-            "name": "Windows {}".format(release),
+            "name": "Windows {0}".format(release),
             "kernel": version,
             "version": version,
             "csd": csd,
@@ -98,7 +98,7 @@ class PlatformCollector(object):
         _, _, kernel, _, _, _ = self._platform.uname()
         return "system_info", "System information (Darwin)", {
             "system": "Darwin",
-            "name": "Mac OS {}".format(release),
+            "name": "Mac OS {0}".format(release),
             "kernel": kernel,
             "version": release
         }

--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -56,4 +56,4 @@ class PlatformCollector(object):
 
 
 PLATFORM_COLLECTOR = PlatformCollector()
-"""PlatfprmCollector in default Registry REGISTRY"""
+"""PlatformCollector in default Registry REGISTRY"""

--- a/tests/test_platform_collector.py
+++ b/tests/test_platform_collector.py
@@ -1,0 +1,131 @@
+from __future__ import unicode_literals
+
+import unittest
+
+from prometheus_client import CollectorRegistry, PlatformCollector
+
+
+class TestPlatformCollector(unittest.TestCase):
+    def setUp(self):
+        self.registry = CollectorRegistry()
+        self.platform = _MockPlatform()
+
+    def test_python_info(self):
+        PlatformCollector(registry=self.registry, platform=self.platform)
+        self.assertLabels("python_info", {
+            "version": "python_version",
+            "implementation": "python_implementation",
+            "major": "pvt_major",
+            "minor": "pvt_minor",
+            "patchlevel": "pvt_patchlevel"
+        })
+
+    def test_machine_info(self):
+        PlatformCollector(registry=self.registry, platform=self.platform)
+        self.assertLabels("machine_info", {
+            "bits": "a_bits",
+            "linkage": "a_linkage",
+            "machine": "u_machine",
+            "processor": "u_processor"
+        })
+
+    def test_system_info_java(self):
+        self.platform._system = "Java"
+        PlatformCollector(registry=self.registry, platform=self.platform)
+        self.assertLabels("system_info", {
+            "system": "os_name",
+            "name": "Java",
+            "kernel": "os_version",
+            "java_version": "jv_release",
+            "vm_release": "vm_release",
+            "vm_vendor": "vm_vendor",
+            "vm_name": "vm_name"
+        })
+
+    def test_system_info_linux(self):
+        self.platform._system = "Linux"
+        PlatformCollector(registry=self.registry, platform=self.platform)
+        self.assertLabels("system_info", {
+            "system": "Linux",
+            "name": "ld_distname",
+            "kernel": "u_kernel",
+            "version": "ld_version",
+            "dist_id": "ld_id",
+            "libc": "lv_lib",
+            "libc_version": "lv_version"
+        })
+
+    def test_system_info_win32(self):
+        self.platform._system = "Windows"
+        PlatformCollector(registry=self.registry, platform=self.platform)
+        self.assertLabels("system_info", {
+            "system": "Windows",
+            "name": "Windows wv_release",
+            "kernel": "wv_version",
+            "version": "wv_version",
+            "csd": "wv_csd",
+            "ptype": "wv_ptype"
+        })
+
+    def test_system_info_darwin(self):
+        self.platform._system = "Darwin"
+        PlatformCollector(registry=self.registry, platform=self.platform)
+        self.assertLabels("system_info", {
+            "system": "Darwin",
+            "name": "Mac OS mv_release",
+            "kernel": "u_kernel",
+            "version": "mv_release"
+        })
+
+    def test_system_info_other(self):
+        self.platform._system = "Non-standard"
+        PlatformCollector(registry=self.registry, platform=self.platform)
+        self.assertLabels("system_info", {
+            "system": "u_system",
+            "kernel": "u_kernel",
+            "version": "u_version"
+        })
+
+    def assertLabels(self, name, labels):
+        for metric in self.registry.collect():
+            for n, l, value in metric.samples:
+                if n == name:
+                    assert l == labels
+
+
+class _MockPlatform(object):
+    def __init__(self):
+        self._system = "system"
+
+    def python_version_tuple(self):
+        return "pvt_major", "pvt_minor", "pvt_patchlevel"
+
+    def python_version(self):
+        return "python_version"
+
+    def python_implementation(self):
+        return "python_implementation"
+
+    def uname(self):
+        return "u_system", "u_node", "u_kernel", "u_version", "u_machine", "u_processor"
+
+    def architecture(self):
+        return "a_bits", "a_linkage"
+
+    def system(self):
+        return self._system
+
+    def java_ver(self):
+        return "jv_release", "jv_vendor", ("vm_name", "vm_release", "vm_vendor"), ("os_name", "os_version", "os_arch")
+
+    def linux_distribution(self):
+        return "ld_distname", "ld_version", "ld_id"
+
+    def libc_ver(self):
+        return "lv_lib", "lv_version"
+
+    def mac_ver(self):
+        return "mv_release", ("mv_version", "mv_dev_stage", "mv_non_release_version"), "mv_machine"
+
+    def win32_ver(self):
+        return "wv_release", "wv_version", "wv_csd", "wv_ptype"

--- a/tests/test_platform_collector.py
+++ b/tests/test_platform_collector.py
@@ -61,4 +61,9 @@ class _MockPlatform(object):
         return self._system
 
     def java_ver(self):
-        return "jv_release", "jv_vendor", ("vm_name", "vm_release", "vm_vendor"), ("os_name", "os_version", "os_arch")
+        return (
+            "jv_release",
+            "jv_vendor",
+            ("vm_name", "vm_release", "vm_vendor"),
+            ("os_name", "os_version", "os_arch")
+        )

--- a/tests/test_platform_collector.py
+++ b/tests/test_platform_collector.py
@@ -20,70 +20,19 @@ class TestPlatformCollector(unittest.TestCase):
             "patchlevel": "pvt_patchlevel"
         })
 
-    def test_machine_info(self):
-        PlatformCollector(registry=self.registry, platform=self.platform)
-        self.assertLabels("machine_info", {
-            "bits": "a_bits",
-            "linkage": "a_linkage",
-            "machine": "u_machine",
-            "processor": "u_processor"
-        })
-
     def test_system_info_java(self):
         self.platform._system = "Java"
         PlatformCollector(registry=self.registry, platform=self.platform)
-        self.assertLabels("system_info", {
-            "system": "os_name",
-            "name": "Java",
-            "kernel": "os_version",
-            "java_version": "jv_release",
-            "vm_release": "vm_release",
-            "vm_vendor": "vm_vendor",
-            "vm_name": "vm_name"
-        })
-
-    def test_system_info_linux(self):
-        self.platform._system = "Linux"
-        PlatformCollector(registry=self.registry, platform=self.platform)
-        self.assertLabels("system_info", {
-            "system": "Linux",
-            "name": "ld_distname",
-            "kernel": "u_kernel",
-            "version": "ld_version",
-            "dist_id": "ld_id",
-            "libc": "lv_lib",
-            "libc_version": "lv_version"
-        })
-
-    def test_system_info_win32(self):
-        self.platform._system = "Windows"
-        PlatformCollector(registry=self.registry, platform=self.platform)
-        self.assertLabels("system_info", {
-            "system": "Windows",
-            "name": "Windows wv_release",
-            "kernel": "wv_version",
-            "version": "wv_version",
-            "csd": "wv_csd",
-            "ptype": "wv_ptype"
-        })
-
-    def test_system_info_darwin(self):
-        self.platform._system = "Darwin"
-        PlatformCollector(registry=self.registry, platform=self.platform)
-        self.assertLabels("system_info", {
-            "system": "Darwin",
-            "name": "Mac OS mv_release",
-            "kernel": "u_kernel",
-            "version": "mv_release"
-        })
-
-    def test_system_info_other(self):
-        self.platform._system = "Non-standard"
-        PlatformCollector(registry=self.registry, platform=self.platform)
-        self.assertLabels("system_info", {
-            "system": "u_system",
-            "kernel": "u_kernel",
-            "version": "u_version"
+        self.assertLabels("python_info", {
+            "version": "python_version",
+            "implementation": "python_implementation",
+            "major": "pvt_major",
+            "minor": "pvt_minor",
+            "patchlevel": "pvt_patchlevel",
+            "jvm_version": "jv_release",
+            "jvm_release": "vm_release",
+            "jvm_vendor": "vm_vendor",
+            "jvm_name": "vm_name"
         })
 
     def assertLabels(self, name, labels):
@@ -91,6 +40,8 @@ class TestPlatformCollector(unittest.TestCase):
             for n, l, value in metric.samples:
                 if n == name:
                     assert l == labels
+                    return
+        assert False
 
 
 class _MockPlatform(object):
@@ -106,26 +57,8 @@ class _MockPlatform(object):
     def python_implementation(self):
         return "python_implementation"
 
-    def uname(self):
-        return "u_system", "u_node", "u_kernel", "u_version", "u_machine", "u_processor"
-
-    def architecture(self):
-        return "a_bits", "a_linkage"
-
     def system(self):
         return self._system
 
     def java_ver(self):
         return "jv_release", "jv_vendor", ("vm_name", "vm_release", "vm_vendor"), ("os_name", "os_version", "os_arch")
-
-    def linux_distribution(self):
-        return "ld_distname", "ld_version", "ld_id"
-
-    def libc_ver(self):
-        return "lv_lib", "lv_version"
-
-    def mac_ver(self):
-        return "mv_release", ("mv_version", "mv_dev_stage", "mv_non_release_version"), "mv_machine"
-
-    def win32_ver(self):
-        return "wv_release", "wv_version", "wv_csd", "wv_ptype"


### PR DESCRIPTION
In the same vein as https://github.com/prometheus/client_java/commit/bdc6f2507a81029c1aec6cd8b5276661bb6c7ee1 and https://github.com/siimon/prom-client/commit/ee561e28e14a62b0ef069f525174ee9a3b66d4d7, this PR adds Python version and some other metadata as labels on a small set of metrics.

This has turned out to be very useful for creating common dashboards across implementation languages, allowing the dashboard to extract metadata from the metrics exposed.

Python, machine and system information is collected once at startup, and
exposed as labels on a metric with value 1.