### PR TITLE
Code style fixups

### DIFF
--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 import logging
 import re
 import socket
-import time
 import threading
+import time
 from timeit import default_timer
 
 from .. import core

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -46,6 +46,7 @@ Sample.__new__.__defaults__ = (None, None)
 
 class Timestamp(object):
     '''A nanosecond-resolution timestamp.'''
+
     def __init__(self, sec, nsec):
         if nsec < 0 or nsec >= 1e9:
             raise ValueError("Invalid value for nanoseconds in Timestamp: {}".format(nsec))
@@ -84,6 +85,7 @@ class CollectorRegistry(object):
     Metric objects. The returned metrics should be consistent with the Prometheus
     exposition formats.
     '''
+
     def __init__(self, auto_describe=False):
         self._collector_to_names = {}
         self._names_to_collectors = {}
@@ -194,8 +196,10 @@ class CollectorRegistry(object):
 REGISTRY = CollectorRegistry(auto_describe=True)
 '''The default registry.'''
 
-_METRIC_TYPES = ('counter', 'gauge', 'summary', 'histogram',
-        'gaugehistogram', 'unknown', 'info', 'stateset')
+_METRIC_TYPES = (
+    'counter', 'gauge', 'summary', 'histogram',
+    'gaugehistogram', 'unknown', 'info', 'stateset',
+)
 
 
 class Metric(object):
@@ -206,6 +210,7 @@ class Metric(object):
     Custom collectors should use GaugeMetricFamily, CounterMetricFamily
     and SummaryMetricFamily instead.
     '''
+
     def __init__(self, name, documentation, typ, unit=''):
         if unit and not name.endswith("_" + unit):
             name += "_" + unit
@@ -236,14 +241,20 @@ class Metric(object):
                 self.samples == other.samples)
 
     def __repr__(self):
-        return "Metric(%s, %s, %s, %s, %s)" % (self.name, self.documentation,
-            self.type, self.unit, self.samples)
+        return "Metric(%s, %s, %s, %s, %s)" % (
+            self.name,
+            self.documentation,
+            self.type,
+            self.unit,
+            self.samples,
+        )
 
 
 class UnknownMetricFamily(Metric):
     '''A single unknwon metric and its samples.
     For use by custom collectors.
     '''
+
     def __init__(self, name, documentation, value=None, labels=None, unit=''):
         Metric.__init__(self, name, documentation, 'unknown', unit)
         if labels is not None and value is not None:
@@ -262,18 +273,21 @@ class UnknownMetricFamily(Metric):
         '''
         self.samples.append(Sample(self.name, dict(zip(self._labelnames, labels)), value, timestamp))
 
+
 # For backward compatibility.
 UntypedMetricFamily = UnknownMetricFamily
+
 
 class CounterMetricFamily(Metric):
     '''A single counter and its samples.
 
     For use by custom collectors.
     '''
+
     def __init__(self, name, documentation, value=None, labels=None, created=None, unit=''):
         # Glue code for pre-OpenMetrics metrics.
         if name.endswith('_total'):
-           name = name[:-6]
+            name = name[:-6]
         Metric.__init__(self, name, documentation, 'counter', unit)
         if labels is not None and value is not None:
             raise ValueError('Can only specify at most one of value and labels.')
@@ -301,6 +315,7 @@ class GaugeMetricFamily(Metric):
 
     For use by custom collectors.
     '''
+
     def __init__(self, name, documentation, value=None, labels=None, unit=''):
         Metric.__init__(self, name, documentation, 'gauge', unit)
         if labels is not None and value is not None:
@@ -326,6 +341,7 @@ class SummaryMetricFamily(Metric):
 
     For use by custom collectors.
     '''
+
     def __init__(self, name, documentation, count_value=None, sum_value=None, labels=None, unit=''):
         Metric.__init__(self, name, documentation, 'summary', unit)
         if (sum_value is None) != (count_value is None):
@@ -355,6 +371,7 @@ class HistogramMetricFamily(Metric):
 
     For use by custom collectors.
     '''
+
     def __init__(self, name, documentation, buckets=None, sum_value=None, labels=None, unit=''):
         Metric.__init__(self, name, documentation, 'histogram', unit)
         if (sum_value is None) != (buckets is None):
@@ -383,9 +400,13 @@ class HistogramMetricFamily(Metric):
             exemplar = None
             if len(b) == 3:
                 exemplar = b[2]
