### PR TITLE
Compact types.MethodType between 2 and 3

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -14,6 +14,10 @@ from .utils import floatToGoString, INF
 
 if sys.version_info > (3,):
     unicode = str
+    create_bound_method = types.MethodType
+else:
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
 
 
 def _build_full_name(metric_type, name, namespace, subsystem, unit):
@@ -369,7 +373,7 @@ class Gauge(MetricWrapperBase):
         def samples(self):
             return (('', {}, float(f())),)
 
-        self._child_samples = types.MethodType(samples, self)
+        self._child_samples = create_bound_method(samples, self)
 
     def _child_samples(self):
         return (('', {}, self._value.get()),)


### PR DESCRIPTION
In Python2, the `MethodType` constructor requires the obj‘s class to be passed. Compact code is copied from `six` https://github.com/benjaminp/six/blob/8da94b8a153ceb0d6417d76729ba75e80eaa75c1/six.py#L545-L556