### PR TITLE
Text parser optimization (~4.5x perf)

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -182,12 +182,8 @@ class Metric(object):
                 self.samples == other.samples)
 
     def __repr__(self):
-        return str(self)
-
-    def __str__(self):
-        return "<Metric name: %s, documentation: %s, type: %s, samples: %s>" % (
-            self.name, self.documentation, self.type, self.samples)
-
+        return "Metric(%s, %s, %s, %s)" % (self.name, self.documentation,
+            self.type, self.samples)
 
 class UntypedMetricFamily(Metric):
     '''A single untyped metric and its samples.

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -181,6 +181,13 @@ class Metric(object):
                 self.type == other.type and
                 self.samples == other.samples)
 
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return "<Metric name: %s, documentation: %s, type: %s, samples: %s>" % (
+            self.name, self.documentation, self.type, self.samples)
+
 
 class UntypedMetricFamily(Metric):
     '''A single untyped metric and its samples.

--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -25,7 +25,6 @@ def _replace_help_escaping(s):
 def _replace_escaping(s):
     return s.replace("\\n", "\n").replace('\\\\', '\\').replace('\\"', '"')
 
-
 def _parse_labels(labels_string):
     labels = {}
     # Return if we don't have valid labels

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -119,6 +119,15 @@ a\t1
 """)
         self.assertEqual([CounterMetricFamily("a", "help", value=1)], list(families))
 
+    def test_labels_with_curly_braces(self):
+        families = text_string_to_metric_families("""# TYPE a counter
+# HELP a help
+a{foo="bar", bar="b{a}z"} 1
+""")
+        metric_family = CounterMetricFamily("a", "help", labels=["foo", "bar"])
+        metric_family.add_metric(["bar", "b{a}z"], 1)
+        self.assertEqual([metric_family], list(families))
+
     def test_empty_help(self):
         families = text_string_to_metric_families("""# TYPE a counter
 # HELP a
@@ -142,10 +151,16 @@ a{foo="baz"} -Inf
 # HELP a help
 a{ foo = "bar" } 1
 a\t\t{\t\tfoo\t\t=\t\t"baz"\t\t}\t\t2
+a   {    foo   =  "buz"   }    3
+a\t {  \t foo\t = "biz"\t  } \t 4
+a \t{\t foo   = "boz"\t}\t 5
 """)
         metric_family = CounterMetricFamily("a", "help", labels=["foo"])
         metric_family.add_metric(["bar"], 1)
         metric_family.add_metric(["baz"], 2)
+        metric_family.add_metric(["buz"], 3)
+        metric_family.add_metric(["biz"], 4)
+        metric_family.add_metric(["boz"], 5)
         self.assertEqual([metric_family], list(families))
 
     def test_commas(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -189,6 +189,17 @@ a{} 1
         # Can't use a simple comparison as nan != nan.
         self.assertTrue(math.isnan(list(families)[0].samples[0][2]))
 
+    def test_empty_label(self):
+        families = text_string_to_metric_families("""# TYPE a counter
+# HELP a help
+a{foo="bar"} 1
+a{foo=""} 2
+""")
+        metric_family = CounterMetricFamily("a", "help", labels=["foo"])
+        metric_family.add_metric(["bar"], 1)
+        metric_family.add_metric([""], 2)
+        self.assertEqual([metric_family], list(families))
+
     def test_escaping(self):
         families = text_string_to_metric_families("""# TYPE a counter
 # HELP a he\\n\\\\l\\tp


### PR DESCRIPTION
Hi,

As we extensively use this library for parsing prometheus text format, we have observed that for big payloads (like https://github.com/kubernetes/kube-state-metrics for a big cluster) that can contains 400k+ lines the text parsing can be quite slow. (up to 27secs)

We tried to optimize the parser by dropping the state machine and leveraging native python functions such as `index` or `find` and it gives us an average of x5 performances.

Here are some benchmark using `timeit`:
```
call (x100000): _parse_sample('simple_metric 1.513767429e+09')
previous implementation: 1.10845804214
new implementation: 0.277444839478
improvement: x3.99523755508

call (x100000): _parse_sample('kube_service_labels{label_app="kube-state-metrics",label_chart="kube-state-metrics-0.5.0",label_heritage="Tiller",label_release="ungaged-panther",namespace="default",service="ungaged-panther-kube-state-metrics"} 1')
previous implementation: 7.58089208603
new implementation: 1.48280119896
improvement: x5.11254785291
```

For the KSM payload (400k lines) the parsing goes from ~27sec to ~4.7sec

**Note**: We could go up to almost 10x performance if we dropped some edge-cases treatment (like escaping, tab/space, etc...) could we consider a "strict" parsing mode that we could optionally use for "good citizens"?

