### PR TITLE
Thread safety done right

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -13,7 +13,7 @@ import sys
 import time
 import types
 
-from threading import Lock
+from threading import local, Lock
 from timeit import default_timer
 
 from .decorator import decorate
@@ -765,7 +765,7 @@ class Gauge(object):
 
         Can be used as a function decorator or context manager.
         '''
-        return _GaugeTimer(self)
+        return _Timer(self.set)
 
     def set_function(self, f):
         '''Call the provided function to return the Gauge value.
@@ -829,7 +829,7 @@ class Summary(object):
 
         Can be used as a function decorator or context manager.
         '''
-        return _SummaryTimer(self)
+        return _Timer(self.observe)
 
     def _samples(self):
         return (
@@ -919,7 +919,7 @@ class Histogram(object):
 
         Can be used as a function decorator or context manager.
         '''
-        return _HistogramTimer(self)
+        return _Timer(self.observe)
 
     def _samples(self):
         samples = []
@@ -930,24 +930,6 @@ class Histogram(object):
         samples.append(('_count', {}, acc))
         samples.append(('_sum', {}, self._sum.get()))
         return tuple(samples)
-
-
-class _HistogramTimer(object):
-    def __init__(self, histogram):
-        self._histogram = histogram
-
-    def __enter__(self):
-        self._start = default_timer()
-
-    def __exit__(self, typ, value, traceback):
-        # Time can go backwards.
-        self._histogram.observe(max(default_timer() - self._start, 0))
-
-    def __call__(self, f):
-        def wrapped(func, *args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-        return decorate(f, wrapped)
 
 
 class _ExceptionCounter(object):
@@ -986,34 +968,18 @@ class _InprogressTracker(object):
         return decorate(f, wrapped)
 
 
-class _SummaryTimer(object):
-    def __init__(self, summary):
-        self._summary = summary
+class _Timer(object):
+    def __init__(self, callback):
+        self._callback = callback
+        self._storage = local()
 
     def __enter__(self):
-        self._start = default_timer()
+        self._storage.start = default_timer()
 
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
-        self._summary.observe(max(default_timer() - self._start, 0))
-
-    def __call__(self, f):
-        def wrapped(func, *args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-        return decorate(f, wrapped)
-
-
-class _GaugeTimer(object):
-    def __init__(self, gauge):
-        self._gauge = gauge
-
-    def __enter__(self):
-        self._start = default_timer()
-
-    def __exit__(self, typ, value, traceback):
-        # Time can go backwards.
-        self._gauge.set(max(default_timer() - self._start, 0))
+        duration = max(default_timer() - self._storage.start, 0)
+        self._callback(duration)
 
     def __call__(self, f):
         def wrapped(func, *args, **kwargs):

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -972,13 +972,15 @@ class _Timer(object):
     def __init__(self, callback):
         self._callback = callback
         self._storage = local()
+        self.key = "k_{}".format(id(self))
 
     def __enter__(self):
-        self._storage.start = default_timer()
+        setattr(self._storage, self.key, default_timer())
 
     def __exit__(self, typ, value, traceback):
+        start = getattr(self._storage, self.key)
         # Time can go backwards.
-        duration = max(default_timer() - self._storage.start, 0)
+        duration = max(default_timer() - start, 0)
         self._callback(duration)
 
     def __call__(self, f):

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -972,7 +972,7 @@ class _Timer(object):
     def __init__(self, callback):
         self._callback = callback
         self._storage = local()
-        self.key = "k_{}".format(id(self))
+        self.key = "k_{0}".format(id(self))
 
     def __enter__(self):
         setattr(self._storage, self.key, default_timer())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import inspect
 import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
+
 
 from prometheus_client.core import (
     CollectorRegistry,
@@ -124,6 +126,26 @@ class TestGauge(unittest.TestCase):
         f()
         self.assertNotEqual(0, self.registry.get_sample_value('g'))
 
+    def test_function_decorator_multithread(self):
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        workers = 2
+        pool = ThreadPoolExecutor(max_workers=workers)
+
+        @self.gauge.time()
+        def f(duration):
+            time.sleep(duration)
+
+        expected_duration = 1
+        pool.submit(f, expected_duration)
+        time.sleep(0.7 * expected_duration)
+        pool.submit(f, expected_duration * 2)
+        time.sleep(expected_duration)
+
+        rounding_coefficient = 0.9
+        adjusted_expected_duration = expected_duration * rounding_coefficient
+        self.assertLess(adjusted_expected_duration, self.registry.get_sample_value('g'))
+        pool.shutdown(wait=True)
+
     def test_time_block_decorator(self):
         self.assertEqual(0, self.registry.get_sample_value('g'))
         with self.gauge.time():
@@ -154,6 +176,27 @@ class TestSummary(unittest.TestCase):
 
         f()
         self.assertEqual(1, self.registry.get_sample_value('s_count'))
+
+    def test_function_decorator_multithread(self):
+        self.assertEqual(0, self.registry.get_sample_value('s_count'))
+        workers = 3
+        duration = 0.1
+        pool = ThreadPoolExecutor(max_workers=workers)
+
+        @self.summary.time()
+        def f():
+            time.sleep(duration)
+
+        jobs = workers * 3
+        for i in range(jobs):
+            pool.submit(f)
+        pool.shutdown(wait=True)
+
+        self.assertEqual(jobs, self.registry.get_sample_value('s_count'))
+
+        rounding_coefficient = 0.9
+        total_expected_duration = jobs * duration * rounding_coefficient
+        self.assertLess(total_expected_duration, self.registry.get_sample_value('s_sum'))
 
     def test_block_decorator(self):
         self.assertEqual(0, self.registry.get_sample_value('s_count'))
@@ -233,6 +276,27 @@ class TestHistogram(unittest.TestCase):
         f()
         self.assertEqual(1, self.registry.get_sample_value('h_count'))
         self.assertEqual(1, self.registry.get_sample_value('h_bucket', {'le': '+Inf'}))
+
+    def test_function_decorator_multithread(self):
+        self.assertEqual(0, self.registry.get_sample_value('h_count'))
+        workers = 3
+        duration = 0.1
+        pool = ThreadPoolExecutor(max_workers=workers)
+
+        @self.histogram.time()
+        def f():
+            time.sleep(duration)
+
+        jobs = workers * 3
+        for i in range(jobs):
+            pool.submit(f)
+        pool.shutdown(wait=True)
+
+        self.assertEqual(jobs, self.registry.get_sample_value('h_count'))
+
+        rounding_coefficient = 0.9
+        total_expected_duration = jobs * duration * rounding_coefficient
+        self.assertLess(total_expected_duration, self.registry.get_sample_value('h_sum'))
 
     def test_block_decorator(self):
         self.assertEqual(0, self.registry.get_sample_value('h_count'))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,8 +2,12 @@ from __future__ import unicode_literals
 
 import inspect
 import time
-import unittest
 from concurrent.futures import ThreadPoolExecutor
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 
 from prometheus_client.core import (

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,17 @@ deps =
 
 [testenv:py26]
 ; Last pytest and py version supported on py26 .
-deps = 
+deps =
   unittest2
   py==1.4.31
   pytest==2.9.2
   coverage
+  futures
+
+[testenv:py27]
+deps =
+    {[base]deps}
+    futures
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,9 @@ commands = coverage run --parallel -m pytest {posargs}
 
 ; Ensure test suite passes if no optional dependencies are present.
 [testenv:py27-nooptionals]
-deps = {[base]deps}
+deps = 
+    {[base]deps}
+    futures
 commands = coverage run --parallel -m pytest {posargs}
 
 [testenv:py36-nooptionals]

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,11 @@ deps =
     {[base]deps}
     futures
 
+[testenv:pypy]
+deps =
+    {[base]deps}
+    futures
+
 [testenv]
 deps =
     {[base]deps}


### PR DESCRIPTION
Fixes #287.
Creates new timer object on each invocation - this solves both reentrancy and thread safety (added a test for reentrancy).

It's about 5% slower than the previous version with TLS, but in fact it's only 0.12us (micro) difference per function call. Assuming that actual functions will do other things besides updating metrics, I think it's quite negligible.

Here are the detailed performance test results:

```
Timing manual `observe'
10000000 loops in 14.906 seconds
1.491us per iteration
670.875k iterations per second

Timing ThreadLocalTimer
10000000 loops in 23.368 seconds
2.337us per iteration
427.944k iterations per second

Timing ObjectTimer
10000000 loops in 24.539 seconds
2.454us per iteration
407.510k iterations per second
```

And the actual performance test code:
```python
from threading import local

from prometheus_client.core import Summary, default_timer, decorate, _Timer


class ThreadLocalTimer(object):
    def __init__(self, callback):
        self._callback = callback
        self._storage = local()
        self.key = "k_{0}".format(id(self))

    def __enter__(self):
        setattr(self._storage, self.key, default_timer())

    def __exit__(self, typ, value, traceback):
        start = getattr(self._storage, self.key)
        # Time can go backwards.
        duration = max(default_timer() - start, 0)
        self._callback(duration)

    def __call__(self, f):
        def wrapped(func, *args, **kwargs):
            with self:
                return func(*args, **kwargs)
        return decorate(f, wrapped)


class ObjectTimer(object):
    def __init__(self, callback):
        self._callback = callback

    def _new_timer(self):
        return self.__class__(self._callback)

    def __enter__(self):
        self._start = default_timer()

    def __exit__(self, typ, value, traceback):
        # Time can go backwards.
        duration = max(default_timer() - self._start, 0)
        self._callback(duration)

    def __call__(self, f):
        def wrapped(func, *args, **kwargs):
            with self._new_timer():
                return func(*args, **kwargs)
        return decorate(f, wrapped)


def time_me(f, iterations=10000000):
    start = default_timer()
    for i in range(iterations):
        f()
    duration = default_timer() - start
    print(iterations, "loops in %.3f seconds" % duration)
    print("%.3fus per iteration" % (duration / iterations * 1000 * 1000))
    print("%.3fk iterations per second" % (iterations / duration / 1000))


def main():
    s = Summary("s", "help")
    st = Summary("st", "help")
    so = Summary("so", "help")

    dummy = lambda: None

    def s_f():
        start = default_timer()
        dummy()
        duration = max(default_timer() - start, 0)
        s.observe(duration)

    st_f = ThreadLocalTimer(st.observe)(lambda: None)
    so_f = ObjectTimer(so.observe)(lambda: None)

    print("\nTiming manual `observe'")
    time_me(s_f)
    print("\nTiming ThreadLocalTimer")
    time_me(st_f)
    print("\nTiming ObjectTimer")
    time_me(so_f)


if __name__ == "__main__":
    main()
```