### PR TITLE
add: default arg to write_to_textfile

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -184,7 +184,7 @@ def start_http_server(port, addr='', registry=REGISTRY):
     t.start()
 
 
-def write_to_textfile(path, registry):
+def write_to_textfile(path, registry=REGISTRY):
     '''Write metrics to the given path.
 
     This is intended for use with the Node exporter textfile collector.


### PR DESCRIPTION
### What

Add `REGISTRY` as the default arg of `write_to_textfile`

### Why

`write_to_textfile` is one of the easiest way to bring the power of custom metrics to the users' Prometheus, so it should be very nice to have its interface simple.
Other functions like `make_wsgi_app`, `start_http_server` already have it as default value, so it seems fair to add `REGISTRY` here as default.

#### before

```
from prometheus_client import write_to_textfile, REGISTRY

while True:
    do_whatever()
    write_to_textfile(TMP_PATH, REGISTRY)
```

#### after

```
from prometheus_client import write_to_textfile

while True:
    do_whatever()
    write_to_textfile(TMP_PATH)
```