### PR TITLE
Make the format strings compatible with Python 2.6

### DIFF
--- a/prometheus_client/samples.py
+++ b/prometheus_client/samples.py
@@ -6,7 +6,7 @@ class Timestamp(object):
 
     def __init__(self, sec, nsec):
         if nsec < 0 or nsec >= 1e9:
-            raise ValueError("Invalid value for nanoseconds in Timestamp: {}".format(nsec))
+            raise ValueError("Invalid value for nanoseconds in Timestamp: {0}".format(nsec))
         if sec < 0:
             nsec = -nsec
         self.sec = int(sec)

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -18,6 +18,6 @@ def floatToGoString(d):
         # Go switches to exponents sooner than Python.
         # We only need to care about positive values for le/quantile.
         if d > 0 and dot > 6:
-            mantissa = '{0}.{1}{2}'.format(s[0], s[1:dot], s[dot+1:16]).rstrip('0.')
+            mantissa = '{0}.{1}{2}'.format(s[0], s[1:dot], s[dot+1:]).rstrip('0.')
             return '{0}e+0{1}'.format(mantissa, dot-1)
         return s

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -18,6 +18,6 @@ def floatToGoString(d):
         # Go switches to exponents sooner than Python.
         # We only need to care about positive values for le/quantile.
         if d > 0 and dot > 6:
-            mantissa = '{}.{}{}'.format(s[0], s[1:dot], s[dot+1:]).rstrip('0.')
-            return '{}e+0{}'.format(mantissa, dot-1)
+            mantissa = '{0}.{1}{2}'.format(s[0], s[1:dot], s[dot+1:]).rstrip('0.')
+            return '{0}e+0{1}'.format(mantissa, dot-1)
         return s

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -18,6 +18,6 @@ def floatToGoString(d):
         # Go switches to exponents sooner than Python.
         # We only need to care about positive values for le/quantile.
         if d > 0 and dot > 6:
-            mantissa = '{0}.{1}{2}'.format(s[0], s[1:dot], s[dot+1:]).rstrip('0.')
+            mantissa = '{0}.{1}{2}'.format(s[0], s[1:dot], s[dot+1:16]).rstrip('0.')
             return '{0}e+0{1}'.format(mantissa, dot-1)
         return s

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -568,6 +568,7 @@ foo_created 1.520430000123e+09
                 ('# TYPE a histogram\na_bucket{le="+Inf"} 0\na_count 1\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="9.999999999999999e+22"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
+                ('# TYPE a histogram\na_bucket{le="1.5555555555555201e+06"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1e-04"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1e+05"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="+INF"} 0\n# EOF\n'),

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -567,8 +567,6 @@ foo_created 1.520430000123e+09
                 ('# TYPE a histogram\na_count 1\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="+Inf"} 0\na_count 1\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
-                ('# TYPE a histogram\na_bucket{le="9.999999999999999e+22"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
-                ('# TYPE a histogram\na_bucket{le="1.5555555555555201e+06"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1e-04"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1e+05"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="+INF"} 0\n# EOF\n'),
@@ -586,6 +584,16 @@ foo_created 1.520430000123e+09
                 ('# TYPE a gauge\na 0 1\na 0 0\n# EOF\n'),
                 ('# TYPE a gauge\na 0\na 0 0\n# EOF\n'),
                 ('# TYPE a gauge\na 0 0\na 0\n# EOF\n'),
+        ]:
+            with self.assertRaises(ValueError):
+                list(text_string_to_metric_families(case))
+
+    @unittest.skipIf(sys.version_info < (2, 7), "float repr changed from 2.6 to 2.7")
+    def test_invalid_float_input(self):
+        for case in [
+                # Bad histograms.
+                ('# TYPE a histogram\na_bucket{le="9.999999999999999e+22"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
+                ('# TYPE a histogram\na_bucket{le="1.5555555555555201e+06"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
         ]:
             with self.assertRaises(ValueError):
                 list(text_string_to_metric_families(case))

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -568,7 +568,6 @@ foo_created 1.520430000123e+09
                 ('# TYPE a histogram\na_bucket{le="+Inf"} 0\na_count 1\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="9.999999999999999e+22"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
-                ('# TYPE a histogram\na_bucket{le="1.5555555555555201e+06"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1e-04"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="1e+05"} 0\na_bucket{le="+Inf"} 0\n# EOF\n'),
                 ('# TYPE a histogram\na_bucket{le="+INF"} 0\n# EOF\n'),


### PR DESCRIPTION
This should restore compatibility with Python 2.6, current version fails with:
```
Traceback (most recent call last):
...
  File "/usr/lib/python2.6/site-packages/prometheus_client-0.5.0-py2.6.egg/prometheus_client/exposition.py", line 194, in write_to_textfile
    f.write(generate_latest(registry))
  File "/usr/lib/python2.6/site-packages/prometheus_client-0.5.0-py2.6.egg/prometheus_client/exposition.py", line 119, in generate_latest
    output.append(sample_line(s))
  File "/usr/lib/python2.6/site-packages/prometheus_client-0.5.0-py2.6.egg/prometheus_client/exposition.py", line 86, in sample_line
    s.name, labelstr, floatToGoString(s.value), timestamp)
  File "/usr/lib/python2.6/site-packages/prometheus_client-0.5.0-py2.6.egg/prometheus_client/utils.py", line 21, in floatToGoString
    mantissa = '{}.{}{}'.format(s[0], s[1:dot], s[dot+1:]).rstrip('0.')
ValueError: zero length field name in format
```