### PR TITLE
Test and support Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,10 @@ matrix:
       env: TOXENV=py34
     - python: "3.5"
       env: TOXENV=py35
-    - python: "3.5"
-      env: TOXENV=py35-nooptionals
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.6"
+      env: TOXENV=py36-nooptionals
     - python: "pypy"
       env: TOXENV=pypy
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Monitoring",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py26,py27,py34,py35,py36,pypy,{py27,py35,py36}-nooptionals,coverage-report
+envlist = coverage-clean,py26,py27,py34,py35,py36,pypy,{py27,py36}-nooptionals,coverage-report
 
 
 [base]
@@ -12,7 +12,7 @@ deps =
     {[base]deps}
     py26: unittest2
     ; Twisted does not support Python 2.6.
-    {py27,py34,py35,pypy}: twisted
+    {py27,py34,py35,py36,pypy}: twisted
 commands = coverage run --parallel -m pytest {posargs}
 
 
@@ -21,7 +21,7 @@ commands = coverage run --parallel -m pytest {posargs}
 deps = {[base]deps}
 commands = coverage run --parallel -m pytest {posargs}
 
-[testenv:py35-nooptionals]
+[testenv:py36-nooptionals]
 deps = {[base]deps}
 commands = coverage run --parallel -m pytest {posargs}
 


### PR DESCRIPTION
Add py36 to the Travis CI config, and `setup.py` classifiers.

Also tweak local tox config, install twisted for 3.6 but make `noptionals` variant use 2.7 and 3.5 only.