### PR TITLE
Move os.getpid() inside _MmapedValue (#130)

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -392,8 +392,7 @@ class _MmapedDict(object):
             self._f = None
 
 
-def _MultiProcessValue(__pid=os.getpid()):
-    pid = __pid
+def _MultiProcessValue(_pid=None):
     files = {}
     files_lock = Lock()
 
@@ -403,6 +402,8 @@ def _MultiProcessValue(__pid=os.getpid()):
         _multiprocess = True
 
         def __init__(self, typ, metric_name, name, labelnames, labelvalues, multiprocess_mode='', **kwargs):
+            pid = _pid or os.getpid()
+
             if typ == 'gauge':
                 file_prefix = typ + '_' +  multiprocess_mode
             else:


### PR DESCRIPTION
Related to issue #130 
uwsgi imports all python script in master process and after that forks children, so we need move os.getpid() call inside function