### PR TITLE
Deadlock on gcCollector

### DIFF
--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -13,10 +13,6 @@ class GCCollector(object):
     """Collector for Garbage collection statistics."""
 
     def __init__(self, registry=REGISTRY):
-        # the GC collector is always disabled in multiprocess mode.
-        if 'prometheus_multiproc_dir' in os.environ:
-            return
-
         if not hasattr(gc, 'get_stats'):
             return
         registry.register(self)

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -4,124 +4,48 @@ from __future__ import unicode_literals
 
 import gc
 import os
-import time
-from collections import defaultdict
 
-from .metrics_core import HistogramMetricFamily
+from .metrics_core import GaugeMetricFamily
 from .registry import REGISTRY
-from .utils import INF
 
 
 class GCCollector(object):
     """Collector for Garbage collection statistics."""
 
-    _LATENCY = 'latency'
-    _COLLECTED = 'collected'
-    _UNCOLLECTABLE = 'uncollectable'
-
     def __init__(self, registry=REGISTRY):
-        # To work around the deadlock issue described in
-        # https://github.com/prometheus/client_python/issues/322,
         # the GC collector is always disabled in multiprocess mode.
         if 'prometheus_multiproc_dir' in os.environ:
             return
 
-        if not hasattr(gc, 'callbacks'):
+        if not hasattr(gc, 'get_stats'):
             return
-
-        self._buckets = [{
-            self._LATENCY: defaultdict(lambda: 0.0),
-            self._COLLECTED: defaultdict(lambda: 0),
-            self._UNCOLLECTABLE: defaultdict(lambda: 0),
-        } for _ in [0, 1, 2]]
-
-        self._sums = [{
-            self._LATENCY: 0.0,
-            self._COLLECTED: 0,
-            self._UNCOLLECTABLE: 0,
-        } for _ in [0, 1, 2]]
-
-        times = {}
-
-        # Avoid _cb() being called re-entrantly
-        # by setting this flag and clearing it once
-        # the callback operation is complete.
-        # See https://github.com/prometheus/client_python/issues/322#issuecomment-438021132
-        self.gc_cb_active = False
-
-        def _cb(phase, info):
-            try:
-                if self.gc_cb_active:
-                    return
-                self.gc_cb_active = True
-
-                gen = info['generation']
-
-                if phase == 'start':
-                    times[gen] = time.time()
-
-                if phase == 'stop':
-                    delta = time.time() - times[gen]
-                    self._add_to_bucket(self._LATENCY, gen, delta)
-                    if 'collected' in info and info['collected'] != 0:
-                        self._add_to_bucket(self._COLLECTED, gen, info['collected'])
-                    if 'uncollectable' in info and info['uncollectable'] != 0:
-                        self._add_to_bucket(self._UNCOLLECTABLE, gen, info['uncollectable'])
-            finally:
-                self.gc_cb_active = False
-
-        gc.callbacks.append(_cb)
         registry.register(self)
 
-    def _add_to_bucket(self, bucket_name, gen, value):
-        bucket = self._buckets[gen][bucket_name]
-        self._sums[gen][bucket_name] += value
-
-        for bound in self._get_bounds(gen, bucket_name):
-            if value <= bound:
-                bucket[INF] += 1
-                bucket[bound] += 1
-                break
-
-    @staticmethod
-    def _get_bounds(gen, bucket_name):
-        if bucket_name == GC_COLLECTOR._LATENCY:
-            return .005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0
-        _max = gc.get_threshold()[gen] * 2
-        return int(_max / 100), int(_max / 50), int(_max / 10), int(_max / 5), int(_max / 2), _max
-
     def collect(self):