-            self.samples.append(Sample(self.name + '_bucket',
+            self.samples.append(Sample(
+                self.name + '_bucket',
                 dict(list(zip(self._labelnames, labels)) + [('le', bucket)]),
-                value, timestamp, exemplar))
+                value,
+                timestamp,
+                exemplar,
+            ))
         # +Inf is last and provides the count value.
         self.samples.append(Sample(self.name + '_count', dict(zip(self._labelnames, labels)), buckets[-1][1], timestamp))
         self.samples.append(Sample(self.name + '_sum', dict(zip(self._labelnames, labels)), sum_value, timestamp))
@@ -396,6 +417,7 @@ class GaugeHistogramMetricFamily(Metric):
 
     For use by custom collectors.
     '''
+
     def __init__(self, name, documentation, buckets=None, gsum_value=None, labels=None, unit=''):
         Metric.__init__(self, name, documentation, 'gaugehistogram', unit)
         if labels is not None and buckets is not None:
@@ -430,6 +452,7 @@ class InfoMetricFamily(Metric):
 
     For use by custom collectors.
     '''
+
     def __init__(self, name, documentation, value=None, labels=None):
         Metric.__init__(self, name, documentation, 'info')
         if labels is not None and value is not None:
@@ -456,6 +479,7 @@ class StateSetMetricFamily(Metric):
 
     For use by custom collectors.
     '''
+
     def __init__(self, name, documentation, value=None, labels=None):
         Metric.__init__(self, name, documentation, 'stateset')
         if labels is not None and value is not None:
@@ -524,6 +548,7 @@ class _MmapedDict(object):
 
     Not thread safe.
     """
+
     def __init__(self, filename, read_mode=False):
         self._f = open(filename, 'rb' if read_mode else 'a+b')
         if os.fstat(self._f.fileno()).st_size == 0:
@@ -691,6 +716,7 @@ else:
 
 class _LabelWrapper(object):
     '''Handles labels for the wrapped metric.'''
+
     def __init__(self, wrappedClass, name, labelnames, **kwargs):
         self._wrappedClass = wrappedClass
         self._type = wrappedClass._type
@@ -851,7 +877,7 @@ class Counter(object):
 
     def __init__(self, name, labelnames, labelvalues):
         if name.endswith('_total'):
-           name = name[:-6]
+            name = name[:-6]
         self._value = _ValueClass(self._type, name, name + '_total', labelnames, labelvalues)
         self._created = time.time()
 
@@ -963,6 +989,7 @@ class Gauge(object):
         The function must return a float, and may be called from
         multiple threads. All other methods of the Gauge become NOOPs.
         '''
+
         def samples(self):
             return (('', {}, float(f())), )
         self._samples = types.MethodType(samples, self)
@@ -1156,7 +1183,6 @@ class Info(object):
                 self._labelnames, val))
         with self._lock:
             self._value = dict(val)
-
 
     def _samples(self):
         with self._lock:

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -12,10 +12,9 @@ import struct
 import sys
 import time
 import types
-
+from collections import namedtuple
 from threading import Lock
 from timeit import default_timer
-from collections import namedtuple
 
 from .decorator import decorate
 

--- a/prometheus_client/decorator.py
+++ b/prometheus_client/decorator.py
@@ -50,6 +50,7 @@ if sys.version_info >= (3,):
 else:
     class getfullargspec(object):
         "A quick and dirty replacement for getfullargspec for Python 2.X"
+
         def __init__(self, f):
             self.args, self.varargs, self.varkw, self.defaults = \
                 inspect.getargspec(f)

