### PR TITLE
Refactor MultiProcessCollector.collect() to allow for arbitrary merging.

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -1016,6 +1016,11 @@ def _floatToGoString(d):
         return '-Inf'
     elif math.isnan(d):
         return 'NaN'
+    elif sys.version_info[:2] == (2, 6):
+        format = '%g' % float(d)
+        if isinstance(d, float) and '.' not in format:
+            format += '.0'
+        return format
     else:
         return repr(float(d))
 

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -586,6 +586,13 @@ class _MmapedDict(object):
             self._f = None
 
 
+def _mmap_key(metric_name, name, labelnames, labelvalues):
+    """Format a key for use in the mmap file."""
+    # ensure labels are in consistent order for identity
+    labels = dict(zip(labelnames, labelvalues))
+    return json.dumps([metric_name, name, labels], sort_keys=True)
+
+
 def _MultiProcessValue(_pidFunc=os.getpid):
     files = {}
     values = []
@@ -618,7 +625,7 @@ def _MultiProcessValue(_pidFunc=os.getpid):
                     '{0}_{1}.db'.format(file_prefix, pid['value']))
                 files[file_prefix] = _MmapedDict(filename)
             self._file = files[file_prefix]
-            self._key = json.dumps((metric_name, name, labelnames, labelvalues))
+            self._key = _mmap_key(metric_name, name, labelnames, labelvalues)
             self._value = self._file.read_value(self._key)
 
         def __check_for_pid_change(self):

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -185,7 +185,7 @@ class CollectorRegistry(object):
 REGISTRY = CollectorRegistry(auto_describe=True)
 '''The default registry.'''
 