-        collected = HistogramMetricFamily(
+        collected = GaugeMetricFamily(
             'python_gc_collected_objects',
             'Objects collected during gc',
             labels=['generation'],
         )
-        uncollectable = HistogramMetricFamily(
+        uncollectable = GaugeMetricFamily(
             'python_gc_uncollectable_objects',
             'Uncollectable object found during GC',
             labels=['generation'],
         )
 
-        latency = HistogramMetricFamily(
-            'python_gc_duration_seconds',
-            'Time spent in garbage collection',
+        collections = GaugeMetricFamily(
+            'python_gc_collections',
+            'Number of times this generation was collected',
             labels=['generation'],
         )
 
-        for generation, buckets in enumerate(self._buckets):
-            _sums = self._sums[generation]
+        for generation, stat in enumerate(gc.get_stats()):
             generation = str(generation)
+            collected.add_metric([generation], value=stat['collected'])
+            uncollectable.add_metric([generation], value=stat['uncollectable'])
+            collections.add_metric([generation], value=stat['collections'])
 
-            if _sums[self._LATENCY] != 0:
-                latency.add_metric([generation], buckets=list(buckets[self._LATENCY].items()),
-                                   sum_value=_sums[self._LATENCY])
-            if _sums[self._COLLECTED] != 0:
-                collected.add_metric([generation], buckets=list(buckets[self._COLLECTED].items()),
-                                     sum_value=_sums[self._COLLECTED])
-            if _sums[self._UNCOLLECTABLE] != 0:
-                uncollectable.add_metric([generation], buckets=list(buckets[self._UNCOLLECTABLE].items()),
-                                         sum_value=_sums[self._UNCOLLECTABLE])
-        return [collected, uncollectable, latency]
+        return [collected, uncollectable, collections]
 
 
 GC_COLLECTOR = GCCollector()

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -7,7 +7,6 @@ import os
 import time
 from collections import defaultdict
 
-from .metrics import Histogram
 from .metrics_core import HistogramMetricFamily
 from .registry import REGISTRY
 from .utils import INF
@@ -87,9 +86,9 @@ class GCCollector(object):
     @staticmethod
     def _get_bounds(gen, bucket_name):
         if bucket_name == GC_COLLECTOR._LATENCY:
-            return Histogram.DEFAULT_BUCKETS
-        _max = gc.get_threshold()[gen]
-        return [int(_max / 100), int(_max / 50), int(_max / 10), int(_max / 5), int(_max / 2), _max]
+            return .005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0
+        _max = gc.get_threshold()[gen] * 2
+        return int(_max / 100), int(_max / 50), int(_max / 10), int(_max / 5), int(_max / 2), _max
 
     def collect(self):
         collected = HistogramMetricFamily(

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -5,15 +5,22 @@ from __future__ import unicode_literals
 import gc
 import os
 import time
+from collections import defaultdict
 
-from .metrics import Histogram
+from .metrics_core import HistogramMetricFamily
 from .registry import REGISTRY
+from .metrics import Histogram
+from .utils import INF
 
 
 class GCCollector(object):
     """Collector for Garbage collection statistics."""
 
-    def __init__(self, registry=REGISTRY, gc=gc):
+    _LATENCY = 'latency'
+    _COLLECTED = 'collected'
+    _UNCOLLECTABLE = 'uncollectable'
+
+    def __init__(self, registry=REGISTRY):
         # To work around the deadlock issue described in
         # https://github.com/prometheus/client_python/issues/322,
         # the GC collector is always disabled in multiprocess mode.
@@ -23,28 +30,17 @@ class GCCollector(object):
         if not hasattr(gc, 'callbacks'):
             return
 
-        collected = Histogram(
-            'python_gc_collected_objects',
-            'Objects collected during gc',
-            ['generation'],
-            buckets=[500, 1000, 5000, 10000, 50000],
-            registry=registry
-        )
+        self._buckets = [{
+            self._LATENCY: defaultdict(lambda: 0.0),
+            self._COLLECTED: defaultdict(lambda: 0),
+            self._UNCOLLECTABLE: defaultdict(lambda: 0),
+        } for _ in [0, 1, 2]]
 
-        uncollectable = Histogram(
-            'python_gc_uncollectable_objects',
-            'Uncollectable object found during GC',
-            ['generation'],
-            buckets=[500, 1000, 5000, 10000, 50000],
-            registry=registry
-        )
-
-        latency = Histogram(
-            'python_gc_duration_seconds',
-            'Time spent in garbage collection',
-            ['generation'],
-            registry=registry
-        )
+        self._sums = [{
+            self._LATENCY: 0.0,
+            self._COLLECTED: 0,
+            self._UNCOLLECTABLE: 0,
+        } for _ in [0, 1, 2]]
 
         times = {}
 
@@ -67,15 +63,66 @@ class GCCollector(object):
 
                 if phase == 'stop':
                     delta = time.time() - times[gen]
-                    latency.labels(gen).observe(delta)
-                    if 'collected' in info:
-                        collected.labels(gen).observe(info['collected'])
-                    if 'uncollectable' in info:
-                        uncollectable.labels(gen).observe(info['uncollectable'])
+                    self._add_to_bucket(self._LATENCY, gen, delta)
+                    if 'collected' in info and info['collected'] != 0:
+                        self._add_to_bucket(self._COLLECTED, gen, info['collected'])
+                    if 'uncollectable' in info and info['uncollectable'] != 0:
+                        self._add_to_bucket(self._UNCOLLECTABLE, gen, info['uncollectable'])
             finally:
                 self.gc_cb_active = False
 
         gc.callbacks.append(_cb)
+        registry.register(self)
+
+    def _add_to_bucket(self, bucket_name, gen, value):
+        bucket = self._buckets[gen][bucket_name]
+        self._sums[gen][bucket_name] += value
+
+        for bound in self._get_bounds(gen, bucket_name):
+            if value <= bound:
+                bucket[INF] += 1
+                bucket[bound] += 1
+                break
+
+    @staticmethod
+    def _get_bounds(gen, bucket_name):
+        if bucket_name == GC_COLLECTOR._LATENCY:
+            return Histogram.DEFAULT_BUCKETS
+        _max = gc.get_threshold()[gen]
+        return [int(_max/100), int(_max/50), int(_max/10), int(_max/5), int(_max/2), _max]
+
+    def collect(self):
+        collected = HistogramMetricFamily(
+            'python_gc_collected_objects',
+            'Objects collected during gc',
+            labels=['generation'],
+        )
+        uncollectable = HistogramMetricFamily(
+            'python_gc_uncollectable_objects',
+            'Uncollectable object found during GC',
+            labels=['generation'],
+        )
+
+        latency = HistogramMetricFamily(
+            'python_gc_duration_seconds',
+            'Time spent in garbage collection',
+            labels=['generation'],
+        )
+
+        for generation, buckets in enumerate(self._buckets):
+            _sums = self._sums[generation]
+            generation = str(generation)
+
+            if _sums[self._LATENCY] != 0:
+                latency.add_metric([generation], buckets=list(buckets[self._LATENCY].items()),
+                                   sum_value=_sums[self._LATENCY])
+            if _sums[self._COLLECTED] != 0:
+                collected.add_metric([generation], buckets=list(buckets[self._COLLECTED].items()),
+                                     sum_value=_sums[self._COLLECTED])
+            if _sums[self._UNCOLLECTABLE] != 0:
+                uncollectable.add_metric([generation], buckets=list(buckets[self._UNCOLLECTABLE].items()),
+                                         sum_value=_sums[self._UNCOLLECTABLE])
+        return [collected, uncollectable, latency]
 
 
 GC_COLLECTOR = GCCollector()

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -3,9 +3,8 @@
 from __future__ import unicode_literals
 
 import gc
-import os
 
-from .metrics_core import GaugeMetricFamily
+from .metrics_core import CounterMetricFamily
 from .registry import REGISTRY
 
 
@@ -18,18 +17,18 @@ class GCCollector(object):
         registry.register(self)
 
     def collect(self):
-        collected = GaugeMetricFamily(
-            'python_gc_collected_objects',
+        collected = CounterMetricFamily(
+            'python_gc_objects_collected',
             'Objects collected during gc',
             labels=['generation'],
         )
-        uncollectable = GaugeMetricFamily(
-            'python_gc_uncollectable_objects',
+        uncollectable = CounterMetricFamily(
+            'python_gc_objects_uncollectable',
             'Uncollectable object found during GC',
             labels=['generation'],
         )
 
-        collections = GaugeMetricFamily(
+        collections = CounterMetricFamily(
             'python_gc_collections',
             'Number of times this generation was collected',
             labels=['generation'],

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -7,9 +7,9 @@ import os
 import time
 from collections import defaultdict
 
+from .metrics import Histogram
 from .metrics_core import HistogramMetricFamily
 from .registry import REGISTRY
-from .metrics import Histogram
 from .utils import INF
 
 

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -89,7 +89,7 @@ class GCCollector(object):
         if bucket_name == GC_COLLECTOR._LATENCY:
             return Histogram.DEFAULT_BUCKETS
         _max = gc.get_threshold()[gen]
-        return [int(_max/100), int(_max/50), int(_max/10), int(_max/5), int(_max/2), _max]
+        return [int(_max / 100), int(_max / 50), int(_max / 10), int(_max / 5), int(_max / 2), _max]
 
     def collect(self):
         collected = HistogramMetricFamily(

--- a/tests/test_gc_collector.py
+++ b/tests/test_gc_collector.py
@@ -23,7 +23,8 @@ class TestGCCollector(unittest.TestCase):
 
         GCCollector(registry=self.registry)
         self.registry.collect()
-        before = self.registry.get_sample_value('python_gc_collected_objects', labels={"generation": "0"})
+        before = self.registry.get_sample_value('python_gc_objects_collected_total',
+                                                labels={"generation": "0"})
 
         #  add targets for gc
         a = []
@@ -36,22 +37,25 @@ class TestGCCollector(unittest.TestCase):
         gc.collect(0)
         self.registry.collect()
 
-        after = self.registry.get_sample_value('python_gc_collected_objects', labels={"generation": "0"})
+        after = self.registry.get_sample_value('python_gc_objects_collected_total',
+                                               labels={"generation": "0"})
         self.assertEqual(2, after - before)
         self.assertEqual(0,
                          self.registry.get_sample_value(
-                             'python_gc_uncollectable_objects',
+                             'python_gc_objects_uncollectable_total',
                              labels={"generation": "0"}))
 
     def test_empty(self):
 
         GCCollector(registry=self.registry)
         self.registry.collect()
-        before = self.registry.get_sample_value('python_gc_collected_objects', labels={"generation": "0"})
+        before = self.registry.get_sample_value('python_gc_objects_collected_total',
+                                                labels={"generation": "0"})
         gc.collect(0)
         self.registry.collect()
 
-        after = self.registry.get_sample_value('python_gc_collected_objects', labels={"generation": "0"})
+        after = self.registry.get_sample_value('python_gc_objects_collected_total',
+                                               labels={"generation": "0"})
         self.assertEqual(0, after - before)
 
     def tearDown(self):

--- a/tests/test_gc_collector.py
+++ b/tests/test_gc_collector.py
@@ -55,7 +55,10 @@ class TestGCCollector(unittest.TestCase):
         self.assertEqual(1,
                          self.registry.get_sample_value(
                              'python_gc_collected_objects_bucket',
-                             labels={"generation": "0", "le": 7}))
+                             labels={
+                                 "generation": "0",
+                                 "le": gc.get_threshold()[0] * 2 / 100
+                             }))
 
     def test_empty(self):
 

--- a/tests/test_gc_collector.py
+++ b/tests/test_gc_collector.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 
 import gc
+import sys
 import unittest
 
 from prometheus_client import CollectorRegistry, GCCollector
 
 
+@unittest.skipIf(sys.version_info < (3, ), "Test requires Python 3.+")
 class TestGCCollector(unittest.TestCase):
     def setUp(self):
         gc.disable()

--- a/tests/test_gc_collector.py
+++ b/tests/test_gc_collector.py
@@ -2,7 +2,12 @@ from __future__ import unicode_literals
 
 import gc
 import sys
-import unittest
+
+if sys.version_info < (2, 7):
+    # We need the skip decorators from unittest2 on Python 2.6.
+    import unittest2 as unittest
+else:
+    import unittest
 
 from prometheus_client import CollectorRegistry, GCCollector
 


### PR DESCRIPTION
Hello!
Regading https://github.com/prometheus/client_python/issues/363

We have the same problem with asyncio using (aiohttp, single process, single thread)

As we cannot predict when `gc.collect()` will be executed (with `gc.enable`), it is not possible to use something that has locks inside the `gc.collect` callbacks. So, YES, we neet to reconsidered how the GC collector works.
 
One way it is remove GC Collector  :sunglasses:  . 
Another way in this PR - Collect metrics in simle structures witout locks and represent it in 'collect' method.
Therd way is to use `gc.stats` (since python 3.4) with Gauge (`GaugeMetricFamily`) metrics at `collect`.
Or as @megabotan said, just remove lock in `get` methof of `MutexValue`