### PR TITLE
Enable flake8 import lint checking

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from collections import namedtuple
 import copy
 import json
 import math
@@ -10,11 +11,10 @@ import os
 import re
 import struct
 import sys
-import time
-import types
-from collections import namedtuple
 from threading import Lock
+import time
 from timeit import default_timer
+import types
 
 from .decorator import decorate
 

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -3,12 +3,12 @@
 from __future__ import unicode_literals
 
 import base64
+from contextlib import closing
 import os
 import socket
 import sys
 import threading
-from contextlib import closing
-from wsgiref.simple_server import WSGIRequestHandler, make_server
+from wsgiref.simple_server import make_server, WSGIRequestHandler
 
 from prometheus_client import core
 from prometheus_client.openmetrics import exposition as openmetrics

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -2,10 +2,10 @@
 
 from __future__ import unicode_literals
 
+from collections import defaultdict
 import glob
 import json
 import os
-from collections import defaultdict
 
 from . import core
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[isort]
-multi_line_output = 3

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,27 +1,14 @@
 from __future__ import unicode_literals
 
+from concurrent.futures import ThreadPoolExecutor
 import inspect
 import time
-from concurrent.futures import ThreadPoolExecutor
 
 from prometheus_client.core import (
-    CollectorRegistry,
-    Counter,
-    CounterMetricFamily,
-    Enum,
-    Gauge,
-    GaugeHistogramMetricFamily,
-    GaugeMetricFamily,
-    Histogram,
-    HistogramMetricFamily,
-    Info,
-    InfoMetricFamily,
-    Metric,
-    Sample,
-    StateSetMetricFamily,
-    Summary,
-    SummaryMetricFamily,
-    UntypedMetricFamily
+    CollectorRegistry, Counter, CounterMetricFamily, Enum, Gauge,
+    GaugeHistogramMetricFamily, GaugeMetricFamily, Histogram,
+    HistogramMetricFamily, Info, InfoMetricFamily, Metric, Sample,
+    StateSetMetricFamily, Summary, SummaryMetricFamily, UntypedMetricFamily,
 )
 
 try:

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -5,26 +5,13 @@ import threading
 import time
 
 from prometheus_client import (
-    CONTENT_TYPE_LATEST,
-    CollectorRegistry,
-    Counter,
-    Enum,
-    Gauge,
-    Histogram,
-    Info,
-    Metric,
-    Summary,
-    delete_from_gateway,
-    generate_latest,
-    instance_ip_grouping_key,
-    push_to_gateway,
-    pushadd_to_gateway
+    CollectorRegistry, CONTENT_TYPE_LATEST, Counter, delete_from_gateway, Enum,
+    Gauge, generate_latest, Histogram, Info, instance_ip_grouping_key, Metric,
+    push_to_gateway, pushadd_to_gateway, Summary,
 )
 from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp
 from prometheus_client.exposition import (
-    MetricsHandler,
-    basic_auth_handler,
-    default_handler
+    basic_auth_handler, default_handler, MetricsHandler,
 )
 
 if sys.version_info < (2, 7):

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -8,16 +8,10 @@ import tempfile
 
 from prometheus_client import core
 from prometheus_client.core import (
-    CollectorRegistry,
-    Counter,
-    Gauge,
-    Histogram,
-    Sample,
-    Summary
+    CollectorRegistry, Counter, Gauge, Histogram, Sample, Summary,
 )
 from prometheus_client.multiprocess import (
-    MultiProcessCollector,
-    mark_process_dead
+    mark_process_dead, MultiProcessCollector,
 )
 
 if sys.version_info < (2, 7):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,13 +4,8 @@ import math
 import sys
 
 from prometheus_client.core import (
-    CollectorRegistry,
-    CounterMetricFamily,
-    GaugeMetricFamily,
-    HistogramMetricFamily,
-    Metric,
-    Sample,
-    SummaryMetricFamily
+    CollectorRegistry, CounterMetricFamily, GaugeMetricFamily,
+    HistogramMetricFamily, Metric, Sample, SummaryMetricFamily,
 )
 from prometheus_client.exposition import generate_latest
 from prometheus_client.parser import text_string_to_metric_families

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ commands =
 [flake8]
 ignore =
     D,
-    I,
     E303,
     E402,
     E501,
@@ -85,3 +84,10 @@ ignore =
     W503,
 import-order-style = google
 application-import-names = prometheus_client
+
+
+[isort]
+force_alphabetical_sort_within_sections = True
+force_sort_within_sections = True
+include_trailing_comma = True
+multi_line_output = 5

--- a/tox.ini
+++ b/tox.ini
@@ -73,10 +73,15 @@ commands =
 ignore =
     D,
     I,
+    E303,
     E402,
     E501,
     E722,
     E741,
+    F821,
+    F841,
+    W291,
     W293,
+    W503,
 import-order-style = google
 application-import-names = prometheus_client


### PR DESCRIPTION
With #325 by @akx has landed, the flake8 rules on import style lint can be enabled.

Combined the isort `setup.cfg` into `tox.ini` and added a couple of extra config options so it passes the default flake8 rules.

As it wasn't very obvious that there was existing lint tooling #326 updates `CONTRIBUTING.md` to point it out.