### PR TITLE
Multiprocess mode: using direct assignment for writing into mmap

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -30,7 +30,7 @@ _INF = float("inf")
 _MINUS_INF = float("-inf")
 _INITIAL_MMAP_SIZE = 1 << 20
 
-_pack_integer = struct.Struct(b'i').pack_into
+_pack_integer_func = struct.Struct(b'i').pack
 _pack_double_func = struct.Struct(b'd').pack
 _unpack_integer = struct.Struct(b'i').unpack_from
 _unpack_double = struct.Struct(b'd').unpack_from
@@ -493,8 +493,15 @@ class _MutexValue(object):
             return self._value
 
 
+# struct.pack_into has atomicity issues because it will temporarily write 0 into
+# the mmap, resulting in false reads to 0 when experiencing a lot of writes.
+# Using direct assignment solves this issue.
 def _pack_double(data, pos, value):
     data[pos:pos + 8] = _pack_double_func(value)
+
+
+def _pack_integer(data, pos, value):
+    data[pos:pos + 4] = _pack_integer_func(value)
 
 
 class _MmapedDict(object):

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -31,7 +31,7 @@ _MINUS_INF = float("-inf")
 _INITIAL_MMAP_SIZE = 1 << 20
 
 _pack_integer = struct.Struct(b'i').pack_into
-_pack_double = struct.Struct(b'd').pack_into
+_pack_double_func = struct.Struct(b'd').pack
 _unpack_integer = struct.Struct(b'i').unpack_from
 _unpack_double = struct.Struct(b'd').unpack_from
 
@@ -491,6 +491,10 @@ class _MutexValue(object):
     def get(self):
         with self._lock:
             return self._value
+
+
+def _pack_double(data, pos, value):
+    data[pos:pos + 8] = _pack_double_func(value)
 
 
 class _MmapedDict(object):


### PR DESCRIPTION
@brian-brazil 

Using `struct.pack_into` can create atomicity problems when writing on CPython, setting the bytes to 0 before writing the value.

When having a lot of writes, some reads would return 0 instead of the real value. This line in CPython is suspected: https://github.com/python/cpython/blob/2.7/Modules/_struct.c#L1563

You can reproduce the issue by having two scripts running in two different processes but using the same file, one writing an always incrementing counter and the other reading it. Sometimes, the reader script will read 0 instead of the real value. We encountered this in production by running a Django web service behind gunicorn.

Example writer script:
```python
#!/usr/bin/python

import time
from prometheus_client.core import _MmapedDict


f = _MmapedDict('mf.db')
start = time.time()
iterations = 0

while True:
    iterations += 1
    f.write_value('v', float(iterations))
    if iterations % 500000 == 0:
        elapsed = time.time() - start
        rate = int(iterations / elapsed)
        print("{elapsed}s\t{iterations} it\t{rate} it/s".format(elapsed=elapsed, iterations=iterations, rate=rate))
```

Example reader script:
```python
#!/usr/bin/python

import time
from prometheus_client.core import _MmapedDict


f = _MmapedDict('mf.db', read_mode=True)
start = time.time()
iterations = 0
errors = 0

while True:
    values = list(f._read_all_values())
    iterations += 1
    if values[0][1] == 0:
        errors += 1
    if iterations % 100000 == 0:
        elapsed = time.time() - start
        rate = int(iterations / elapsed)
        print("{elapsed}s\t{iterations} it\t{rate} it/s (v={value}, e={errors})".format(
            elapsed=elapsed,
            iterations=iterations,
            rate=rate,
            value=values[0][1],
            errors=errors,
        ))
```

If you execute both of these at the same time, you will see the number of 0 reads increasing. This PR fixes the issue.