-_METRIC_TYPES = ('counter', 'gauge', 'summary', 'histogram', 
+_METRIC_TYPES = ('counter', 'gauge', 'summary', 'histogram',
         'gaugehistogram', 'unknown', 'info', 'stateset')
 
 
@@ -378,8 +378,8 @@ class HistogramMetricFamily(Metric):
             exemplar = None
             if len(b) == 3:
                 exemplar = b[2]
-            self.samples.append(Sample(self.name + '_bucket', 
-                dict(list(zip(self._labelnames, labels)) + [('le', bucket)]), 
+            self.samples.append(Sample(self.name + '_bucket',
+                dict(list(zip(self._labelnames, labels)) + [('le', bucket)]),
                 value, timestamp, exemplar))
         # +Inf is last and provides the count value.
         self.samples.append(Sample(self.name + '_count', dict(zip(self._labelnames, labels)), buckets[-1][1], timestamp))
@@ -411,7 +411,7 @@ class GaugeHistogramMetricFamily(Metric):
         '''
         for bucket, value in buckets:
             self.samples.append(Sample(
-                self.name + '_bucket', 
+                self.name + '_bucket',
                 dict(list(zip(self._labelnames, labels)) + [('le', bucket)]),
                 value, timestamp))
 
@@ -438,7 +438,7 @@ class InfoMetricFamily(Metric):
           labels: A list of label values
           value: A dict of labels
         '''
-        self.samples.append(Sample(self.name + '_info', 
+        self.samples.append(Sample(self.name + '_info',
             dict(dict(zip(self._labelnames, labels)), **value), 1, timestamp))
 
 
@@ -1016,11 +1016,6 @@ def _floatToGoString(d):
         return '-Inf'
     elif math.isnan(d):
         return 'NaN'
-    elif sys.version_info[:2] == (2, 6):
-        format = '%g' % float(d)
-        if isinstance(d, float) and '.' not in format:
-            format += '.0'
-        return format
     else:
         return repr(float(d))
 
@@ -1155,7 +1150,7 @@ class Enum(object):
      Example usage:
         from prometheus_client import Enum
 
-        e = Enum('task_state', 'Description of enum', 
+        e = Enum('task_state', 'Description of enum',
           states=['starting', 'running', 'stopped'])
         e.state('running')
 

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 
 import glob
 import json
@@ -23,8 +23,18 @@ class MultiProcessCollector(object):
             registry.register(self)
 
     def collect(self):
+        files = glob.glob(os.path.join(self._path, '*.db'))
+        return self.merge(files, accumulate=True)
+
+    def merge(self, files, accumulate=True):
+        """Merge metrics from given mmap files.
+
+        By default, histograms are accumulated, as per prometheus wire format.
+        But if writing the merged data back to mmap files, use
+        accumulate=False to avoid compound accumulation.
+        """
         metrics = {}
-        for f in glob.glob(os.path.join(self._path, '*.db')):
+        for f in files:
             parts = os.path.basename(f).split('_')
             typ = parts[0]
             d = core._MmapedDict(f, read_mode=True)
@@ -86,9 +96,17 @@ class MultiProcessCollector(object):
                 for labels, values in buckets.items():
                     acc = 0.0
                     for bucket, value in sorted(values.items()):
-                        acc += value
-                        samples[(metric.name + '_bucket', labels + (('le', core._floatToGoString(bucket)), ))] = acc
-                    samples[(metric.name + '_count', labels)] = acc
+                        sample_key = (
+                            metric.name + '_bucket',
+                            labels + (('le', core._floatToGoString(bucket)), ),
+                        )
+                        if accumulate:
+                            acc += value
+                            samples[sample_key] = acc
+                        else:
+                            samples[sample_key] = value
+                    if accumulate:
+                        samples[(metric.name + '_count', labels)] = acc
 
             # Convert to correct sample format.
             metric.samples = [core.Sample(name, dict(labels), value) for (name, labels), value in samples.items()]

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -40,6 +40,7 @@ class MultiProcessCollector(object):
             d = core._MmapedDict(f, read_mode=True)
             for key, value in d.read_all_values():
                 metric_name, name, labels = json.loads(key)
+                labels_key = tuple(sorted(labels.items()))
 
                 metric = metrics.get(metric_name)
                 if metric is None:
@@ -49,10 +50,10 @@ class MultiProcessCollector(object):
                 if typ == 'gauge':
                     pid = parts[2][:-3]
                     metric._multiprocess_mode = parts[1]
-                    metric.add_sample(name, tuple(labels.items()) + (('pid', pid), ), value)
+                    metric.add_sample(name, labels_key + (('pid', pid), ), value)
                 else:
                     # The duplicates and labels are fixed in the next for.
-                    metric.add_sample(name, tuple(labels.items()), value)
+                    metric.add_sample(name, labels_key, value)
             d.close()
 
         for metric in metrics.values():

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -2,7 +2,12 @@
 
 from __future__ import unicode_literals
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    OrderedDict = dict
 
 import glob
 import json

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -4,11 +4,6 @@ from __future__ import unicode_literals
 
 from collections import defaultdict
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    OrderedDict = dict
-
 import glob
 import json
 import os
@@ -44,7 +39,7 @@ class MultiProcessCollector(object):
             typ = parts[0]
             d = core._MmapedDict(f, read_mode=True)
             for key, value in d.read_all_values():
-                metric_name, name, labelnames, labelvalues = json.loads(key)
+                metric_name, name, labels = json.loads(key)
 
                 metric = metrics.get(metric_name)
                 if metric is None:
@@ -54,10 +49,10 @@ class MultiProcessCollector(object):
                 if typ == 'gauge':
                     pid = parts[2][:-3]
                     metric._multiprocess_mode = parts[1]
-                    metric.add_sample(name, tuple(zip(labelnames, labelvalues)) + (('pid', pid), ), value)
+                    metric.add_sample(name, tuple(labels.items()) + (('pid', pid), ), value)
                 else:
                     # The duplicates and labels are fixed in the next for.
-                    metric.add_sample(name, tuple(zip(labelnames, labelvalues)), value)
+                    metric.add_sample(name, tuple(labels.items()), value)
             d.close()
 
         for metric in metrics.values():

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -1,9 +1,5 @@
 from __future__ import unicode_literals
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    OrderedDict = dict
 import glob
 import os
 import shutil
@@ -145,7 +141,7 @@ class TestMultiProcess(unittest.TestCase):
     def test_collect(self):
         pid = 0
         core._ValueClass = core._MultiProcessValue(lambda: pid)
-        labels = OrderedDict((i, i) for i in 'abcd')
+        labels = dict((i, i) for i in 'abcd')
 
         def add_label(key, value):
             l = labels.copy()
@@ -203,7 +199,7 @@ class TestMultiProcess(unittest.TestCase):
     def test_merge_no_accumulate(self):
         pid = 0
         core._ValueClass = core._MultiProcessValue(lambda: pid)
-        labels = OrderedDict((i, i) for i in 'abcd')
+        labels = dict((i, i) for i in 'abcd')
 
         def add_label(key, value):
             l = labels.copy()

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -5,7 +5,13 @@ import os
 import shutil
 import sys
 import tempfile
-import unittest
+
+if sys.version_info < (2, 7):
+    # We need the skip decorators from unittest2 on Python 2.6.
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 from prometheus_client import core
 from prometheus_client.core import (

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -19,6 +19,7 @@ from prometheus_client.core import (
     Counter,
     Gauge,
     Histogram,
+    Sample,
     Summary,
 )
 from prometheus_client.multiprocess import (
@@ -172,34 +173,36 @@ class TestMultiProcess(unittest.TestCase):
 
         metrics = dict((m.name, m) for m in self.collector.collect())
 
-        self.assertEqual(metrics['c'].samples, [('c', labels, 2.0)])
+        self.assertEqual(
+            metrics['c'].samples, [Sample('c_total', labels, 2.0)]
+        )
         metrics['g'].samples.sort(key=lambda x: x[1]['pid'])
         self.assertEqual(metrics['g'].samples, [
-            ('g', add_label('pid', '0'), 1.0),
-            ('g', add_label('pid', '1'), 1.0),
+            Sample('g', add_label('pid', '0'), 1.0),
+            Sample('g', add_label('pid', '1'), 1.0),
         ])
 
         metrics['h'].samples.sort(
             key=lambda x: (x[0], float(x[1].get('le', 0)))
         )
         expected_histogram = [
-            ('h_bucket', add_label('le', '0.005'), 0.0),
-            ('h_bucket', add_label('le', '0.01'), 0.0),
-            ('h_bucket', add_label('le', '0.025'), 0.0),
-            ('h_bucket', add_label('le', '0.05'), 0.0),
-            ('h_bucket', add_label('le', '0.075'), 0.0),
-            ('h_bucket', add_label('le', '0.1'), 0.0),
-            ('h_bucket', add_label('le', '0.25'), 0.0),
-            ('h_bucket', add_label('le', '0.5'), 0.0),
-            ('h_bucket', add_label('le', '0.75'), 0.0),
-            ('h_bucket', add_label('le', '1.0'), 1.0),
-            ('h_bucket', add_label('le', '2.5'), 1.0),
-            ('h_bucket', add_label('le', '5.0'), 2.0),
-            ('h_bucket', add_label('le', '7.5'), 2.0),
-            ('h_bucket', add_label('le', '10.0'), 2.0),
-            ('h_bucket', add_label('le', '+Inf'), 2.0),
-            ('h_count', labels, 2.0),
-            ('h_sum', labels, 6.0),
+            Sample('h_bucket', add_label('le', '0.005'), 0.0),
+            Sample('h_bucket', add_label('le', '0.01'), 0.0),
+            Sample('h_bucket', add_label('le', '0.025'), 0.0),
+            Sample('h_bucket', add_label('le', '0.05'), 0.0),
+            Sample('h_bucket', add_label('le', '0.075'), 0.0),
+            Sample('h_bucket', add_label('le', '0.1'), 0.0),
+            Sample('h_bucket', add_label('le', '0.25'), 0.0),
+            Sample('h_bucket', add_label('le', '0.5'), 0.0),
+            Sample('h_bucket', add_label('le', '0.75'), 0.0),
+            Sample('h_bucket', add_label('le', '1.0'), 1.0),
+            Sample('h_bucket', add_label('le', '2.5'), 1.0),
+            Sample('h_bucket', add_label('le', '5.0'), 2.0),
+            Sample('h_bucket', add_label('le', '7.5'), 2.0),
+            Sample('h_bucket', add_label('le', '10.0'), 2.0),
+            Sample('h_bucket', add_label('le', '+Inf'), 2.0),
+            Sample('h_count', labels, 2.0),
+            Sample('h_sum', labels, 6.0),
         ]
 
         self.assertEqual(metrics['h'].samples, expected_histogram)
@@ -230,22 +233,22 @@ class TestMultiProcess(unittest.TestCase):
             key=lambda x: (x[0], float(x[1].get('le', 0)))
         )
         expected_histogram = [
-            ('h_bucket', add_label('le', '0.005'), 0.0),
-            ('h_bucket', add_label('le', '0.01'), 0.0),
-            ('h_bucket', add_label('le', '0.025'), 0.0),
-            ('h_bucket', add_label('le', '0.05'), 0.0),
-            ('h_bucket', add_label('le', '0.075'), 0.0),
-            ('h_bucket', add_label('le', '0.1'), 0.0),
-            ('h_bucket', add_label('le', '0.25'), 0.0),
-            ('h_bucket', add_label('le', '0.5'), 0.0),
-            ('h_bucket', add_label('le', '0.75'), 0.0),
-            ('h_bucket', add_label('le', '1.0'), 1.0),
-            ('h_bucket', add_label('le', '2.5'), 0.0),
-            ('h_bucket', add_label('le', '5.0'), 1.0),
-            ('h_bucket', add_label('le', '7.5'), 0.0),
-            ('h_bucket', add_label('le', '10.0'), 0.0),
-            ('h_bucket', add_label('le', '+Inf'), 0.0),
-            ('h_sum', labels, 6.0),
+            Sample('h_bucket', add_label('le', '0.005'), 0.0),
+            Sample('h_bucket', add_label('le', '0.01'), 0.0),
+            Sample('h_bucket', add_label('le', '0.025'), 0.0),
+            Sample('h_bucket', add_label('le', '0.05'), 0.0),
+            Sample('h_bucket', add_label('le', '0.075'), 0.0),
+            Sample('h_bucket', add_label('le', '0.1'), 0.0),
+            Sample('h_bucket', add_label('le', '0.25'), 0.0),
+            Sample('h_bucket', add_label('le', '0.5'), 0.0),
+            Sample('h_bucket', add_label('le', '0.75'), 0.0),
+            Sample('h_bucket', add_label('le', '1.0'), 1.0),
+            Sample('h_bucket', add_label('le', '2.5'), 0.0),
+            Sample('h_bucket', add_label('le', '5.0'), 1.0),
+            Sample('h_bucket', add_label('le', '7.5'), 0.0),
+            Sample('h_bucket', add_label('le', '10.0'), 0.0),
+            Sample('h_bucket', add_label('le', '+Inf'), 0.0),
+            Sample('h_sum', labels, 6.0),
         ]
 
         self.assertEqual(metrics['h'].samples, expected_histogram)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    OrderedDict = dict
 import glob
 import os
 import shutil

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import glob
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -138,6 +139,7 @@ class TestMultiProcess(unittest.TestCase):
         self.assertEqual(3, self.registry.get_sample_value('c_total'))
         self.assertEqual(1, c1._value.get())
 
+    @unittest.skipIf(sys.version_info < (2, 7), "Test requires Python 2.7+.")
     def test_collect(self):
         pid = 0
         core._ValueClass = core._MultiProcessValue(lambda: pid)
@@ -196,6 +198,7 @@ class TestMultiProcess(unittest.TestCase):
 
         self.assertEqual(metrics['h'].samples, expected_histogram)
 
+    @unittest.skipIf(sys.version_info < (2, 7), "Test requires Python 2.7+.")
     def test_merge_no_accumulate(self):
         pid = 0
         core._ValueClass = core._MultiProcessValue(lambda: pid)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from collections import OrderedDict
+import glob
 import os
 import shutil
 import tempfile
@@ -25,7 +27,7 @@ class TestMultiProcess(unittest.TestCase):
         os.environ['prometheus_multiproc_dir'] = self.tempdir
         core._ValueClass = core._MultiProcessValue(lambda: 123)
         self.registry = CollectorRegistry()
-        MultiProcessCollector(self.registry, self.tempdir)
+        self.collector = MultiProcessCollector(self.registry, self.tempdir)
 
     def tearDown(self):
         del os.environ['prometheus_multiproc_dir']
@@ -136,6 +138,109 @@ class TestMultiProcess(unittest.TestCase):
         c1.inc(1)
         self.assertEqual(3, self.registry.get_sample_value('c_total'))
         self.assertEqual(1, c1._value.get())
+
+    def test_collect(self):
+        pid = 0
+        core._ValueClass = core._MultiProcessValue(lambda: pid)
+        labels = OrderedDict((i, i) for i in 'abcd')
+
+        def add_label(key, value):
+            l = labels.copy()
+            l[key] = value
+            return l
+
+        c = Counter('c', 'help', labelnames=labels.keys(), registry=None)
+        g = Gauge('g', 'help', labelnames=labels.keys(), registry=None)
+        h = Histogram('h', 'help', labelnames=labels.keys(), registry=None)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(1)
+
+        pid = 1
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(5)
+
+        metrics = dict((m.name, m) for m in self.collector.collect())
+
+        self.assertEqual(metrics['c'].samples, [('c', labels, 2.0)])
+        metrics['g'].samples.sort(key=lambda x: x[1]['pid'])
+        self.assertEqual(metrics['g'].samples, [
+            ('g', add_label('pid', '0'), 1.0),
+            ('g', add_label('pid', '1'), 1.0),
+        ])
+
+        metrics['h'].samples.sort(
+            key=lambda x: (x[0], float(x[1].get('le', 0)))
+        )
+        expected_histogram = [
+            ('h_bucket', add_label('le', '0.005'), 0.0),
+            ('h_bucket', add_label('le', '0.01'), 0.0),
+            ('h_bucket', add_label('le', '0.025'), 0.0),
+            ('h_bucket', add_label('le', '0.05'), 0.0),
+            ('h_bucket', add_label('le', '0.075'), 0.0),
+            ('h_bucket', add_label('le', '0.1'), 0.0),
+            ('h_bucket', add_label('le', '0.25'), 0.0),
+            ('h_bucket', add_label('le', '0.5'), 0.0),
+            ('h_bucket', add_label('le', '0.75'), 0.0),
+            ('h_bucket', add_label('le', '1.0'), 1.0),
+            ('h_bucket', add_label('le', '2.5'), 1.0),
+            ('h_bucket', add_label('le', '5.0'), 2.0),
+            ('h_bucket', add_label('le', '7.5'), 2.0),
+            ('h_bucket', add_label('le', '10.0'), 2.0),
+            ('h_bucket', add_label('le', '+Inf'), 2.0),
+            ('h_count', labels, 2.0),
+            ('h_sum', labels, 6.0),
+        ]
+
+        self.assertEqual(metrics['h'].samples, expected_histogram)
+
+    def test_merge_no_accumulate(self):
+        pid = 0
+        core._ValueClass = core._MultiProcessValue(lambda: pid)
+        labels = OrderedDict((i, i) for i in 'abcd')
+
+        def add_label(key, value):
+            l = labels.copy()
+            l[key] = value
+            return l
+
+        h = Histogram('h', 'help', labelnames=labels.keys(), registry=None)
+        h.labels(**labels).observe(1)
+        pid = 1
+        h.labels(**labels).observe(5)
+
+        path = os.path.join(os.environ['prometheus_multiproc_dir'], '*.db')
+        files = glob.glob(path)
+        metrics = dict(
+            (m.name, m) for m in self.collector.merge(files, accumulate=False)
+        )
+
+        metrics['h'].samples.sort(
+            key=lambda x: (x[0], float(x[1].get('le', 0)))
+        )
+        expected_histogram = [
+            ('h_bucket', add_label('le', '0.005'), 0.0),
+            ('h_bucket', add_label('le', '0.01'), 0.0),
+            ('h_bucket', add_label('le', '0.025'), 0.0),
+            ('h_bucket', add_label('le', '0.05'), 0.0),
+            ('h_bucket', add_label('le', '0.075'), 0.0),
+            ('h_bucket', add_label('le', '0.1'), 0.0),
+            ('h_bucket', add_label('le', '0.25'), 0.0),
+            ('h_bucket', add_label('le', '0.5'), 0.0),
+            ('h_bucket', add_label('le', '0.75'), 0.0),
+            ('h_bucket', add_label('le', '1.0'), 1.0),
+            ('h_bucket', add_label('le', '2.5'), 0.0),
+            ('h_bucket', add_label('le', '5.0'), 1.0),
+            ('h_bucket', add_label('le', '7.5'), 0.0),
+            ('h_bucket', add_label('le', '10.0'), 0.0),
+            ('h_bucket', add_label('le', '+Inf'), 0.0),
+            ('h_sum', labels, 6.0),
+        ]
+
+        self.assertEqual(metrics['h'].samples, expected_histogram)
 
 
 class TestMmapedDict(unittest.TestCase):


### PR DESCRIPTION
Factors out a merge() method from the previous collect() method, which
is parameterized, and thus can be used for arbitrary merging of samples.
For motivation, see discussion in issue #275 around merging dead worker's
data into a single mmaped file.

This basically allows us to parameterize the files to be merged, and
also whether to accumulate histograms or not. Accumulation is on by
default, as that is what the prometheus format expects. But it can now
be disabled, which allows merged values to be correctly written back to
an mmaped file. For the same reason, the order of labels is preserved
via OrderedDict.