### PR TITLE
Permit subclassing of MetricsHandler

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -154,8 +154,8 @@ class MetricsHandler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         """Log nothing."""
 
-    @staticmethod
-    def factory(registry):
+    @classmethod
+    def factory(cls, registry):
         """Returns a dynamic MetricsHandler class tied
            to the passed registry.
         """
@@ -164,8 +164,8 @@ class MetricsHandler(BaseHTTPRequestHandler):
 
         # As we have unicode_literals, we need to create a str()
         #  object for type().
-        cls_name = str('MetricsHandler')
-        MyMetricsHandler = type(cls_name, (MetricsHandler, object),
+        cls_name = str(cls.__name__)
+        MyMetricsHandler = type(cls_name, (cls, object),
                                 {"registry": registry})
         return MyMetricsHandler
 

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -296,6 +296,12 @@ class TestPushGateway(unittest.TestCase):
         handler = MetricsHandler.factory(self.registry)
         self.assertEqual(handler.registry, self.registry)
 
+    def test_metrics_handler_subclassing(self):
+        subclass = type(str('MetricsHandlerSubclass'), (MetricsHandler, object), {})
+        handler = subclass.factory(self.registry)
+
+        self.assertTrue(issubclass(handler, (MetricsHandler, subclass)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
@brian-brazil 

Changes MetricsHandler.factory from a staticmethod to a classmethod to be able to determine the correct subclass to return. This way if a user wants to extend the behavior of their MetricsHandler, they don't have to reimplement the factory() method.