### PR TITLE
Example on how to expose metrics in a flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,36 @@ from prometheus_client import start_wsgi_server
 start_wsgi_server(8000)
 ```
 
+#### Flask
+
+To use Prometheus with [Flask](http://flask.pocoo.org/) we need to serve metrics through a Prometheus WSGI application. This can be achieved using [Flask's application dispatching](http://flask.pocoo.org/docs/latest/patterns/appdispatch/). Below is a working example.
+
+Save the snippet below in a `myapp.py` file
+
+```python
+from flask import Flask
+from werkzeug.wsgi import DispatcherMiddleware
+from prometheus_client import make_wsgi_app
+
+# Create my app
+app = Flask(__name__)
+
+# Add prometheus wsgi middleware to route /metrics requests
+app_dispatch = DispatcherMiddleware(app, {
+    '/metrics': make_wsgi_app()
+})
+```
+
+Run the example web application like this
+
+```bash
+# Install uwsgi if you do not have it
+pip install uwsgi
+uwsgi --http 127.0.0.1:8000 --wsgi-file myapp.py --callable app_dispatch
+```
+
+Visit http://localhost:8000/metrics to see the metrics
+
 ### Node exporter textfile collector
 
 The [textfile collector](https://github.com/prometheus/node_exporter#textfile-collector)


### PR DESCRIPTION
I'm working on a flask application that needs to expose metrics to prometheus. It was not very clear how that could be done without reading the code. This PR updates the README with a simple example of doing so. Hopefully it saves someone some time of trying to figure that out.

@brian-brazil 
