### PR TITLE
address prometheus/client_python#80

### DIFF
--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -84,7 +84,7 @@ class ProcessCollector(object):
                                               'Number of open file descriptors.',
                                               len(os.listdir(os.path.join(pid, 'fd'))))
             result.extend([open_fds, max_fds])
-        except (IOError, OSError):
+        except (IOError, OSError, ValueError):
             pass
 
         return result


### PR DESCRIPTION
sdc-docker (Joyent's implementation of Docker that sits on top of their Triton orchestration platform) sometimes produces non-float values (the string `unlimited`) for open file descriptor limits. When they're cast at floats, a ValueError is raised. This commit catches that exception and passes.

This problem has been previously discussed in issue #80 