### PR TITLE
Limit memory reads for mmaped files

### DIFF
--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -562,6 +562,7 @@ class _MmapedDict(object):
 
     def __init__(self, filename, read_mode=False):
         self._f = open(filename, 'rb' if read_mode else 'a+b')
+        self._fname = filename
         if os.fstat(self._f.fileno()).st_size == 0:
             self._f.truncate(_INITIAL_MMAP_SIZE)
         self._capacity = os.fstat(self._f.fileno()).st_size

--- a/prometheus_client/core.py
+++ b/prometheus_client/core.py
@@ -607,6 +607,10 @@ class _MmapedDict(object):
 
         while pos < used:
             encoded_len = _unpack_integer(data, pos)[0]
+            # check we are not reading beyond bounds
+            if encoded_len + pos > used:
+                msg = 'Read beyond file size detected, %s is corrupted.'
+                raise RuntimeError(msg % self._fname)
             pos += 4
             encoded = unpack_from(('%ss' % encoded_len).encode(), data, pos)[0]
             padded_len = encoded_len + (8 - (encoded_len + 4) % 8)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -296,6 +296,13 @@ class TestMmapedDict(unittest.TestCase):
             [('abc', 42.0), (key, 123.0), ('def', 17.0)],
             list(self.d.read_all_values()))
 
+    def test_corruption_detected(self):
+        self.d.write_value('abc', 42.0)
+        # corrupt the written data
+        self.d._m[8:16] = b'somejunk'
+        with self.assertRaises(RuntimeError):
+            list(self.d.read_all_values())
+
     def tearDown(self):
         os.unlink(self.tempfile)
 


### PR DESCRIPTION
This is a follow on fix for the initialisation corruption fixed in #328.

When corruption of the master's mmaped file occured, it ended up reading the corrupted data as an large integer. It would then feed this into *struct.unpack_from* as the length to read, which would rightly raise an exception.

However, it also somehow caused a much bigger problem. After this had occurred, Gunicorn would for some unknown reason fail to successfully launch new workers, and thus exit. We saw this pattern of corruption and subsequent gunicorn death happen consistently over multiple machines and services. 
The issue was transient, and we didn't get coredumps, but the suspicion is that trying to read a large chunk of memory somehow broke gunicorn. 

So this change adds a reasonable bounds check on read length, and if corruption occurs in future, then it should blow up earlier, with a better error, and without breaking Gunicorn. 
 