### PR TITLE
Added set() to Counter so it is now possible to set an specific value

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ from prometheus_client import Counter
 c = Counter('my_failures_total', 'Description of counter')
 c.inc()     # Increment by 1
 c.inc(1.6)  # Increment by given value
+c.set(1.6)  # Sets counter by given value
 ```
 
 There are utilities to count exceptions raised:

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -646,6 +646,7 @@ class Counter(object):
         c = Counter('my_failures_total', 'Description of counter')
         c.inc()     # Increment by 1
         c.inc(1.6)  # Increment by given value
+        c.set(1.6)  # Sets counter by given value
 
     There are utilities to count exceptions raised:
 
@@ -671,6 +672,10 @@ class Counter(object):
         if amount < 0:
             raise ValueError('Counters can only be incremented by non-negative amounts.')
         self._value.inc(amount)
+
+    def set(self, value):
+        '''Set counter to the given value.'''
+        self._value.set(float(value))
 
     def count_exceptions(self, exception=Exception):
         '''Count exceptions in a block of code or function.

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -995,3 +995,4 @@ class _Timer(object):
             with self._new_timer():
                 return func(*args, **kwargs)
         return decorate(f, wrapped)
+


### PR DESCRIPTION
I (think I ) needed this because I will not track the counter through my app processing. I'll get the value from a DB table where another processes save results. I can not change these other processes to track the counter, so what I wanted to do is to watch the results direct from the log table and send the deterministic value to Prometheus.