### PR TITLE
Remove hack to encode __all__ as ascii

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -6,8 +6,6 @@ from . import process_collector
 from . import platform_collector
 
 __all__ = ['Counter', 'Gauge', 'Summary', 'Histogram']
-# http://stackoverflow.com/questions/19913653/no-unicode-in-all-for-a-packages-init
-__all__ = [n.encode('ascii') for n in __all__]
 
 CollectorRegistry = core.CollectorRegistry
 REGISTRY = core.REGISTRY


### PR DESCRIPTION
Previously the code included:

    from __future__ import unicode_literals

But with that gone in the current version, it makes no sense to mess with the contents of `__all__` at all.