### PR TITLE
Fix SyntaxWarning due to unescaped sequence

### DIFF
--- a/prometheus_client/decorator.py
+++ b/prometheus_client/decorator.py
@@ -79,7 +79,7 @@ def getargspec(f):
     return ArgSpec(spec.args, spec.varargs, spec.varkw, spec.defaults)
 
 
-DEF = re.compile('\s*def\s*([_\w][_\w\d]*)\s*\(')
+DEF = re.compile(r'\s*def\s*([_\w][_\w\d]*)\s*\(')
 
 
 # basic functionality


### PR DESCRIPTION
This seemed to be trivial one so I didn't open an issue. This fixes a `SyntaxWarning` introduced on CPython master that will be released as 3.8. It's already a `DeprecationWarning` on Python 3.6. The escape sequence needs to be present inside a raw string to fix the warning.

```
prometheus_client/decorator.py:82
  /home/karthi/client_python/prometheus_client/decorator.py:82: SyntaxWarning: invalid escape sequence \s
    DEF = re.compile('\s*def\s*([_\w][_\w\d]*)\s*\(')
```

Thanks for the library :)