### PR TITLE
flake8 compliance

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -2,9 +2,9 @@
 
 from . import core
 from . import exposition
-from . import process_collector
-from . import platform_collector
 from . import gc_collector
+from . import platform_collector
+from . import process_collector
 
 __all__ = ['Counter', 'Gauge', 'Summary', 'Histogram', 'Info', 'Enum']
 

--- a/prometheus_client/twisted/_exposition.py
+++ b/prometheus_client/twisted/_exposition.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from twisted.web.resource import Resource
 
-from .. import REGISTRY, exposition
+from .. import exposition, REGISTRY
 
 
 class MetricsResource(Resource):


### PR DESCRIPTION
The contribution guide says that new code should be flake8 compliant, so this fixes ordering in a couple of import statements which were previously causing that test to fail. :)

I didn't add `- env: TOXENV=flake8` to the `travis.yml` file, though maybe that wouldn't be a terrible idea.

@brian-brazil 