### PR TITLE
py26 has fixed dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest
 
 [testenv:py26]
+; Last pytest and py version supported on py26 .
 deps = 
   unittest2
   py==1.4.31

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,16 @@ deps =
     coverage
     pytest
 
+[testenv:py26]
+deps = 
+  unittest2
+  py==1.4.31
+  pytest==2.9.2
+  coverage
+
 [testenv]
 deps =
     {[base]deps}
-    py26: unittest2
-    ; Twisted does not support Python 2.6.
     {py27,py34,py35,py36,pypy}: twisted
 commands = coverage run --parallel -m pytest {posargs}
 


### PR DESCRIPTION
## what does this PR do

for py26: fix dependencies: `pytest`, `py` 