### PR TITLE
Fix unescaping implementation in parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -167,14 +167,32 @@ a \t{\t foo   = "boz"\t}\t 5
         families = text_string_to_metric_families("""# TYPE a counter
 # HELP a help
 a{foo="bar",} 1
+a{foo="baz",  } 1
 # TYPE b counter
 # HELP b help
 b{,} 2
+# TYPE c counter
+# HELP c help
+c{  ,} 3
+# TYPE d counter
+# HELP d help
+d{,  } 4
 """)
         a = CounterMetricFamily("a", "help", labels=["foo"])
         a.add_metric(["bar"], 1)
+        a.add_metric(["baz"], 1)
         b = CounterMetricFamily("b", "help", value=2)
-        self.assertEqual([a, b], list(families))
+        c = CounterMetricFamily("c", "help", value=3)
+        d = CounterMetricFamily("d", "help", value=4)
+        self.assertEqual([a, b, c, d], list(families))
+
+    def test_multiple_trailing_commas(self):
+        text = """# TYPE a counter
+# HELP a help
+a{foo="bar",, } 1
+"""
+        self.assertRaises(ValueError,
+                          lambda: list(text_string_to_metric_families(text)))
 
     def test_empty_brackets(self):
         families = text_string_to_metric_families("""# TYPE a counter
@@ -199,6 +217,49 @@ a{foo=""} 2
         metric_family.add_metric(["bar"], 1)
         metric_family.add_metric([""], 2)
         self.assertEqual([metric_family], list(families))
+
+    def test_label_escaping(self):
+        for escaped_val, etalon_val in [
+                ('foo', 'foo'),
+                ('\\foo', '\\foo'),
+                ('\\\\foo', '\\foo'),
+                ('foo\\\\', 'foo\\'),
+                ('\\n', '\n'),
+                ('\\\\n', '\\n'),
+                ('\\\\\\n', '\\\n'),
+                ('\\"', '"'),
+                ('\\\\\\"', '\\"')]:
+            families = list(text_string_to_metric_families("""
+# TYPE a counter
+# HELP a help
+a{foo="%s",bar="baz"} 1
+""" % escaped_val))
+            metric_family = CounterMetricFamily(
+                "a", "help", labels=["foo", "bar"])
+            metric_family.add_metric([etalon_val, "baz"], 1)
+            self.assertEqual([metric_family], list(families))
+
+    def test_help_escaping(self):
+        for escaped_val, etalon_val in [
+                ('foo', 'foo'),
+                ('\\foo', '\\foo'),
+                ('\\\\foo', '\\foo'),
+                ('foo\\', 'foo\\'),
+                ('foo\\\\', 'foo\\'),
+                ('\\n', '\n'),
+                ('\\\\n', '\\n'),
+                ('\\\\\\n', '\\\n'),
+                ('\\"', '\\"'),
+                ('\\\\"', '\\"'),
+                ('\\\\\\"', '\\\\"')]:
+            families = list(text_string_to_metric_families("""
+# TYPE a counter
+# HELP a %s
+a{foo="bar"} 1
+""" % escaped_val))
+            metric_family = CounterMetricFamily("a", etalon_val, labels=["foo"])
+            metric_family.add_metric(["bar"], 1)
+            self.assertEqual([metric_family], list(families))
 
     def test_escaping(self):
         families = text_string_to_metric_families("""# TYPE a counter


### PR DESCRIPTION
Hi!

This PR addresses some bugs introduced with the recent parser rewrite (#282). The old implementation
```
s.replace("\\n", "\n").replace('\\\\', '\\').replace('\\"', '"')
```
would produce invalid results in presence of `\\n` substring in input: 
- the expected result AFAIU is `\\n -> \n` (simply unescaping the `\\`)
- the implementation from #282 would do `\\n -> \<NL>`, where `<NL>` means newline character
- if you place `replace('\\\\', '\\')` at the beginning it would still be wrong (`\\n -> \n -> <NL>`)

Also, the rewritten version of `_parse_labels` didn't work well with `"foo\\"` strings, because it only checked for one slash before quotes. With all that in mind I went on to rewrite the entire thing with regexes.

It should be more correct *and* more performant. Taking the input values from #282 on Python 3.6 gave me the following.

Short string, 1M reps
```python

# OLD
In [7]: %time for i in range(1000000*5): _parse_sample('simple_metric 1.513767429e+09')
CPU times: user 13.6 s, sys: 0 ns, total: 13.6 s
Wall time: 13.6 s

#NEW
In [16]: %time for i in range(1000000*5): _parse_sample('simple_metric 1.513767429e+09')
CPU times: user 9.97 s, sys: 0 ns, total: 9.97 s
Wall time: 9.97 s
```

Long string 100k reps:
```python
# OLD
In [5]: %time for i in range(100000*5): _parse_sample('kube_service_labels{label_app="kube-state-metrics",label_chart="kube-state-metrics-0.5.0",label_heritage="Tiller",label_release="ungaged
   ...: -panther",namespace="default",service="ungaged-panther-kube-state-metrics"} 1')
CPU times: user 9.07 s, sys: 0 ns, total: 9.07 s
Wall time: 9.07 s

# NEW
In [13]: %time for i in range(100000*5): _parse_sample('kube_service_labels{label_app="kube-state-metrics",label_chart="kube-state-metrics-0.5.0",label_heritage="Tiller",label_release="ungage
    ...: d-panther",namespace="default",service="ungaged-panther-kube-state-metrics"} 1')
CPU times: user 7.49 s, sys: 3 µs, total: 7.49 s
Wall time: 7.49 s

```
