### PR TITLE
Add namespace support to platform

### DIFF
--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -10,14 +10,16 @@ from . import core
 class PlatformCollector(object):
     """Collector for python platform information"""
 
-    def __init__(self, registry=core.REGISTRY, platform=None):
+    def __init__(self, namespace='', registry=core.REGISTRY, platform=None):
+        self._namespace = namespace
+        self._prefix = namespace + '_python_' if namespace else 'python_'
         self._platform = pf if platform is None else platform
         info = self._info()
         system = self._platform.system()
         if system == "Java":
             info.update(self._java())
         self._metrics = [
-            self._add_metric("python_info", "Python platform information", info)
+            self._add_metric(self._prefix + "info", "Python platform information", info)
         ]
         if registry:
             registry.register(self)

--- a/tests/test_platform_collector.py
+++ b/tests/test_platform_collector.py
@@ -20,10 +20,35 @@ class TestPlatformCollector(unittest.TestCase):
             "patchlevel": "pvt_patchlevel"
         })
 
+    def test_python_info_namespace(self):
+        PlatformCollector(registry=self.registry, platform=self.platform, namespace='n')
+        self.assertLabels("n_python_info", {
+            "version": "python_version",
+            "implementation": "python_implementation",
+            "major": "pvt_major",
+            "minor": "pvt_minor",
+            "patchlevel": "pvt_patchlevel"
+        })
+
     def test_system_info_java(self):
         self.platform._system = "Java"
         PlatformCollector(registry=self.registry, platform=self.platform)
         self.assertLabels("python_info", {
+            "version": "python_version",
+            "implementation": "python_implementation",
+            "major": "pvt_major",
+            "minor": "pvt_minor",
+            "patchlevel": "pvt_patchlevel",
+            "jvm_version": "jv_release",
+            "jvm_release": "vm_release",
+            "jvm_vendor": "vm_vendor",
+            "jvm_name": "vm_name"
+        })
+
+    def test_system_info_java_namespace(self):
+        self.platform._system = "Java"
+        PlatformCollector(registry=self.registry, platform=self.platform, namespace='n')
+        self.assertLabels("n_python_info", {
             "version": "python_version",
             "implementation": "python_implementation",
             "major": "pvt_major",
@@ -67,3 +92,7 @@ class _MockPlatform(object):
             ("vm_name", "vm_release", "vm_vendor"),
             ("os_name", "os_version", "os_arch")
         )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There was no namespace support in the platform collector.  That seemed weird, so here it is - complete with extra tests. :)