### PR TITLE
Prevent double reading all values when collect multiprocess metrics

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -345,7 +345,7 @@ class _MmapedDict(object):
 
     Not thread safe.
     """
-    def __init__(self, filename):
+    def __init__(self, filename, read_mode=False):
         self._f = open(filename, 'a+b')
         if os.fstat(self._f.fileno()).st_size == 0:
             self._f.truncate(_INITIAL_MMAP_SIZE)
@@ -358,8 +358,9 @@ class _MmapedDict(object):
             self._used = 8
             struct.pack_into(b'i', self._m, 0, self._used)
         else:
-            for key, _, pos in self._read_all_values():
-                self._positions[key] = pos
+            if not read_mode:
+                for key, _, pos in self._read_all_values():
+                    self._positions[key] = pos
 
     def _init_value(self, key):
         """Initialize a value. Lock must be held by caller."""

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -27,7 +27,7 @@ class MultiProcessCollector(object):
         for f in glob.glob(os.path.join(self._path, '*.db')):
             parts = os.path.basename(f).split('_')
             typ = parts[0]
-            d = core._MmapedDict(f)
+            d = core._MmapedDict(f, read_mode=True)
             for key, value in d.read_all_values():
                 metric_name, name, labelnames, labelvalues = json.loads(key)
 


### PR DESCRIPTION
In multiprocess mode, when reading metrics from files, there is no need to read all values in constructor, because `read_all_values` method called explicitly in multiprocess collector.