### PR TITLE
Remove travis pypy version hack and use latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,6 @@ cache:
   directories:
     - $HOME/.cache/pip
 
-# Pending https://github.com/travis-ci/travis-ci/issues/5027
-before_install:
-  - |
-      if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
-        export PYENV_ROOT="$HOME/.pyenv"
-        if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
-          cd "$PYENV_ROOT" && git pull
-        else
-          rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
-        fi
-        export PYPY_VERSION="4.0.1"
-        "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
-        virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
-        source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
-      fi
-
 language: python
 
 matrix:


### PR DESCRIPTION
From the linked issue, it's now possible with travis to explictly
select a newer pypy version to use, so pick the latest 5.10.0 one.