### PR TITLE
Reset multiproc values when the pid changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,6 @@ This comes with a number of limitations:
 - Custom collectors do not work (e.g. cpu and memory metrics)
 - The pushgateway cannot be used
 - Gauges cannot use the `pid` label
-- Gunicorn's `preload_app` feature and equivalents are not supported
 
 There's several steps to getting this working:
 

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -13,7 +13,7 @@ class TestMultiProcess(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         os.environ['prometheus_multiproc_dir'] = self.tempdir
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(123)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 123)
         self.registry = CollectorRegistry()
         MultiProcessCollector(self.registry, self.tempdir)
 
@@ -24,7 +24,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_counter_adds(self):
         c1 = Counter('c', 'help', registry=None)
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
         c2 = Counter('c', 'help', registry=None)
         self.assertEqual(0, self.registry.get_sample_value('c'))
         c1.inc(1)
@@ -33,7 +33,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_summary_adds(self):
         s1 = Summary('s', 'help', registry=None)
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
         s2 = Summary('s', 'help', registry=None)
         self.assertEqual(0, self.registry.get_sample_value('s_count'))
         self.assertEqual(0, self.registry.get_sample_value('s_sum'))
@@ -44,7 +44,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_histogram_adds(self):
         h1 = Histogram('h', 'help', registry=None)
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
         h2 = Histogram('h', 'help', registry=None)
         self.assertEqual(0, self.registry.get_sample_value('h_count'))
         self.assertEqual(0, self.registry.get_sample_value('h_sum'))
@@ -57,7 +57,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_all(self):
         g1 = Gauge('g', 'help', registry=None)
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
         g2 = Gauge('g', 'help', registry=None)
         self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '123'}))
         self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
@@ -69,7 +69,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_liveall(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='liveall')
         self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '123'}))
         self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
@@ -83,7 +83,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_min(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='min')
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='min')
         self.assertEqual(0, self.registry.get_sample_value('g'))
         g1.set(1)
@@ -92,7 +92,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_max(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
         self.assertEqual(0, self.registry.get_sample_value('g'))
         g1.set(1)
@@ -101,7 +101,7 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_livesum(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')
-        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(456)
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
         g2 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')
         self.assertEqual(0, self.registry.get_sample_value('g'))
         g1.set(1)
@@ -114,6 +114,20 @@ class TestMultiProcess(unittest.TestCase):
          c1 = Counter('c', 'help', registry=None, namespace='ns', subsystem='ss')
          c1.inc(1)
          self.assertEqual(1, self.registry.get_sample_value('ns_ss_c'))
+
+    def test_counter_across_forks(self):
+        pid = 0
+        def get_pid():
+            return pid
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(get_pid)
+        c1 = Counter('c', 'help', registry=None)
+        self.assertEqual(0, self.registry.get_sample_value('c'))
+        c1.inc(1)
+        c1.inc(1)
+        pid = 1
+        c1.inc(1)
+        self.assertEqual(3, self.registry.get_sample_value('c'))
+        self.assertEqual(1, c1._value.get())
 
 
 class TestMmapedDict(unittest.TestCase):


### PR DESCRIPTION
This puts us at ~2000ns for an operation,
which is ~300ns than previously but still slightly
better than we were before we switched to a single lock.

This is twice as slow as without multiproc mode.