### PR TITLE
Fix for python3 bytes vs string problem.

### DIFF
--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -16,7 +16,8 @@ def text_string_to_metric_families(text):
 
     See text_fd_to_metric_families.
     """
-    for metric_family in text_fd_to_metric_families(StringIO.StringIO(text)):
+    data = StringIO.StringIO(text.decode('utf-8'))
+    for metric_family in text_fd_to_metric_families(data):
         yield metric_family
 
 
@@ -141,7 +142,7 @@ def _parse_sample(text):
             else:
                 value.append(char)
     return (''.join(name), labels, float(''.join(value)))
-    
+
 
 def text_fd_to_metric_families(fd):
     """Parse Prometheus text format from a file descriptor.


### PR DESCRIPTION
The parser example at https://github.com/prometheus/client_python#parser fails under python 3. It looks like another python 3 bytes vs string problem.

Sample code:
```
import requests

from prometheus_client.parser import text_string_to_metric_families

metrics = requests.get("http://localhost:9090/metrics").content

for family in text_string_to_metric_families(metrics):
    for sample in family.samples:
        print("Name: {0} Labels: {1} Value: {2}".format(*sample))
```

Error under python3 (python2 does not produce any errors):
```
$ python --version
Python 3.6.1
$ python prometheus_python_client_testing.py
Traceback (most recent call last):
  File "prometheus_python_client_testing.py", line 7, in <module>
    for family in text_string_to_metric_families(metrics):
  File "{...}/lib/python3.6/site-packages/prometheus_client-0.1.0-py3.6.egg/prometheus_client/parser.py", line 19, in text_string_to_metric_families
TypeError: initial_value must be str or None, not bytes
```

Proposed fix: Have text_string_to_metric_families decode the text to utf-8 which produces both python2 and python3 compatible results.

Results after the the fix (now getting the same results for both python 2 and python 3):
```
$ python prometheus_python_client_testing.py
Name: go_gc_duration_seconds Labels: {'quantile': '0'} Value: 0.0001011
Name: go_gc_duration_seconds Labels: {'quantile': '0.25'} Value: 0.000222089
Name: go_gc_duration_seconds Labels: {'quantile': '0.5'} Value: 0.0002778
Name: go_gc_duration_seconds Labels: {'quantile': '0.75'} Value: 0.000367716
Name: go_gc_duration_seconds Labels: {'quantile': '1'} Value: 0.007713041
...
```