### PR TITLE
Histogram samples should not accumulate buckets

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -541,8 +541,9 @@ class Histogram(MetricWrapperBase):
         samples = []
         acc = 0
         for i, bound in enumerate(self._upper_bounds):
-            acc += self._buckets[i].get()
-            samples.append(('_bucket', {'le': floatToGoString(bound)}, acc))
+            bucket = self._buckets[i].get()
+            acc += bucket
+            samples.append(('_bucket', {'le': floatToGoString(bound)}, bucket))
         samples.append(('_count', {}, acc))
         samples.append(('_sum', {}, self._sum.get()))
         samples.append(('_created', {}, self._created))


### PR DESCRIPTION
@brian-brazil it appears that the histogram is accumulating values across all buckets instead of reporting the sampled value for each bucket.