### PR TITLE
Unable to convert string to float: b'unlimited'

### DIFF
--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -88,7 +88,7 @@ class ProcessCollector(object):
                                          'Number of open file descriptors.',
                                          len(os.listdir(os.path.join(pid, 'fd'))))
             result.extend([open_fds, max_fds])
-        except (IOError, OSError):
+        except (IOError, OSError, ValueError):
             pass
 
         return result


### PR DESCRIPTION
On https://github.com/prometheus/client_python/blob/v0.3.1/prometheus_client/process_collector.py#L81, on a Linux zone running on SmartOS, I'm getting the following error:

```
May 18 23:47:57 myserver matrix-synapse[27352]: Traceback (most recent call last):
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
May 18 23:47:57 myserver matrix-synapse[27352]:     "__main__", mod_spec)
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
May 18 23:47:57 myserver matrix-synapse[27352]:     exec(code, run_globals)
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/var/www/synapse/.venv/lib/python3.5/site-packages/synapse/app/homeserver.py", line 28, in <module>
May 18 23:47:57 myserver matrix-synapse[27352]:     from prometheus_client import Gauge
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/var/www/synapse/.venv/lib/python3.5/site-packages/prometheus_client/__init__.py", line 5, in <module>
May 18 23:47:57 myserver matrix-synapse[27352]:     from . import process_collector
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/var/www/synapse/.venv/lib/python3.5/site-packages/prometheus_client/process_collector.py", line 93, in <module>
May 18 23:47:57 myserver matrix-synapse[27352]:     PROCESS_COLLECTOR = ProcessCollector()
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/var/www/synapse/.venv/lib/python3.5/site-packages/prometheus_client/process_collector.py", line 39, in __init__
May 18 23:47:57 myserver matrix-synapse[27352]:     registry.register(self)
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/var/www/synapse/.venv/lib/python3.5/site-packages/prometheus_client/core.py", line 54, in register
May 18 23:47:57 myserver matrix-synapse[27352]:     names = self._get_names(collector)
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/var/www/synapse/.venv/lib/python3.5/site-packages/prometheus_client/core.py", line 91, in _get_names
May 18 23:47:57 myserver matrix-synapse[27352]:     for metric in desc_func():
May 18 23:47:57 myserver matrix-synapse[27352]:   File "/var/www/synapse/.venv/lib/python3.5/site-packages/prometheus_client/process_collector.py", line 81, in collect
May 18 23:47:57 myserver matrix-synapse[27352]:     value=float(line.split()[3]))
May 18 23:47:57 myserver matrix-synapse[27352]: ValueError: could not convert string to float: b'unlimited'
```

I think if we also capture the `ValueError`, then the code will proceed safely.

My `/proc/27352/limits` file looks like:

```
root@myserver:~# cat /proc/27440/limits 
Limit                     Soft Limit           Hard Limit           Units     
Max cpu time              unlimited            unlimited            seconds   
Max file size             unlimited            9223372036854775807  bytes     
Max data size             unlimited            unlimited            bytes     
Max stack size            10485760             35184372088832       bytes     
Max core file size        unlimited            unlimited            bytes     
Max resident set          unlimited            8589934592           bytes     
Max processes             unlimited            2000                 processes 
Max open files            unlimited            1048576              files     
Max locked memory         unlimited            8589934592           bytes     
Max address space         unlimited            unlimited            bytes     
Max file locks            unlimited            unlimited            locks     
Max pending signals       128                  512                  signals   
Max msgqueue size         unlimited            8192                 bytes  
```