### PR TITLE
Assert label values be str or unicode

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -198,6 +198,11 @@ class CounterMetricFamily(Metric):
           labels: A list of label values
           value: The value of the metric.
         '''
+        try:
+            for label in labels:
+                assert isinstance(label,''.__class__) or isinstance(label,u''.__class__)
+        except AssertionError:
+            raise TypeError("label values must be 'str' or 'unicode' NOT %r"% type(label).__name__)
         self.samples.append((self.name, dict(zip(self._labelnames, labels)), value))
 
 


### PR DESCRIPTION
Right now, if you call add_metric() method with no string variables. Nothing will happen. But will raise meanless AttributError when first scrape. 

quick reproduce
``` python
import time
from prometheus_client import start_http_server
from prometheus_client.core import GaugeMetricFamily, REGISTRY

class CustomCollector(object):
    def collect(self):
        foo = GaugeMetricFamily('foo_bar', '', labels=['label1', 'label2'])
        foo.add_metric([1, 'bar'], 1) # Use an int as label value
        yield foo

REGISTRY.register(CustomCollector())

if __name__ == '__main__':
    start_http_server(9091)
    while True:
        time.sleep(30)
```



When you try to scrape the metrics, it will raise a helpless Tracback.
```
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 64728)
----------------------------------------
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/socketserver.py", line 318, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/socketserver.py", line 344, in process_request
    self.finish_request(request, client_address)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/socketserver.py", line 357, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/socketserver.py", line 684, in __init__
    self.handle()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/http/server.py", line 415, in handle
    self.handle_one_request()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/http/server.py", line 403, in handle_one_request
    method()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/prometheus_client/exposition.py", line 86, in do_GET
    output = generate_latest(registry)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/prometheus_client/exposition.py", line 72, in generate_latest
    for k, v in sorted(labels.items())]))
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/prometheus_client/exposition.py", line 72, in <listcomp>
    for k, v in sorted(labels.items())]))
AttributeError: 'int' object has no attribute 'replace'
```

