### PR TITLE
Add tox env for running flake8 lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py26,py27,py34,py35,py36,pypy,{py27,py36}-nooptionals,coverage-report
+envlist = coverage-clean,py26,py27,py34,py35,py36,pypy,{py27,py36}-nooptionals,coverage-report,flake8
 
 
 [base]
@@ -44,3 +44,47 @@ skip_install = true
 commands =
     coverage combine
     coverage report
+
+
+[testenv:flake8]
+deps =
+    flake8==3.5.0
+    flake8-docstrings==1.3.0
+    flake8-import-order==0.16
+skip_install = true
+commands =
+    flake8 prometheus_client/ tests/ setup.py
+
+
+[flake8]
+ignore =
+    D,
+    I,
+    E111,
+    E114,
+    E123,
+    E126,
+    E127,
+    E128,
+    E231,
+    E222,
+    E225,
+    E226,
+    E251,
+    E302,
+    E303,
+    E305,
+    E306,
+    E402,
+    E501,
+    E722,
+    E741,
+    F401,
+    F403,
+    F405,
+    F811,
+    F841,
+    W293,
+    W503
+import-order-style = google
+application-import-names = prometheus_client


### PR DESCRIPTION
Add ignore rules for all current lint failures, they can be tackled
in follow up branches along with enabling each rule.