### PR TITLE
Add an obvious notice for metric initialization of multiprocess collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,8 @@ def app(environ, start_response):
     return iter([data])
 ```
 
+**Note: don't initialize metric with MultiProcessCollector registry argument.**
+
 **Three**: Instrumentation
 
 Counters, Summarys and Histograms work as normal.


### PR DESCRIPTION
As a beginner, I build a histogram metric in my Python application with a self-defined collect registry.When deploy under multiple process circumstance, I get a help from README file. According to that, I don't change metric's initialzation and get http 500 when making requests to pushgateway. Finally, I fix the problem and think there should be a more clear and obvious description for beginners. 