### PR TITLE
Fixed deletion of max/min db files in multiprocessor mode

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -126,3 +126,7 @@ def mark_process_dead(pid, path=None):
         os.remove(f)
     for f in glob.glob(os.path.join(path, 'gauge_liveall_{0}.db'.format(pid))):
         os.remove(f)
+    for f in glob.glob(os.path.join(path, 'gauge_min_{0}.db'.format(pid))):
+        os.remove(f)
+    for f in glob.glob(os.path.join(path, 'gauge_max_{0}.db'.format(pid))):
+        os.remove(f)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -106,6 +106,9 @@ class TestMultiProcess(unittest.TestCase):
         g1.set(1)
         g2.set(2)
         self.assertEqual(1, self.registry.get_sample_value('g'))
+        mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
+        self.assertEqual(None, self.registry.get_sample_value('g', {'pid': '123'}))
+        self.assertEqual(2, self.registry.get_sample_value('g'))
 
     def test_gauge_max(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
@@ -114,6 +117,9 @@ class TestMultiProcess(unittest.TestCase):
         self.assertEqual(0, self.registry.get_sample_value('g'))
         g1.set(1)
         g2.set(2)
+        self.assertEqual(2, self.registry.get_sample_value('g'))
+        mark_process_dead(123, os.environ['prometheus_multiproc_dir'])
+        self.assertEqual(None, self.registry.get_sample_value('g', {'pid': '123'}))
         self.assertEqual(2, self.registry.get_sample_value('g'))
 
     def test_gauge_livesum(self):


### PR DESCRIPTION
I found out that for `Gauge` in `max` or `min` multiprocess mode over time, displays incorrect values. Moreover, there is no such problem for `livesum`.

Db files for dead PIDs are not deleted in the same way as it is done for `livesum` and `liveall`
Below is the listing of the `prometheus_multiproc_dir`:

```
-rw-r--r--    1 root     root       1048576 Apr 19 17:35 gauge_livesum_1.db
-rw-r--r--    1 root     root       1048576 Apr 22 11:55 gauge_livesum_5174.db
-rw-r--r--    1 root     root       1048576 Apr 22 11:55 gauge_livesum_5212.db
-rw-r--r--    1 root     root       1048576 Apr 19 17:35 gauge_max_1.db
-rw-r--r--    1 root     root       1048576 Apr 20 18:05 gauge_max_1183.db
-rw-r--r--    1 root     root       1048576 Apr 20 18:01 gauge_max_1197.db
-rw-r--r--    1 root     root       1048576 Apr 20 18:13 gauge_max_1213.db
-rw-r--r--    1 root     root       1048576 Apr 20 17:53 gauge_max_1216.db
-rw-r--r--    1 root     root       1048576 Apr 20 18:23 gauge_max_1231.db
-rw-r--r--    1 root     root       1048576 Apr 20 18:25 gauge_max_1244.db
-rw-r--r--    1 root     root       1048576 Apr 20 06:31 gauge_max_1246.db
-rw-r--r--    1 root     root       1048576 Apr 20 18:33 gauge_max_1253.db
-rw-r--r--    1 root     root       1048576 Apr 20 18:49 gauge_max_1292.db
-rw-r--r--    1 root     root       1048576 Apr 21 05:59 gauge_max_2187.db
-rw-r--r--    1 root     root       1048576 Apr 21 06:21 gauge_max_2202.db
-rw-r--r--    1 root     root       1048576 Apr 21 06:33 gauge_max_2216.d
-rw-r--r--    1 root     root       1048576 Apr 20 06:03 gauge_max_46.db
-rw-r--r--    1 root     root       1048576 Apr 20 05:43 gauge_max_47.db
-rw-r--r--    1 root     root       1048576 Apr 20 06:03 gauge_max_48.db
-rw-r--r--    1 root     root       1048576 Apr 20 05:49 gauge_max_49.db
-rw-r--r--    1 root     root       1048576 Apr 20 05:35 gauge_max_50.db
-rw-r--r--    1 root     root       1048576 Apr 20 06:13 gauge_max_51.db
-rw-r--r--    1 root     root       1048576 Apr 22 11:55 gauge_max_5174.db
-rw-r--r--    1 root     root       1048576 Apr 20 05:59 gauge_max_52.d
-rw-r--r--    1 root     root       1048576 Apr 20 05:49 gauge_max_53.db
```

I fixed this problem by adding the code to remove the `min` and` max` files in the `mark_process_dead` function in the same way as for `livesum` and `liveall`.