### PR TITLE
helpful error message when multiprocessing dir env is unset

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -12,8 +12,8 @@ from . import core
 class MultiProcessCollector(object):
     """Collector for files for multi-process mode."""
     def __init__(self, registry, path=os.environ.get('prometheus_multiproc_dir')):
-        if not path or not os.path.exists(path):
-            raise ValueError('env prometheus_multiproc_dir is not set or not accessible')
+        if not path or not os.path.isdir(path):
+            raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
         self._path = path
         if registry:
           registry.register(self)

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -12,6 +12,8 @@ from . import core
 class MultiProcessCollector(object):
     """Collector for files for multi-process mode."""
     def __init__(self, registry, path=os.environ.get('prometheus_multiproc_dir')):
+        if not path or not os.path.exists(path):
+            raise ValueError('env prometheus_multiproc_dir is not set or not accessible')
         self._path = path
         if registry:
           registry.register(self)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -158,3 +158,9 @@ class TestMmapedDict(unittest.TestCase):
 
     def tearDown(self):
         os.unlink(self.tempfile)
+
+class TestUnsetEnv(unittest.TestCase):
+    def test_unset_syncdir_env(self):
+        self.registry = CollectorRegistry()
+        with self.assertRaises(ValueError):
+            MultiProcessCollector(self.registry)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -160,10 +160,26 @@ class TestMmapedDict(unittest.TestCase):
         os.unlink(self.tempfile)
 
 class TestUnsetEnv(unittest.TestCase):
-    def test_unset_syncdir_env(self):
+    def setUp(self):
         self.registry = CollectorRegistry()
+        fp, self.tmpfl = tempfile.mkstemp()
+        os.close(fp)
+
+    def test_unset_syncdir_env(self):
         self.assertRaises(
             ValueError,
             MultiProcessCollector,
             self.registry
         )
+
+    def test_file_syncpath(self):
+        registry = CollectorRegistry()
+        self.assertRaises(
+            ValueError,
+            MultiProcessCollector,
+            registry,
+            self.tmpfl
+        )
+
+    def tearDown(self):
+        os.remove(self.tmpfl)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -162,5 +162,8 @@ class TestMmapedDict(unittest.TestCase):
 class TestUnsetEnv(unittest.TestCase):
     def test_unset_syncdir_env(self):
         self.registry = CollectorRegistry()
-        with self.assertRaises(ValueError):
-            MultiProcessCollector(self.registry)
+        self.assertRaises(
+            ValueError,
+            MultiProcessCollector,
+            self.registry
+        )


### PR DESCRIPTION

On head it fails with:
```python
ERROR in app: Exception on /metrics [GET]
AttributeError: 'NoneType' object has no attribute 'endswith'
```
With this change:
```python
  File "build/bdist.linux-x86_64/egg/prometheus_client/multiprocess.py", line 16, in __init__
    raise ValueError('env prometheus_multiproc_dir is not set or not accessible')
ValueError: env prometheus_multiproc_dir is not set or not accessible
```