--- a/prometheus_client/decorator.py
+++ b/prometheus_client/decorator.py
@@ -33,12 +33,12 @@ for the documentation.
 """
 from __future__ import print_function
 
+import collections
+import inspect
+import itertools
+import operator
 import re
 import sys
-import inspect
-import operator
-import itertools
-import collections
 
 __version__ = '4.0.10'
 

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -8,10 +8,11 @@ import socket
 import sys
 import threading
 from contextlib import closing
-from wsgiref.simple_server import make_server, WSGIRequestHandler
+from wsgiref.simple_server import WSGIRequestHandler, make_server
 
 from prometheus_client import core
 from prometheus_client.openmetrics import exposition as openmetrics
+
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
     from SocketServer import ThreadingMixIn

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -7,33 +7,35 @@ import time
 
 from . import core
 
+
 class GCCollector(object):
     """Collector for Garbage collection statistics."""
+
     def __init__(self, registry=core.REGISTRY, gc=gc):
         if not hasattr(gc, 'callbacks'):
             return
 
         collected = core.Histogram(
-           'python_gc_collected_objects',
-           'Objects collected during gc',
-           ['generation'],
-           buckets=[500, 1000, 5000, 10000, 50000],
-           registry=registry
+            'python_gc_collected_objects',
+            'Objects collected during gc',
+            ['generation'],
+            buckets=[500, 1000, 5000, 10000, 50000],
+            registry=registry
         )
 
         uncollectable = core.Histogram(
-           'python_gc_uncollectable_objects',
-           'Uncollectable object found during GC',
-           ['generation'],
-           buckets=[500, 1000, 5000, 10000, 50000],
-           registry=registry
+            'python_gc_uncollectable_objects',
+            'Uncollectable object found during GC',
+            ['generation'],
+            buckets=[500, 1000, 5000, 10000, 50000],
+            registry=registry
         )
 
         latency = core.Histogram(
-           'python_gc_duration_seconds',
-           'Time spent in garbage collection',
-           ['generation'],
-           registry=registry
+            'python_gc_duration_seconds',
+            'Time spent in garbage collection',
+            ['generation'],
+            registry=registry
         )
 
         times = {}

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -2,11 +2,10 @@
 
 from __future__ import unicode_literals
 
-from collections import defaultdict
-
 import glob
 import json
 import os
+from collections import defaultdict
 
 from . import core
 

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -13,6 +13,7 @@ from . import core
 
 class MultiProcessCollector(object):
     """Collector for files for multi-process mode."""
+
     def __init__(self, registry, path=None):
         if path is None:
             path = os.environ.get('prometheus_multiproc_dir')

--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -34,18 +34,27 @@ def generate_latest(registry):
                      k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))
                      for k, v in sorted(s.exemplar.labels.items())]))
                 if s.exemplar.timestamp is not None:
-                    exemplarstr = ' # {0} {1} {2}'.format(labels, 
-                            core._floatToGoString(s.exemplar.value), s.exemplar.timestamp)
+                    exemplarstr = ' # {0} {1} {2}'.format(
+                        labels,
+                        core._floatToGoString(s.exemplar.value),
+                        s.exemplar.timestamp,
+                    )
                 else:
-                    exemplarstr = ' # {0} {1}'.format(labels, 
-                            core._floatToGoString(s.exemplar.value))
+                    exemplarstr = ' # {0} {1}'.format(
+                        labels,
+                        core._floatToGoString(s.exemplar.value),
+                    )
             else:
                 exemplarstr = ''
             timestamp = ''
             if s.timestamp is not None:
                 timestamp = ' {0}'.format(s.timestamp)
-            output.append('{0}{1} {2}{3}{4}\n'.format(s.name, labelstr,
-                core._floatToGoString(s.value), timestamp, exemplarstr))
+            output.append('{0}{1} {2}{3}{4}\n'.format(
+                s.name,
+                labelstr,
+                core._floatToGoString(s.value),
+                timestamp,
+                exemplarstr,
+            ))
     output.append('# EOF\n')
     return ''.join(output).encode('utf-8')
-

--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -7,6 +7,7 @@ from .. import core
 CONTENT_TYPE_LATEST = str('application/openmetrics-text; version=0.0.1; charset=utf-8')
 '''Content type of the latest OpenMetrics text format'''
 
+
 def generate_latest(registry):
     '''Returns the metrics from the registry in latest text format as a string.'''
     output = []

--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -4,13 +4,14 @@ from __future__ import unicode_literals
 
 import math
 
+from .. import core
+
 try:
     import StringIO
 except ImportError:
     # Python 3
     import io as StringIO
 
-from .. import core
 
 
 def text_string_to_metric_families(text):

--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -223,9 +223,11 @@ def _parse_sample(text):
         exemplar_length = sum([len(k) + len(v) + 3 for k, v in exemplar_labels.items()]) + 2
         if exemplar_length > 64:
             raise ValueError("Exmplar labels are too long: " + text)
-        exemplar = core.Exemplar(exemplar_labels,
-                _parse_value(exemplar_value),
-                _parse_timestamp(exemplar_timestamp))
+        exemplar = core.Exemplar(
+            exemplar_labels,
+            _parse_value(exemplar_value),
+            _parse_timestamp(exemplar_timestamp),
+        )
 
     return core.Sample(''.join(name), labels, val, ts, exemplar)
 

--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -83,7 +83,7 @@ def _parse_timestamp(timestamp):
 
 def _parse_labels(it, text):
     # The { has already been parsed.
-    state  = 'startoflabelname'
+    state = 'startoflabelname'
     labelname = []
     labelvalue = []
     labels = {}
@@ -299,6 +299,7 @@ def text_fd_to_metric_families(fd):
     eof = False
 
     seen_metrics = set()
+
     def build_metric(name, documentation, typ, unit, samples):
         if name in seen_metrics:
             raise ValueError("Duplicate metric: " + name)
@@ -322,7 +323,7 @@ def text_fd_to_metric_families(fd):
 
     for line in fd:
         if line[-1] == '\n':
-          line = line[:-1]
+            line = line[:-1]
 
         if eof:
             raise ValueError("Received line after # EOF: " + line)

--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -4,13 +4,14 @@ from __future__ import unicode_literals
 
 import re
 
+from . import core
+
 try:
     import StringIO
 except ImportError:
     # Python 3
     import io as StringIO
 
-from . import core
 
 
 def text_string_to_metric_families(text):

--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -158,7 +158,7 @@ def text_fd_to_metric_families(fd):
     def build_metric(name, documentation, typ, samples):
         # Munge counters into OpenMetrics representation
         # used internally.
-        if typ == 'counter': 
+        if typ == 'counter':
             if name.endswith('_total'):
                 name = name[:-6]
             else:

--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import os
 
 from . import core
+
 try:
     import resource
     _PAGESIZE = resource.getpagesize()

--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -15,6 +15,7 @@ except ImportError:
 
 class ProcessCollector(object):
     """Collector for Standard Exports such as cpu and memory."""
+
     def __init__(self, namespace='', pid=lambda: 'self', proc='/proc', registry=core.REGISTRY):
         self._namespace = namespace
         self._pid = pid

--- a/prometheus_client/twisted/_exposition.py
+++ b/prometheus_client/twisted/_exposition.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, unicode_literals
-from .. import REGISTRY, exposition
 
 from twisted.web.resource import Resource
+
+from .. import REGISTRY, exposition
 
 
 class MetricsResource(Resource):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[isort]
+multi_line_output = 3

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -3,18 +3,29 @@ from __future__ import unicode_literals
 import sys
 import time
 
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Enum,
+    Gauge,
+    Histogram,
+    Info,
+    Metric,
+    Summary
+)
+from prometheus_client.core import (
+    Exemplar,
+    GaugeHistogramMetricFamily,
+    Timestamp
+)
+from prometheus_client.openmetrics.exposition import generate_latest
+
 if sys.version_info < (2, 7):
     # We need the skip decorators from unittest2 on Python 2.6.
     import unittest2 as unittest
 else:
     import unittest
 
-from prometheus_client import Gauge, Counter, Summary, Histogram, Info, Enum, Metric
-from prometheus_client import CollectorRegistry
-from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp, Exemplar
-from prometheus_client.openmetrics.exposition import (
-    generate_latest,
-)
 
 
 class TestGenerateText(unittest.TestCase):

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -13,8 +13,9 @@ from prometheus_client import Gauge, Counter, Summary, Histogram, Info, Enum, Me
 from prometheus_client import CollectorRegistry
 from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp, Exemplar
 from prometheus_client.openmetrics.exposition import (
-        generate_latest,
+    generate_latest,
 )
+
 
 class TestGenerateText(unittest.TestCase):
     def setUp(self):

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -3,12 +3,6 @@ from __future__ import unicode_literals
 import math
 import sys
 
-if sys.version_info < (2, 7):
-    # We need the skip decorators from unittest2 on Python 2.6.
-    import unittest2 as unittest
-else:
-    import unittest
-
 from prometheus_client.core import (
     CollectorRegistry,
     CounterMetricFamily,
@@ -21,14 +15,17 @@ from prometheus_client.core import (
     Sample,
     StateSetMetricFamily,
     SummaryMetricFamily,
-    Timestamp,
+    Timestamp
 )
-from prometheus_client.openmetrics.exposition import (
-    generate_latest,
-)
-from prometheus_client.openmetrics.parser import (
-    text_string_to_metric_families,
-)
+from prometheus_client.openmetrics.exposition import generate_latest
+from prometheus_client.openmetrics.parser import text_string_to_metric_families
+
+if sys.version_info < (2, 7):
+    # We need the skip decorators from unittest2 on Python 2.6.
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 
 class TestParse(unittest.TestCase):

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -127,7 +127,7 @@ a_bucket{le="+Inf"} 3 # {a="1234567890123456789012345678901234567890123456789012
 """)
         hfm = HistogramMetricFamily("a", "help")
         hfm.add_sample("a_bucket", {"le": "1"}, 0.0, None, Exemplar({"a": "b"}, 0.5))
