### PR TITLE
Fix bug of multiprocess mode by `path` argument

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -13,7 +13,7 @@ from .samples import Sample
 from .utils import floatToGoString
 
 
-PATH = None
+PATH = os.environ.get('prometheus_multiproc_dir')
 
 
 class MultiProcessCollector(object):
@@ -24,8 +24,6 @@ class MultiProcessCollector(object):
 
         if path is not None:
             PATH = path
-        elif 'prometheus_multiproc_dir' in os.environ:
-            PATH = os.environ['prometheus_multiproc_dir']
 
         if not PATH or not os.path.isdir(PATH):
             raise ValueError('Any prometheus multiprocess dictionary is not set or not a directory.')

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -13,15 +13,23 @@ from .samples import Sample
 from .utils import floatToGoString
 
 
+PATH = None
+
+
 class MultiProcessCollector(object):
     """Collector for files for multi-process mode."""
 
     def __init__(self, registry, path=None):
-        if path is None:
-            path = os.environ.get('prometheus_multiproc_dir')
-        if not path or not os.path.isdir(path):
-            raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
-        self._path = path
+        global PATH
+
+        if path is not None:
+            PATH = path
+        elif 'prometheus_multiproc_dir' in os.environ:
+            PATH = os.environ['prometheus_multiproc_dir']
+
+        if not PATH or not os.path.isdir(PATH):
+            raise ValueError('Any prometheus multiprocess dictionary is not set or not a directory.')
+
         if registry:
             registry.register(self)
 
@@ -114,7 +122,7 @@ class MultiProcessCollector(object):
         return metrics.values()
 
     def collect(self):
-        files = glob.glob(os.path.join(self._path, '*.db'))
+        files = glob.glob(os.path.join(PATH, '*.db'))
         return self.merge(files, accumulate=True)
 
 

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -4,6 +4,7 @@ import os
 from threading import Lock
 
 from .mmap_dict import mmap_key, MmapedDict
+from . import multiprocess
 
 
 class MutexValue(object):
@@ -57,7 +58,7 @@ def MultiProcessValue(_pidFunc=os.getpid):
                 file_prefix = typ
             if file_prefix not in files:
                 filename = os.path.join(
-                    os.environ['prometheus_multiproc_dir'],
+                    multiprocess.PATH,
                     '{0}_{1}.db'.format(file_prefix, pid['value']))
 
                 files[file_prefix] = MmapedDict(filename)
@@ -101,7 +102,7 @@ def get_value_class():
     # This needs to be chosen before the first metric is constructed,
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
-    if 'prometheus_multiproc_dir' in os.environ:
+    if multiprocess.PATH:
         return MultiProcessValue()
     else:
         return MutexValue


### PR DESCRIPTION
`path` argument at `multiprocess.MultiProcessCollector.__init__()` is only for merging multiprocess files but it doesn't work for processing metrics and creating that files (without set `os.environ.['prometheus_multiproc_dir']`). Everybody has to activate the mode by the environment variable `prometheus_multiproc_dir`.


works: 
```
import os
from prometheus_client import REGISTRY

os.environ.['prometheus_multiproc_dir'] = '/tmp'

MultiProcessCollector(REGISTRY)
```

doesn't work:
```
from prometheus_client import REGISTRY

MultiProcessCollector(REGISTRY, path='/tmp')
```