### PR TITLE
Fix instrumentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This package can be found on
 
 Four types of metric are offered: Counter, Gauge, Summary and Histogram.
 See the documentation on [metric types](http://prometheus.io/docs/concepts/metric_types/)
-and [instrumentation best practices](http://prometheus.io/docs/practices/instrumentation/#counter-vs.-gauge,-summary-vs.-histogram)
+and [instrumentation best practices](https://prometheus.io/docs/practices/instrumentation/#counter-vs-gauge-summary-vs-histogram)
 on how to use them.
 
 ### Counter


### PR DESCRIPTION
Maybe the link to `instrumentation best practices` should be

https://prometheus.io/docs/practices/instrumentation/#counter-vs-gauge-summary-vs-histogram

