### PR TITLE
Use `collections.defaultdict` to speed up metrics aggregation

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from collections import defaultdict
+
 import glob
 import json
 import os
@@ -44,39 +46,38 @@ class MultiProcessCollector(object):
             d.close()
 
         for metric in metrics.values():
-            samples = {}
+            samples = defaultdict(float)
             buckets = {}
             for name, labels, value in metric.samples:
                 if metric.type == 'gauge':
-                    without_pid = tuple([l for l in labels if l[0] != 'pid'])
+                    without_pid = tuple(l for l in labels if l[0] != 'pid')
                     if metric._multiprocess_mode == 'min':
-                        samples.setdefault((name, without_pid), value)
-                        if samples[(name, without_pid)] > value:
+                        current = samples.setdefault((name, without_pid), value)
+                        if value < current:
                             samples[(name, without_pid)] = value
                     elif metric._multiprocess_mode == 'max':
-                        samples.setdefault((name, without_pid), value)
-                        if samples[(name, without_pid)] < value:
+                        current = samples.setdefault((name, without_pid), value)
+                        if value > current:
                             samples[(name, without_pid)] = value
                     elif metric._multiprocess_mode == 'livesum':
-                        samples.setdefault((name, without_pid), 0.0)
                         samples[(name, without_pid)] += value
                     else:  # all/liveall
                         samples[(name, labels)] = value
+
                 elif metric.type == 'histogram':
-                    bucket = [float(l[1]) for l in labels if l[0] == 'le']
+                    bucket = tuple(float(l[1]) for l in labels if l[0] == 'le')
                     if bucket:
                         # _bucket
-                        without_le = tuple([l for l in labels if l[0] != 'le'])
+                        without_le = tuple(l for l in labels if l[0] != 'le')
                         buckets.setdefault(without_le, {})
                         buckets[without_le].setdefault(bucket[0], 0.0)
                         buckets[without_le][bucket[0]] += value
                     else:
                         # _sum/_count
-                        samples.setdefault((name, labels), 0.0)
                         samples[(name, labels)] += value
+
                 else:
                     # Counter and Summary.
-                    samples.setdefault((name, labels), 0.0)
                     samples[(name, labels)] += value
 
             # Accumulate bucket values.


### PR DESCRIPTION
Hi!

This is the next performance pull request. This change is about using `collections.defaultdict` for counting samples. It works much faster than `setdefault` method:
```
In [1]: from collections import defaultdict

In [2]: d={}
In [3]: %timeit d.setdefault('key', 0.0);d['key']+=1
197 ns ± 7.5 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
In [4]: d
Out[4]: {'key': 8111111.0}

In [5]: d=defaultdict(float)
In [6]: %timeit d['key']+=1
80.9 ns ± 0.841 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
In [7]: d
Out[7]: defaultdict(float, {'key': 81111111.0})
```