### PR TITLE
Reduce unnecessary metric creation in loop

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -28,8 +28,12 @@ class MultiProcessCollector(object):
             d = core._MmapedDict(f)
             for key, value in d.read_all_values():
                 metric_name, name, labelnames, labelvalues = json.loads(key)
-                metrics.setdefault(metric_name, core.Metric(metric_name, 'Multiprocess metric', typ))
-                metric = metrics[metric_name]
+
+                metric = metrics.get(metric_name)
+                if metric is None:
+                    metric = core.Metric(metric_name, 'Multiprocess metric', typ)
+                    metrics[metric_name] = metric
+
                 if typ == 'gauge':
                     pid = parts[2][:-3]
                     metric._multiprocess_mode = parts[1]


### PR DESCRIPTION
Hi!

I will try to improve multiprocess metrics collections by a series of pull requests.
This one fixes unnecessary metric creation in loop.

The more correct way to use `dict.setdefault` is `result = dict.setdefault(key, value)`. In our case:

```
metric = metrics.setdefault(metric_name, core.Metric(...))
```
instead of
```
metrics.setdefault(metric_name, core.Metric(...))
metric = metrics[metric_name]
```

But the problem is that `core.Metric(...)` will be executed each time when **setdefault** method calls whether needed or not.