### PR TITLE
Disable gcCollector for pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: TOXENV=py36-nooptionals
     - python: "pypy"
       env: TOXENV=pypy
+    - python: "pypy3"
+      env: TOXENV=pypy3
 
 install:
   - pip install tox

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -13,7 +13,7 @@ class GCCollector(object):
     """Collector for Garbage collection statistics."""
 
     def __init__(self, registry=REGISTRY):
-        if not hasattr(gc, 'get_stats') or platform.python_implementation() == 'PyPy':
+        if not hasattr(gc, 'get_stats') or platform.python_implementation() != 'CPython':
             return
         registry.register(self)
 

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import gc
+import platform
 
 from .metrics_core import CounterMetricFamily
 from .registry import REGISTRY
@@ -12,7 +13,7 @@ class GCCollector(object):
     """Collector for Garbage collection statistics."""
 
     def __init__(self, registry=REGISTRY):
-        if not hasattr(gc, 'get_stats'):
+        if not hasattr(gc, 'get_stats') or platform.python_implementation() == 'PyPy':
             return
         registry.register(self)
 

--- a/tests/test_gc_collector.py
+++ b/tests/test_gc_collector.py
@@ -12,7 +12,7 @@ else:
 
 from prometheus_client import CollectorRegistry, GCCollector
 
-SKIP = sys.version_info < (3, 4) or platform.python_implementation() == "PyPy"
+SKIP = sys.version_info < (3, 4) or platform.python_implementation() != "CPython"
 
 
 @unittest.skipIf(SKIP, "Test requires CPython 3.4 +")

--- a/tests/test_gc_collector.py
+++ b/tests/test_gc_collector.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import gc
 import sys
+import platform
 
 if sys.version_info < (2, 7):
     # We need the skip decorators from unittest2 on Python 2.6.
@@ -11,8 +12,10 @@ else:
 
 from prometheus_client import CollectorRegistry, GCCollector
 
+SKIP = sys.version_info < (3, 4) or platform.python_implementation() == "PyPy"
 
-@unittest.skipIf(sys.version_info < (3, 4), "Test requires Python 3.4 +")
+
+@unittest.skipIf(SKIP, "Test requires CPython 3.4 +")
 class TestGCCollector(unittest.TestCase):
     def setUp(self):
         gc.disable()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py26,py27,py34,py35,py36,pypy,{py27,py36}-nooptionals,coverage-report,flake8
+envlist = coverage-clean,py26,py27,py34,py35,py36,pypy,pypy3,{py27,py36}-nooptionals,coverage-report,flake8
 
 
 [base]
@@ -29,7 +29,7 @@ deps =
 [testenv]
 deps =
     {[base]deps}
-    {py27,py34,py35,py36,pypy}: twisted
+    {py27,py34,py35,py36,pypy,pypy3}: twisted
 commands = coverage run --parallel -m pytest {posargs}
 
 


### PR DESCRIPTION
We use `gc.get_stats` to provide metrics at `gcColector` . Pypy gc have the same method but they are very different. (https://github.com/prometheus/client_python/issues/378 http://doc.pypy.org/en/latest/gc_info.html#gc-get-stats)
I think it is better just to not provide gc metrics with pypy.
