### PR TITLE
Make registry optional for MultiProcessCollector

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -11,13 +11,13 @@ from . import core
 
 class MultiProcessCollector(object):
     """Collector for files for multi-process mode."""
-    def __init__(self, registry, path=None):
+    def __init__(self, registry=None, path=None):
         if path is None:
             path = os.environ.get('prometheus_multiproc_dir')
         if not path or not os.path.isdir(path):
             raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
         self._path = path
-        if registry:
+        if registry is not None:
             registry.register(self)
 
     def collect(self):


### PR DESCRIPTION
@brian-brazil this is a trivial first PR to make it possible to make it easier to add more collectors during a multiproc scrape. This is so the pattern eventually can be:

```
    registry = CollectorRegistry()
    registry.register(MultiProcessCollector())
    registry.register(PlatformCollector())
    # add your own CustomCollectors here
```

instead of having to explicitly pass None to each Collector.

I would also have included the change for PlatformCollector, but I'm concerned that might break existing code. Should it be accompanied by deprecation warnings, or is it not worth doing?