### PR TITLE
Change exemplar length limit to be only for label names+values

### DIFF
--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -222,7 +222,7 @@ def _parse_sample(text):
     ts = _parse_timestamp(timestamp)
     exemplar = None
     if exemplar_labels is not None:
-        exemplar_length = sum([len(k) + len(v) + 3 for k, v in exemplar_labels.items()]) + 2
+        exemplar_length = sum([len(k) + len(v) for k, v in exemplar_labels.items()])
         if exemplar_length > 64:
             raise ValueError("Exmplar labels are too long: " + text)
         exemplar = Exemplar(

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -518,7 +518,7 @@ foo_created 1.520430000123e+09
             ('# TYPE a histogram\na_bucket{le="+Inf"} 1 # {} 1 \n# EOF\n'),
             ('# TYPE a histogram\na_bucket{le="+Inf"} 1 # {} 1 1 \n# EOF\n'),
             ('# TYPE a histogram\na_bucket{le="+Inf"} 1 # '
-             '{a="12345678901234567890123456789012345678901234567890123456789"} 1 1\n# EOF\n'),
+             '{a="2345678901234567890123456789012345678901234567890123456789012345"} 1 1\n# EOF\n'),
             # Exemplars on unallowed samples.
             ('# TYPE a histogram\na_sum 1 # {a="b"} 0.5\n# EOF\n'),
             ('# TYPE a gaugehistogram\na_sum 1 # {a="b"} 0.5\n# EOF\n'),


### PR DESCRIPTION
Per recent discussions.

@SuperQ 