### PR TITLE
Use constants for metric types instead of hardcoded strings

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -36,7 +36,7 @@ class MultiProcessCollector(object):
                     metric = core.Metric(metric_name, 'Multiprocess metric', typ)
                     metrics[metric_name] = metric
 
-                if typ == 'gauge':
+                if typ == core.MetricType.GAUGE:
                     pid = parts[2][:-3]
                     metric._multiprocess_mode = parts[1]
                     metric.add_sample(name, tuple(zip(labelnames, labelvalues)) + (('pid', pid), ), value)
@@ -49,7 +49,7 @@ class MultiProcessCollector(object):
             samples = defaultdict(float)
             buckets = {}
             for name, labels, value in metric.samples:
-                if metric.type == 'gauge':
+                if metric.type == core.MetricType.GAUGE:
                     without_pid = tuple(l for l in labels if l[0] != 'pid')
                     if metric._multiprocess_mode == 'min':
                         current = samples.setdefault((name, without_pid), value)
@@ -64,7 +64,7 @@ class MultiProcessCollector(object):
                     else:  # all/liveall
                         samples[(name, labels)] = value
 
-                elif metric.type == 'histogram':
+                elif metric.type == core.MetricType.HISTOGRAM:
                     bucket = tuple(float(l[1]) for l in labels if l[0] == 'le')
                     if bucket:
                         # _bucket
@@ -81,7 +81,7 @@ class MultiProcessCollector(object):
                     samples[(name, labels)] += value
 
             # Accumulate bucket values.
-            if metric.type == 'histogram':
+            if metric.type == core.MetricType.HISTOGRAM:
                 for labels, values in buckets.items():
                     acc = 0.0
                     for bucket, value in sorted(values.items()):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,7 @@ from prometheus_client.core import (
     Histogram,
     HistogramMetricFamily,
     Metric,
+    MetricType,
     Summary,
     SummaryMetricFamily,
     UntypedMetricFamily,
@@ -480,7 +481,7 @@ class TestCollectorRegistry(unittest.TestCase):
         Counter('c', 'help', registry=registry)
         Summary('s', 'help', registry=registry).observe(7)
 
-        m = Metric('s', 'help', 'summary')
+        m = Metric('s', 'help', MetricType.SUMMARY)
         m.samples = [('s_sum', {}, 7)]
         self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())
 

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -90,7 +90,7 @@ hh_sum 0.05
 
         class MyCollector(object):
             def collect(self):
-                metric = Metric("nonnumber", "Non number", 'untyped')
+                metric = Metric("nonnumber", "Non number", core.MetricType.UNTYPED)
                 metric.add_sample("nonnumber", {}, MyNumber())
                 yield metric
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,6 +15,7 @@ from prometheus_client.core import (
     GaugeMetricFamily,
     HistogramMetricFamily,
     Metric,
+    MetricType,
     SummaryMetricFamily,
 )
 from prometheus_client.exposition import (
@@ -74,7 +75,7 @@ a_sum 2
     def test_no_metadata(self):
         families = text_string_to_metric_families("""a 1
 """)
-        metric_family = Metric("a", "", "untyped")
+        metric_family = Metric("a", "", MetricType.UNTYPED)
         metric_family.add_sample("a", {}, 1)
         self.assertEqual([metric_family], list(families))
 
@@ -85,7 +86,7 @@ a_sum 2
 redis_connected_clients{instance="rough-snowflake-web",port="6380"} 10.0
 redis_connected_clients{instance="rough-snowflake-web",port="6381"} 12.0
 """)
-        m = Metric("redis_connected_clients", "Redis connected clients", "untyped")
+        m = Metric("redis_connected_clients", "Redis connected clients", MetricType.UNTYPED)
         m.samples = [
             ("redis_connected_clients", {"instance": "rough-snowflake-web", "port": "6380"}, 10),
             ("redis_connected_clients", {"instance": "rough-snowflake-web", "port": "6381"}, 12),


### PR DESCRIPTION
I propose to use constants for metric types. Ideally, it would be nice to have separate modules for metrics, values, registries.