-        hfm.add_sample("a_bucket", {"le": "2"}, 2.0, None, Exemplar({"a": "c"}, 0.5)), 
+        hfm.add_sample("a_bucket", {"le": "2"}, 2.0, None, Exemplar({"a": "c"}, 0.5)),
         hfm.add_sample("a_bucket", {"le": "+Inf"}, 3.0, None, Exemplar({"a": "1234567890123456789012345678901234567890123456789012345678"}, 4, Timestamp(123, 0)))
         self.assertEqual([hfm], list(families))
 
@@ -152,7 +152,7 @@ a_bucket{le="+Inf"} 3 123 # {a="d"} 4 123
 """)
         hfm = GaugeHistogramMetricFamily("a", "help")
         hfm.add_sample("a_bucket", {"le": "1"}, 0.0, Timestamp(123, 0), Exemplar({"a": "b"}, 0.5))
-        hfm.add_sample("a_bucket", {"le": "2"}, 2.0, Timestamp(123, 0), Exemplar({"a": "c"}, 0.5)), 
+        hfm.add_sample("a_bucket", {"le": "2"}, 2.0, Timestamp(123, 0), Exemplar({"a": "c"}, 0.5)),
         hfm.add_sample("a_bucket", {"le": "+Inf"}, 3.0, Timestamp(123, 0), Exemplar({"a": "d"}, 4, Timestamp(123, 0)))
         self.assertEqual([hfm], list(families))
 
@@ -563,7 +563,7 @@ prometheus_local_storage_chunk_ops_total{type="unpin"} 32662.0
                 ('# TYPE a gauge\na 0 1\na 0 0\n# EOF\n'),
                 ('# TYPE a gauge\na 0\na 0 0\n# EOF\n'),
                 ('# TYPE a gauge\na 0 0\na 0\n# EOF\n'),
-                ]:
+        ]:
             with self.assertRaises(ValueError):
                 list(text_string_to_metric_families(case))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,12 +4,6 @@ import inspect
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
-
 from prometheus_client.core import (
     CollectorRegistry,
     Counter,
@@ -23,12 +17,19 @@ from prometheus_client.core import (
     Info,
     InfoMetricFamily,
     Metric,
-    StateSetMetricFamily,
     Sample,
+    StateSetMetricFamily,
     Summary,
     SummaryMetricFamily,
-    UntypedMetricFamily,
+    UntypedMetricFamily
 )
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
 
 
 class TestCounter(unittest.TestCase):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -199,7 +199,7 @@ class TestSummary(unittest.TestCase):
         def f():
             time.sleep(duration / 2)
             # Testing that different instances of timer do not interfere
-            summary2.time()(lambda : time.sleep(duration / 2))()
+            summary2.time()(lambda: time.sleep(duration / 2))()
 
         jobs = workers * 3
         for i in range(jobs):
@@ -211,7 +211,7 @@ class TestSummary(unittest.TestCase):
         rounding_coefficient = 0.9
         total_expected_duration = jobs * duration * rounding_coefficient
         self.assertLess(total_expected_duration, self.registry.get_sample_value('s_sum'))
-        self.assertLess(total_expected_duration / 2 , self.registry.get_sample_value('s2_sum'))
+        self.assertLess(total_expected_duration / 2, self.registry.get_sample_value('s2_sum'))
 
     def test_function_decorator_reentrancy(self):
         self.assertEqual(0, self.registry.get_sample_value('s_count'))
@@ -224,7 +224,7 @@ class TestSummary(unittest.TestCase):
             time.sleep(sleep)
             if i == iterations:
                 return
-            f(i+1)
+            f(i + 1)
 
         f()
 
@@ -302,7 +302,6 @@ class TestHistogram(unittest.TestCase):
         self.assertEqual(1, self.registry.get_sample_value('hl_bucket', {'le': '+Inf', 'l': 'a'}))
         self.assertEqual(1, self.registry.get_sample_value('hl_count', {'l': 'a'}))
         self.assertEqual(2, self.registry.get_sample_value('hl_sum', {'l': 'a'}))
-
 
     def test_function_decorator(self):
         self.assertEqual(0, self.registry.get_sample_value('h_count'))
@@ -466,6 +465,7 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['a:b'])
         self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['__reserved'])
         self.assertRaises(ValueError, Summary, 'c_total', '', labelnames=['quantile'])
+
     def test_empty_labels_list(self):
         Histogram('h', 'help', [], registry=self.registry)
         self.assertEqual(0, self.registry.get_sample_value('h_sum'))
@@ -587,13 +587,13 @@ class TestMetricFamilies(unittest.TestCase):
         self.assertEqual(1, self.registry.get_sample_value('i_info', {'a': 'b', 'c': 'd'}))
 
     def test_stateset(self):
-        self.custom_collector(StateSetMetricFamily('s', 'help', value={'a': True, 'b': True,}))
+        self.custom_collector(StateSetMetricFamily('s', 'help', value={'a': True, 'b': True, }))
         self.assertEqual(1, self.registry.get_sample_value('s', {'s': 'a'}))
         self.assertEqual(1, self.registry.get_sample_value('s', {'s': 'b'}))
 
     def test_stateset_labels(self):
         cmf = StateSetMetricFamily('s', 'help', labels=['foo'])
-        cmf.add_metric(['bar'], {'a': False, 'b': False,})
+        cmf.add_metric(['bar'], {'a': False, 'b': False, })
         self.custom_collector(cmf)
         self.assertEqual(0, self.registry.get_sample_value('s', {'foo': 'bar', 's': 'a'}))
         self.assertEqual(0, self.registry.get_sample_value('s', {'foo': 'bar', 's': 'b'}))

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -4,18 +4,35 @@ import sys
 import threading
 import time
 
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Enum,
+    Gauge,
+    Histogram,
+    Info,
+    Metric,
+    Summary,
+    delete_from_gateway,
+    generate_latest,
+    instance_ip_grouping_key,
+    push_to_gateway,
+    pushadd_to_gateway
+)
+from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp
+from prometheus_client.exposition import (
+    MetricsHandler,
+    basic_auth_handler,
+    default_handler
+)
+
 if sys.version_info < (2, 7):
     # We need the skip decorators from unittest2 on Python 2.6.
     import unittest2 as unittest
 else:
     import unittest
 
-from prometheus_client import Gauge, Counter, Summary, Histogram, Info, Enum, Metric
-from prometheus_client import CollectorRegistry, generate_latest
-from prometheus_client import push_to_gateway, pushadd_to_gateway, delete_from_gateway
-from prometheus_client import CONTENT_TYPE_LATEST, instance_ip_grouping_key
-from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp
-from prometheus_client.exposition import default_handler, basic_auth_handler, MetricsHandler
 
 try:
     from BaseHTTPServer import BaseHTTPRequestHandler

--- a/tests/test_gc_collector.py
+++ b/tests/test_gc_collector.py
@@ -16,29 +16,29 @@ class TestGCCollector(unittest.TestCase):
         self.gc.stop_gc({'generation': 0, 'collected': 10, 'uncollectable': 2})
 
         self.assertEqual(1,
-            self.registry.get_sample_value(
-                'python_gc_duration_seconds_count',
-                labels={"generation": "0"}))
+                         self.registry.get_sample_value(
+                             'python_gc_duration_seconds_count',
+                             labels={"generation": "0"}))
 
         self.assertEqual(1,
-            self.registry.get_sample_value(
-                'python_gc_collected_objects_count',
-                labels={"generation": "0"}))
+                         self.registry.get_sample_value(
+                             'python_gc_collected_objects_count',
+                             labels={"generation": "0"}))
 
         self.assertEqual(1,
-            self.registry.get_sample_value(
-                'python_gc_uncollectable_objects_count',
-                labels={"generation": "0"}))
+                         self.registry.get_sample_value(
+                             'python_gc_uncollectable_objects_count',
+                             labels={"generation": "0"}))
 
         self.assertEqual(10,
-            self.registry.get_sample_value(
-                'python_gc_collected_objects_sum',
-                labels={"generation": "0"}))
+                         self.registry.get_sample_value(
+                             'python_gc_collected_objects_sum',
+                             labels={"generation": "0"}))
 
         self.assertEqual(2,
-            self.registry.get_sample_value(
-                'python_gc_uncollectable_objects_sum',
-                labels={"generation": "0"}))
+                         self.registry.get_sample_value(
+                             'python_gc_uncollectable_objects_sum',
+                             labels={"generation": "0"}))
 
 
 class _MockGC(object):

--- a/tests/test_graphite_bridge.py
+++ b/tests/test_graphite_bridge.py
@@ -1,12 +1,14 @@
-import unittest
 import threading
+import unittest
+
+from prometheus_client import CollectorRegistry, Gauge
+from prometheus_client.bridge.graphite import GraphiteBridge
+
 try:
     import SocketServer
 except ImportError:
     import socketserver as SocketServer
 
-from prometheus_client import Gauge, CollectorRegistry
-from prometheus_client.bridge.graphite import GraphiteBridge
 
 
 def fake_timer():

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -130,9 +130,9 @@ class TestMultiProcess(unittest.TestCase):
         self.assertEqual(2, self.registry.get_sample_value('g'))
 
     def test_namespace_subsystem(self):
-         c1 = Counter('c', 'help', registry=None, namespace='ns', subsystem='ss')
-         c1.inc(1)
-         self.assertEqual(1, self.registry.get_sample_value('ns_ss_c_total'))
+        c1 = Counter('c', 'help', registry=None, namespace='ns', subsystem='ss')
+        c1.inc(1)
+        self.assertEqual(1, self.registry.get_sample_value('ns_ss_c_total'))
 
     def test_counter_across_forks(self):
         pid = 0

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -6,13 +6,6 @@ import shutil
 import sys
 import tempfile
 
-if sys.version_info < (2, 7):
-    # We need the skip decorators from unittest2 on Python 2.6.
-    import unittest2 as unittest
-else:
-    import unittest
-
-
 from prometheus_client import core
 from prometheus_client.core import (
     CollectorRegistry,
@@ -20,12 +13,20 @@ from prometheus_client.core import (
     Gauge,
     Histogram,
     Sample,
-    Summary,
+    Summary
 )
 from prometheus_client.multiprocess import (
-    mark_process_dead,
     MultiProcessCollector,
+    mark_process_dead
 )
+
+if sys.version_info < (2, 7):
+    # We need the skip decorators from unittest2 on Python 2.6.
+    import unittest2 as unittest
+else:
+    import unittest
+
+
 
 
 class TestMultiProcess(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,12 +3,6 @@ from __future__ import unicode_literals
 import math
 import sys
 
-if sys.version_info < (2, 7):
-    # We need the skip decorators from unittest2 on Python 2.6.
-    import unittest2 as unittest
-else:
-    import unittest
-
 from prometheus_client.core import (
     CollectorRegistry,
     CounterMetricFamily,
@@ -16,14 +10,17 @@ from prometheus_client.core import (
     HistogramMetricFamily,
     Metric,
     Sample,
-    SummaryMetricFamily,
+    SummaryMetricFamily
 )
-from prometheus_client.exposition import (
-    generate_latest,
-)
-from prometheus_client.parser import (
-    text_string_to_metric_families,
-)
+from prometheus_client.exposition import generate_latest
+from prometheus_client.parser import text_string_to_metric_families
+
+if sys.version_info < (2, 7):
+    # We need the skip decorators from unittest2 on Python 2.6.
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 
 class TestParse(unittest.TestCase):

--- a/tests/test_process_collector.py
+++ b/tests/test_process_collector.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 import os
 import unittest
 

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 
+from prometheus_client import CollectorRegistry, Counter, generate_latest
+
 if sys.version_info < (2, 7):
     from unittest2 import skipUnless
 else:
     from unittest import skipUnless
 
-from prometheus_client import Counter
-from prometheus_client import CollectorRegistry, generate_latest
 
 try:
     from prometheus_client.twisted import MetricsResource


### PR DESCRIPTION
This PR fixes some wonky indentation (there were occasions of non-4-divisible indentation 😱 ) both mechanically (`autopep8`) and by hand where manually rewrapping code lead to more readable statements. (That, too, could be automated with something like `black`.)

In addition, there were some duplicate imports, which were cleaned up with `isort`. A `setup.cfg` file was added to configure the multi-line import style to match the one most used in the project.