### PR TITLE
Fix issue #208: parse the correct scheme of URL in Python26

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import base64
 import os
 import socket
+import sys
 import threading
 from contextlib import closing
 from wsgiref.simple_server import make_server, WSGIRequestHandler
@@ -27,6 +28,7 @@ except ImportError:
 CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
 '''Content type of the latest text format'''
 
+PYTHON26_OR_OLDER = tuple(int(val) for val in sys.version.split()[0].split('.')) < (2, 7, 0)
 
 def make_wsgi_app(registry=core.REGISTRY):
     '''Create a WSGI app which serves the metrics from a registry.'''
@@ -251,7 +253,7 @@ def delete_from_gateway(gateway, job, grouping_key=None, timeout=None, handler=d
 
 def _use_gateway(method, gateway, job, registry, grouping_key, timeout, handler):
     gateway_url = urlparse(gateway)
-    if not gateway_url.scheme:
+    if not gateway_url.scheme or (PYTHON26_OR_OLDER and gateway_url.scheme not in ['http', 'https']):
         gateway = 'http://{0}'.format(gateway)
     url = '{0}/metrics/job/{1}'.format(gateway, quote_plus(job))
 


### PR DESCRIPTION
If python version is 2.6 or older, check if scheme is one of “http" or "https".