### PR TITLE
Fix #214: document passing multiprocess registry to start_http_server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ implement a proper `describe`, or if that's not practical have `describe`
 return an empty list.
 
 
-## Multiprocess Mode (Gunicorn)
+## Multiprocess Mode
 
 Prometheus client libaries presume a threaded model, where metrics are shared
 across workers. This doesn't work so well for languages such as Python where
@@ -416,6 +416,28 @@ This comes with a number of limitations:
 - Custom collectors do not work (e.g. cpu and memory metrics)
 - The pushgateway cannot be used
 - Gauges cannot use the `pid` label
+
+Create a multiprocess registry and expose it via `start_http_server`.
+
+```python
+
+from prometheus_client import multiprocess, CollectorRegistry
+
+mpr = CollectorRegistry()
+multiprocess.MultiProcessCollector(mpr)
+
+...
+
+# Serve multiprocess metrics
+start_http_server(8001, registry=mpr)
+
+# Serve default registry.
+start_http_server(8000)
+
+```
+
+
+## Multiprocess Mode (Gunicorn)
 
 There's several steps to getting this working:
 


### PR DESCRIPTION
## What does this PR do?

Show how to pass a multiprocess registry to start_http_server.
## Complete example

```
import os
from time import sleep
from multiprocessing import Process
from random import randint
from urllib import urlopen
from shutil import rmtree

dpath = os.environ['prometheus_multiproc_dir'] = "/tmp/test_prometheus_multi"
if os.path.isdir(dpath) and dpath:
    rmtree(dpath)
os.makedirs(dpath)


from prometheus_client import multiprocess, start_http_server, core
from prometheus_client import Counter, CollectorRegistry


NUM_COUNTER = Counter("num_requests", "Example counter", ["pid"])


def runner(*args):
    """A process thread.
    """
    while True:
        pid = os.getpid()
        NUM_COUNTER.labels(pid).inc(randint(0, 3))
        sleep(1)


if __name__ == '__main__':
    # Create a multiprocess registry.
    mpr = CollectorRegistry()
    multiprocess.MultiProcessCollector(mpr)

    # serve multiprocess stats
    start_http_server(8001, registry=mpr)

    # Serve default registry.
    start_http_server(8000)

    # Run 5 processes
    p = [Process(target=runner, args=('o',)) for x in range(5)]
    for j in p:
        j.start()

    for i in range(5):
        sleep(1)
        print(urlopen("http://localhost:8000").read())
        print(urlopen("http://localhost:8001").read())

```