### PR TITLE
Fix: #222. Support custom registry for MetricsHandler.

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -9,6 +9,7 @@ import shelve
 
 from . import core
 
+
 class MultiProcessCollector(object):
     """Collector for files for multi-process mode."""
     def __init__(self, registry, path=None):

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -13,7 +13,8 @@ from prometheus_client import Gauge, Counter, Summary, Histogram, Metric
 from prometheus_client import CollectorRegistry, generate_latest
 from prometheus_client import push_to_gateway, pushadd_to_gateway, delete_from_gateway
 from prometheus_client import CONTENT_TYPE_LATEST, instance_ip_grouping_key
-from prometheus_client.exposition import default_handler, basic_auth_handler
+from prometheus_client import core
+from prometheus_client.exposition import default_handler, basic_auth_handler, MetricsHandler
 
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler
@@ -194,6 +195,9 @@ class TestPushGateway(unittest.TestCase):
     )
     def test_instance_ip_grouping_key(self):
         self.assertTrue('' != instance_ip_grouping_key()['instance'])
+
+    def test_metrics_handler(self):
+        MyHandler = MetricsHandler.factory(core.REGISTRY)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What does this PR do?
  
Add `registry` parameter to start_http_server, so you can serve data
from a custom registry.

## How it's implemented

Added:
 - the optional named parameter `registry` to `start_http_server`
 - create a  MetricHandler tied to the passed `registry` via MetricHandler.factory 

## How do you use it
Create a new or a multiprocess registry
Pass `registry=myregistry` to start_http_server.

```
from prometheus_client import multiprocess, start_http_server
from prometheus_client import Counter
...
# Serve myregistry metrics.
myregistry = CollectorRegistry()
start_http_server(8000, registry=myregistry)

# Server core.REGISTRY metrics
start_http_server(8001) 
...
```
