### PR TITLE
optimize openmetrics text parsing (~4x perf)

### DIFF
--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -175,9 +175,10 @@ def _parse_labels_with_state_machine(text):
 
 def _parse_labels(text):
     labels = {}
-    # Return if we don't have valid labels
-    if "=" not in text:
-        return labels
+
+    # Raise error if we don't have valid labels
+    if text and "=" not in text:
+        raise ValueError
 
     # Copy original labels
     sub_labels = text
@@ -190,14 +191,16 @@ def _parse_labels(text):
             sub_labels = sub_labels[value_start + 1:]
 
             # Check for missing quotes 
-            if sub_labels[0] != '"':
+            if not sub_labels or sub_labels[0] != '"':
                 raise ValueError
 
             # The first quote is guaranteed to be after the equal
             value_substr = sub_labels[1:]
 
             # Check for extra commas
-            if label_name[0] == ',' or value_substr[-1] == ',':
+            if not label_name or label_name[0] == ',':
+                raise ValueError
+            if not value_substr or value_substr[-1] == ',':
                 raise ValueError
 
             # Find the last unescaped quote
@@ -255,7 +258,7 @@ def _parse_sample(text):
         label = text[label_start + 1:label_end]
         labels = _parse_labels(label)
     else:
-        # Line contains an exemplar
+        # Line potentially contains an exemplar
         # Fallback to parsing labels with a state machine
         labels, labels_len = _parse_labels_with_state_machine(text[label_start + 1:])
         label_end = labels_len + len(name)      

--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -104,7 +104,7 @@ def _parse_timestamp(timestamp):
 
 def _is_character_escaped(s, charpos):
     num_bslashes = 0
-    while (charpos > 0 and
+    while (charpos > num_bslashes and
            s[charpos - 1 - num_bslashes] == '\\'):
         num_bslashes += 1
     return num_bslashes % 2 == 1
@@ -205,7 +205,7 @@ def _parse_labels(text):
             i = 0
             while i < len(value_substr):
                 i = value_substr.index('"', i)
-                if not _is_character_escaped(value_substr, i):
+                if not _is_character_escaped(value_substr[:i], i):
                     break
                 i += 1
 

--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -187,7 +187,7 @@ def _parse_sample(text):
         return Sample(name, labels, value, timestamp, exemplar)
 
     except ValueError as e:
-        if str(e) == "substring not found":
+        if str(e).startswith("substring not found"):
             # We don't have labels
             # Detect what separator is used
             separator = " "

--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -142,7 +142,6 @@ def _parse_labels_with_state_machine(text):
                 if not METRIC_LABEL_NAME_RE.match(''.join(labelname)):
                     raise ValueError("Invalid line: " + text)
                 labels[''.join(labelname)] = ''.join(labelvalue)
-                labels_len += len(labelname) + len(labelvalue) + 1
                 labelname = []
                 labelvalue = []
                 state = 'endoflabelvalue'
@@ -170,6 +169,7 @@ def _parse_labels_with_state_machine(text):
                 break
             else:
                 raise ValueError("Invalid line: " + text)
+        labels_len += 1
     return labels, labels_len
 
 
@@ -258,7 +258,7 @@ def _parse_sample(text):
         # Line contains an exemplar
         # Fallback to parsing labels with a state machine
         labels, labels_len = _parse_labels_with_state_machine(text[label_start + 1:])
-        label_end = labels_len + len(name) + 3  # We count the braces        
+        label_end = labels_len + len(name)      
     # Parsing labels succeeded, continue parsing the remaining text
     remaining_text = text[label_end + 2:]
     value, timestamp, exemplar = _parse_remaining_text(remaining_text)

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -374,6 +374,18 @@ b_total 2 1234567890
         b.add_metric([], 2, timestamp=Timestamp(1234567890, 0))
         self.assertEqual([a, b], list(families))
 
+    def test_hash_in_label_value(self):
+        families = text_string_to_metric_families("""# TYPE a counter
+# HELP a help
+a_total{foo="foo # bar"} 1
+a_total{foo="} foo # bar # "} 1
+# EOF
+""")
+        a = CounterMetricFamily("a", "help", labels=["foo"])
+        a.add_metric(["foo # bar"], 1)
+        a.add_metric(["} foo # bar # "], 1)
+        self.assertEqual([a], list(families))
+
     @unittest.skipIf(sys.version_info < (2, 7), "Test requires Python 2.7+.")
     def test_roundtrip(self):
         text = """# HELP go_gc_duration_seconds A summary of the GC invocation durations.

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -595,6 +595,7 @@ foo_created 1.520430000123e+09
             ('# TYPE a gauge\na 0 0\na 0\n# EOF\n'),
         ]:
             with self.assertRaises(ValueError):
+                print(case)
                 list(text_string_to_metric_families(case))
 
     @unittest.skipIf(sys.version_info < (2, 7), "float repr changed from 2.6 to 2.7")


### PR DESCRIPTION
This PR optimizes the openmetrics parser using the logic introduced in https://github.com/prometheus/client_python/pull/282 to optimize the prometheus parser.

Here are some benchmark using `timeit`:

```
call (x100000): _parse_sample('simple_metric 1.513767429e+09')

Simple example with prometheus parser: 0.2489180564880371
Simple example with openmetrics parser: 1.1144659519195557
Simple example with the optimized openmetrics parser: 0.5948491096496582

call (x100000): _parse_sample('kube_service_labels{label_app="kube-state-metrics",label_chart="kube-state-metrics-0.5.0",label_heritage="Tiller",label_release="ungaged-panther",namespace="default",service="ungaged-panther-kube-state-metrics"} 1')

KSM metric example with prometheus parser: 1.6796550750732422
KSM metric example openmetrics parser: 6.6183180809021
KSM metric example optimized openmetrics parser: 2.0289480686187744
```