### PR TITLE
check Python version with sys.version_info

### DIFF
--- a/prometheus_client/decorator.py
+++ b/prometheus_client/decorator.py
@@ -42,7 +42,7 @@ import collections
 
 __version__ = '4.0.10'
 
-if sys.version >= '3':
+if sys.version_info >= (3,):
     from inspect import getfullargspec
 
     def get_init(cls):
@@ -109,7 +109,7 @@ class FunctionMaker(object):
                     setattr(self, a, getattr(argspec, a))
                 for i, arg in enumerate(self.args):
                     setattr(self, 'arg%d' % i, arg)
-                if sys.version < '3':  # easy way
+                if sys.version_info < (3,):  # easy way
                     self.shortsignature = self.signature = (
                         inspect.formatargspec(
                             formatvalue=lambda val: "", *argspec)[1:-1])

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -28,7 +28,7 @@ except ImportError:
 CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
 '''Content type of the latest text format'''
 
-PYTHON26_OR_OLDER = tuple(int(val) for val in sys.version.split()[0].split('.')) < (2, 7, 0)
+PYTHON26_OR_OLDER = sys.version_info < (2, 7)
 
 def make_wsgi_app(registry=core.REGISTRY):
     '''Create a WSGI app which serves the metrics from a registry.'''


### PR DESCRIPTION
sys.version_info is a parsed tuple of numbers, so not vulnerable to incorrect string version comparison (e.g. '10' < '3') or parse errors on sys.version.

Discovered because prometheus-client cannot be imported on development versions of Python which have version strings like `3.7.0a0`.