### PR TITLE
Fix: #214. Pass a registry to MetricHandler via start_http_server.

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -17,6 +17,7 @@ Histogram = core.Histogram
 
 CONTENT_TYPE_LATEST = exposition.CONTENT_TYPE_LATEST
 generate_latest = exposition.generate_latest
+MetricsHandler = exposition.MetricsHandler
 make_wsgi_app = exposition.make_wsgi_app
 start_http_server = exposition.start_http_server
 start_wsgi_server = exposition.start_wsgi_server

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -17,7 +17,6 @@ Histogram = core.Histogram
 
 CONTENT_TYPE_LATEST = exposition.CONTENT_TYPE_LATEST
 generate_latest = exposition.generate_latest
-MetricsHandler = exposition.MetricsHandler
 make_wsgi_app = exposition.make_wsgi_app
 start_http_server = exposition.start_http_server
 start_wsgi_server = exposition.start_wsgi_server

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -83,21 +83,13 @@ def generate_latest(registry=core.REGISTRY):
 
 
 def factory_MetricsHandler(registry=core.REGISTRY):
-    '''Returns a MetricsHandler tied to a given registry.
+    '''Returns a MetricsHandler class tied to a given registry.
     '''
 
     class MetricsHandler(BaseHTTPRequestHandler):
-        """HTTP handler that gives metrics from ``MetricsHandler.registry``."""
+        """HTTP handler that gives metrics from the context ``registry``."""
         def do_GET(self):
-            # In the _multiprocess case, the CollectorRegistry
-            # should be instantiated at every call or we
-            # get duplicated metrics.
-            if core._ValueClass._multiprocess:
-                r = core.CollectorRegistry()
-                MultiProcessCollector(r)
-            else:
-                r = registry
-
+            r = registry
             params = parse_qs(urlparse(self.path).query)
             if 'name[]' in params:
                 r = r.restricted_registry(params['name[]'])

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -9,6 +9,37 @@ import shelve
 
 from . import core
 
+
+class MultiProcessRegistry(object):
+    """The one and only multiprocess registry."""
+    def __init__(self):
+        self.registry = None
+
+    def _refresh(self):
+        """Refresh registry entries from path.
+
+           Registry should be reset every time
+           or we get duplicated entries.
+        """
+        self.registry = core.CollectorRegistry()
+        MultiProcessCollector(self.registry)
+
+    def collect(self):
+        """Proxy to self.registry.collect.
+        """
+        # Always refresh the registry before collecting, or
+        #   we'll end with duplicate metrics.
+        self._refresh()
+        return self.registry.collect()
+
+    def restricted_registry(self, names):
+        """Proxy to self.registry.restricted_registry.
+        """
+        if not self.registry:
+            self._refresh()
+        return self.registry.restricted_registry(names)
+
+
 class MultiProcessCollector(object):
     """Collector for files for multi-process mode."""
     def __init__(self, registry, path=None):

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -13,7 +13,8 @@ from prometheus_client import Gauge, Counter, Summary, Histogram, Metric
 from prometheus_client import CollectorRegistry, generate_latest
 from prometheus_client import push_to_gateway, pushadd_to_gateway, delete_from_gateway
 from prometheus_client import CONTENT_TYPE_LATEST, instance_ip_grouping_key
-from prometheus_client.exposition import default_handler, basic_auth_handler
+from prometheus_client import core
+from prometheus_client.exposition import default_handler, basic_auth_handler, MetricsHandler
 
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler
@@ -194,6 +195,9 @@ class TestPushGateway(unittest.TestCase):
     )
     def test_instance_ip_grouping_key(self):
         self.assertTrue('' != instance_ip_grouping_key()['instance'])
+
+    def test_metrics_handler(self):
+        MyHandler = MetricsHandler.factory(core.REGISTRY)
 
 
 if __name__ == '__main__':

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -129,6 +129,15 @@ class TestMultiProcess(unittest.TestCase):
         self.assertEqual(3, self.registry.get_sample_value('c'))
         self.assertEqual(1, c1._value.get())
 
+    def test_multiprocess_registry(self):
+        prometheus_client.core._ValueClass = prometheus_client.core._MultiProcessValue(lambda: 456)
+        c1 = Counter('c', 'help')
+        mpr = MultiProcessRegistry()
+        metrics = mpr.collect()
+        self.assertTrue(len(list(metrics)))
+        # Just test that we don't get exceptions.
+        mpr.restricted_registry(["c"]).collect()
+
 
 class TestMmapedDict(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What does this PR do?
  
Add `registry` parameter to start_http_server, so you can serve data
from a custom registry.

## How it's implemented

Added:
 - a `MultiprocessRegistry` wrapping `CollectorRegistry`
 - the optional named parameter `registry` to `start_http_server`
 - create a  MetricHandler tied to the passed `registry` via a MetricHandler_factory 
 - if `prometheus_multiproc_dir` is set, gather metrics the multiprocess way

## How do you use it
Create a new or a multiprocess registry
Pass `registry=myregistry` to start_http_server.

```
from prometheus_client import multiprocess, start_http_server
from prometheus_client import Counter
...
# Serve multiprocess metrics
registry = multiprocess.MultiProcessRegistry()
start_http_server(8000, registry=registry)

# Server core.REGISTRY metrics
start_http_server(8001) 
...
```
## Further notes.

Changes are backward compatible.

## Complete example

```
import os
from time import sleep
from multiprocessing import Process
from random import randint
from urllib import urlopen
from shutil import rmtree

dpath = os.environ['prometheus_multiproc_dir'] = "/tmp/test_prometheus_multi"
if os.path.isdir(dpath) and dpath:
    rmtree(dpath)
os.makedirs(dpath)


from prometheus_client import multiprocess, start_http_server, core
from prometheus_client import Counter, CollectorRegistry


NUM_COUNTER = Counter("num_requests", "Example counter", ["pid"])


def runner(*args):
    """A process thread.
    """
    while True:
        pid = os.getpid()
        NUM_COUNTER.labels(pid).inc(randint(0, 3))
        sleep(1)


if __name__ == '__main__':
    # Create a multiprocess registry.
    mpr = multiprocess.MultiProcessRegistry()
    start_http_server(8001, registry=mpr)

    # Serve default registry.
    start_http_server(8000)

    # Run 5 processes
    p = [Process(target=runner, args=('o',)) for x in range(5)]
    for j in p:
        j.start()

    for i in range(5):
        sleep(1)
        print(urlopen("http://localhost:8000").read())
        print(urlopen("http://localhost:8001").read())

```