### PR TITLE
added _max to summary allowed_names

### DIFF
--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -195,7 +195,7 @@ def text_fd_to_metric_families(fd):
                 allowed_names = {
                     'counter': [''],
                     'gauge': [''],
-                    'summary': ['_count', '_sum', ''],
+                    'summary': ['_count', '_sum', '_max', ''],
                     'histogram': ['_count', '_sum', '_bucket'],
                 }.get(typ, [''])
                 allowed_names = [name + n for n in allowed_names]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -207,6 +207,7 @@ go_gc_duration_seconds{quantile="0.75"} 0.013962066
 go_gc_duration_seconds{quantile="1"} 0.021383540000000003
 go_gc_duration_seconds_sum 56.12904785
 go_gc_duration_seconds_count 7476.0
+go_gc_duration_seconds_max 0.0
 # HELP go_goroutines Number of goroutines that currently exist.
 # TYPE go_goroutines gauge
 go_goroutines 166.0


### PR DESCRIPTION
@brian-brazil 

We have a few teams using the [micrometer metrics library](https://github.com/micrometer-metrics/micrometer) and it comes with a "Timer" metric (which is actually a summary). Unfortunately that metric seems to produce "_max" metrics in addition to "_sum" and "_count".

```
# HELP jvm_gc_pause_seconds Time spent in GC pause
# TYPE jvm_gc_pause_seconds summary
jvm_gc_pause_seconds_count{action="end of minor GC",cause="Allocation Failure",} 6.0
jvm_gc_pause_seconds_sum{action="end of minor GC",cause="Allocation Failure",} 0.135
jvm_gc_pause_seconds_max{action="end of minor GC",cause="Allocation Failure",} 0.0
jvm_gc_pause_seconds_count{action="end of minor GC",cause="Metadata GC Threshold",} 2.0
jvm_gc_pause_seconds_sum{action="end of minor GC",cause="Metadata GC Threshold",} 0.022
jvm_gc_pause_seconds_max{action="end of minor GC",cause="Metadata GC Threshold",} 0.0
jvm_gc_pause_seconds_count{action="end of major GC",cause="Metadata GC Threshold",} 2.0
jvm_gc_pause_seconds_sum{action="end of major GC",cause="Metadata GC Threshold",} 0.308
jvm_gc_pause_seconds_max{action="end of major GC",cause="Metadata GC Threshold",} 0.0
```

This results in the parser producing invalid Output:

```
# HELP jvm_gc_pause_seconds Time spent in GC pause
# TYPE jvm_gc_pause_seconds summary
jvm_gc_pause_seconds_count{action="end of minor GC",cause="Allocation Failure"} 16.0
jvm_gc_pause_seconds_sum{action="end of minor GC",cause="Allocation Failure"} 0.363
# HELP jvm_gc_pause_seconds_max 
# TYPE jvm_gc_pause_seconds_max untyped
jvm_gc_pause_seconds_max{action="end of minor GC",cause="Allocation Failure"} 0.0
jvm_gc_pause_seconds_max{action="end of minor GC",cause="Metadata GC Threshold"} 0.0
jvm_gc_pause_seconds_max{action="end of major GC",cause="Metadata GC Threshold"} 0.0
# HELP jvm_gc_pause_seconds_count 
# TYPE jvm_gc_pause_seconds_count untyped
jvm_gc_pause_seconds_count{action="end of minor GC",cause="Metadata GC Threshold"} 2.0
jvm_gc_pause_seconds_count{action="end of major GC",cause="Metadata GC Threshold"} 2.0
# HELP jvm_gc_pause_seconds_sum 
# TYPE jvm_gc_pause_seconds_sum untyped
jvm_gc_pause_seconds_sum{action="end of minor GC",cause="Metadata GC Threshold"} 0.074
jvm_gc_pause_seconds_sum{action="end of major GC",cause="Metadata GC Threshold"} 0.312
```

While I don't see this anywhere in the Prometheus documentation and absolutely understand if it is being rejected, I hope this is sensible enough to make it upstream.