### PR TITLE
Make prometheus_multiproc_dir uppercase to support running under Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ There's several steps to getting this working:
 
 **One**: Gunicorn deployment
 
-The `prometheus_multiproc_dir` environment variable must be set to a directory
+The `PROMETHEUS_MULTIPROC_DIR` environment variable must be set to a directory
 that the client library can use for metrics. This directory must be wiped
 between Gunicorn runs (before startup is recommended).
 

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -17,7 +17,8 @@ class GCCollector(object):
         # To work around the deadlock issue described in
         # https://github.com/prometheus/client_python/issues/322,
         # the GC collector is always disabled in multiprocess mode.
-        if 'prometheus_multiproc_dir' in os.environ:
+        if 'PROMETHEUS_MULTIPROC_DIR' in os.environ \
+                or 'prometheus_multiproc_dir' in os.environ:
             return
 
         if not hasattr(gc, 'callbacks'):

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -18,9 +18,10 @@ class MultiProcessCollector(object):
 
     def __init__(self, registry, path=None):
         if path is None:
-            path = os.environ.get('prometheus_multiproc_dir')
+            path = os.environ.get('PROMETHEUS_MULTIPROC_DIR',
+                                  os.environ.get('prometheus_multiproc_dir'))
         if not path or not os.path.isdir(path):
-            raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
+            raise ValueError('env PROMETHEUS_MULTIPROC_DIR is not set or not a directory')
         self._path = path
         if registry:
             registry.register(self)
@@ -120,7 +121,8 @@ class MultiProcessCollector(object):
 def mark_process_dead(pid, path=None):
     """Do bookkeeping for when one process dies in a multi-process setup."""
     if path is None:
-        path = os.environ.get('prometheus_multiproc_dir')
+        path = os.environ.get('PROMETHEUS_MULTIPROC_DIR',
+                              os.environ.get('prometheus_multiproc_dir'))
     for f in glob.glob(os.path.join(path, 'gauge_livesum_{0}.db'.format(pid))):
         os.remove(f)
     for f in glob.glob(os.path.join(path, 'gauge_liveall_{0}.db'.format(pid))):

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -56,8 +56,10 @@ def MultiProcessValue(_pidFunc=os.getpid):
             else:
                 file_prefix = typ
             if file_prefix not in files:
+                multiproc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR',
+                                               os.environ.get('prometheus_multiproc_dir'))
                 filename = os.path.join(
-                    os.environ['prometheus_multiproc_dir'],
+                    multiproc_dir,
                     '{0}_{1}.db'.format(file_prefix, pid['value']))
 
                 files[file_prefix] = MmapedDict(filename)
@@ -101,7 +103,8 @@ def get_value_class():
     # This needs to be chosen before the first metric is constructed,
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
-    if 'prometheus_multiproc_dir' in os.environ:
+    if 'PROMETHEUS_MULTIPROC_DIR' in os.environ \
+            or 'prometheus_multiproc_dir' in os.environ:
         return MultiProcessValue()
     else:
         return MutexValue

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -27,7 +27,7 @@ else:
 class TestMultiProcess(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
-        os.environ['prometheus_multiproc_dir'] = self.tempdir
+        os.environ['PROMETHEUS_MULTIPROC_DIR'] = self.tempdir
         values.ValueClass = MultiProcessValue(lambda: 123)
         self.registry = CollectorRegistry()
         self.collector = MultiProcessCollector(self.registry, self.tempdir)
@@ -37,7 +37,7 @@ class TestMultiProcess(unittest.TestCase):
         return
 
     def tearDown(self):
-        del os.environ['prometheus_multiproc_dir']
+        del os.environ['PROMETHEUS_MULTIPROC_DIR']
         shutil.rmtree(self.tempdir)
         values.ValueClass = MutexValue
 
@@ -82,7 +82,7 @@ class TestMultiProcess(unittest.TestCase):
         self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
         g1.set(1)
         g2.set(2)
-        mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
+        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
         self.assertEqual(1, self.registry.get_sample_value('g', {'pid': '123'}))
         self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
 
@@ -96,7 +96,7 @@ class TestMultiProcess(unittest.TestCase):
         g2.set(2)
         self.assertEqual(1, self.registry.get_sample_value('g', {'pid': '123'}))
         self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
-        mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
+        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
         self.assertEqual(None, self.registry.get_sample_value('g', {'pid': '123'}))
         self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
 
@@ -126,7 +126,7 @@ class TestMultiProcess(unittest.TestCase):
         g1.set(1)
         g2.set(2)
         self.assertEqual(3, self.registry.get_sample_value('g'))
-        mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
+        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
         self.assertEqual(2, self.registry.get_sample_value('g'))
 
     def test_namespace_subsystem(self):
@@ -153,7 +153,7 @@ class TestMultiProcess(unittest.TestCase):
         # can not inspect the files cache directly, as it's a closure, so we
         # check for the actual files themselves
         def files():
-            fs = os.listdir(os.environ['prometheus_multiproc_dir'])
+            fs = os.listdir(os.environ['PROMETHEUS_MULTIPROC_DIR'])
             fs.sort()
             return fs
 
@@ -243,7 +243,7 @@ class TestMultiProcess(unittest.TestCase):
         pid = 1
         h.labels(**labels).observe(5)
 
-        path = os.path.join(os.environ['prometheus_multiproc_dir'], '*.db')
+        path = os.path.join(os.environ['PROMETHEUS_MULTIPROC_DIR'], '*.db')
         files = glob.glob(path)
         metrics = dict(
             (m.name, m) for m in self.collector.merge(files, accumulate=False)


### PR DESCRIPTION
Currently it's not possible to define the `prometheus_multiproc_dir` when the application is running inside a Docker container because you can't define lowercase environment variables for a container.

This fix makes the environment variable uppercase while still supporting the old lowercase `prometheus_multiproc_dir` environment variable.