### PR TITLE
In multiprocess mode, ensure that metrics initialise to the correct file

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -666,6 +666,7 @@ def _MultiProcessValue(_pidFunc=os.getpid):
         def __init__(self, typ, metric_name, name, labelnames, labelvalues, multiprocess_mode='', **kwargs):
             self._params = typ, metric_name, name, labelnames, labelvalues, multiprocess_mode
             with lock:
+                self.__check_for_pid_change()
                 self.__reset()
                 values.append(self)
 


### PR DESCRIPTION
Without this, when forking, children can initialise metrics to the
cached master pid file. This is racy, and can corrupt the master's
mmaped file, breaking all subsequent collections.