### PR TITLE
Refactor internal sample to use tuple for labels

### DIFF
--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -65,7 +65,7 @@ class GraphiteBridge(object):
                     labelstr = '.' + '.'.join(
                         ['{0}.{1}'.format(
                             _sanitize(k), _sanitize(v))
-                            for k, v in sorted(labels.items())])
+                            for k, v in sorted(labels)])
                 else:
                     labelstr = ''
                 output.append('{0}{1}{2} {3} {4}\n'.format(

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -75,7 +75,7 @@ def generate_latest(registry=core.REGISTRY):
                 labelstr = '{{{0}}}'.format(','.join(
                     ['{0}="{1}"'.format(
                      k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))
-                     for k, v in sorted(labels.items())]))
+                     for k, v in sorted(labels)]))
             else:
                 labelstr = ''
             output.append('{0}{1} {2}\n'.format(name, labelstr, core._floatToGoString(value)))

--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -54,10 +54,11 @@ def _is_character_escaped(s, charpos):
 
 
 def _parse_labels(labels_string):
-    labels = {}
     # Return if we don't have valid labels
     if "=" not in labels_string:
-        return labels
+        return ()
+
+    labels = []
 
     escaping = False
     if "\\" in labels_string:
@@ -90,14 +91,14 @@ def _parse_labels(labels_string):
             # Replace escaping if needed
             if escaping:
                 label_value = _replace_escaping(label_value)
-            labels[label_name.strip()] = label_value
+            labels.append((label_name.strip(), label_value))
 
             # Remove the processed label from the sub-slice for next iteration
             sub_labels = sub_labels[quote_end + 1:]
             next_comma = sub_labels.find(",") + 1
             sub_labels = sub_labels[next_comma:].lstrip()
 
-        return labels
+        return tuple(labels)
 
     except ValueError:
         raise ValueError("Invalid labels: %s" % labels_string)
@@ -137,7 +138,7 @@ def _parse_sample(text):
         name = text[:name_end]
         # The value is after the name
         value = float(_parse_value(text[name_end:]))
-        return name, {}, value
+        return name, (), value
 
 
 def text_fd_to_metric_families(fd):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -577,7 +577,7 @@ class TestCollectorRegistry(unittest.TestCase):
         Summary('s', 'help', registry=registry).observe(7)
 
         m = Metric('s', 'help', 'summary')
-        m.samples = [('s_sum', {}, 7)]
+        m.samples = [('s_sum', (), 7)]
         self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())
 
 

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -47,6 +47,7 @@ class TestGenerateText(unittest.TestCase):
     def test_histogram(self):
         s = Histogram('hh', 'A histogram', registry=self.registry)
         s.observe(0.05)
+        list(generate_latest(self.registry))
         self.assertEqual(b'''# HELP hh A histogram
 # TYPE hh histogram
 hh_bucket{le="0.005"} 0.0
@@ -90,7 +91,7 @@ hh_sum 0.05
         class MyCollector(object):
             def collect(self):
                 metric = Metric("nonnumber", "Non number", 'untyped')
-                metric.add_sample("nonnumber", {}, MyNumber())
+                metric.add_sample("nonnumber", (), MyNumber())
                 yield metric
 
         self.registry.register(MyCollector())

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -60,7 +60,7 @@ a{quantile="0.5"} 0.7
         # The Python client doesn't support quantiles, but we
         # still need to be able to parse them.
         metric_family = SummaryMetricFamily("a", "help", count_value=1, sum_value=2)
-        metric_family.add_sample("a", {"quantile": "0.5"}, 0.7)
+        metric_family.add_sample("a", (("quantile", "0.5"),), 0.7)
         self.assertEqual([metric_family], list(families))
 
     def test_simple_histogram(self):
@@ -77,7 +77,7 @@ a_sum 2
         families = text_string_to_metric_families("""a 1
 """)
         metric_family = Metric("a", "", "untyped")
-        metric_family.add_sample("a", {}, 1)
+        metric_family.add_sample("a", (), 1)
         self.assertEqual([metric_family], list(families))
 
     def test_untyped(self):
@@ -89,8 +89,8 @@ redis_connected_clients{instance="rough-snowflake-web",port="6381"} 12.0
 """)
         m = Metric("redis_connected_clients", "Redis connected clients", "untyped")
         m.samples = [
-            ("redis_connected_clients", {"instance": "rough-snowflake-web", "port": "6380"}, 10),
-            ("redis_connected_clients", {"instance": "rough-snowflake-web", "port": "6381"}, 12),
+            ("redis_connected_clients", (("instance", "rough-snowflake-web"), ("port", "6380")), 10),
+            ("redis_connected_clients", (("instance", "rough-snowflake-web"), ("port", "6381")), 12),
         ]
         self.assertEqual([m], list(families))
 

--- a/tests/test_platform_collector.py
+++ b/tests/test_platform_collector.py
@@ -39,7 +39,7 @@ class TestPlatformCollector(unittest.TestCase):
         for metric in self.registry.collect():
             for n, l, value in metric.samples:
                 if n == name:
-                    assert l == labels
+                    assert dict(l) == labels
                     return
         assert False
 


### PR DESCRIPTION
This preserves the order of labels at all times. The only place a dict
of labels was used in the public api is in get_sample_value(), where we
convert to dict for the comparison, which seems reasonable for
a testing helper.

Originally tried just using OrderedDict, for the best of both worlds,
but sadly python 2.6 doesn't have OrderedDict. If dropping 2.6 support is on the table, then just using OrderedDict would probably be a better change, as you'd get the ordering and the convenient dict API

Signed-off-by: Simon Davy <simon.davy@canonical.com>