### PR TITLE
Added gauge files to be deleted when multiprocess worker exit

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -126,9 +126,9 @@ def mark_process_dead(pid, path=None):
         os.remove(f)
     for f in glob.glob(os.path.join(path, 'gauge_liveall_{0}.db'.format(pid))):
         os.remove(f)
-    for f in glob.glob(os.path.join(path, 'gauge_all_{0}.db'.format(worker.pid))):
+    for f in glob.glob(os.path.join(path, 'gauge_all_{0}.db'.format(pid))):
         os.remove(f)
-    for f in glob.glob(os.path.join(path, 'histogram_{0}.db'.format(worker.pid))):
+    for f in glob.glob(os.path.join(path, 'histogram_{0}.db'.format(pid))):
         os.remove(f)
-    for f in glob.glob(os.path.join(path, 'counter_{0}.db'.format(worker.pid))):
+    for f in glob.glob(os.path.join(path, 'counter_{0}.db'.format(pid))):
         os.remove(f)

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -126,3 +126,9 @@ def mark_process_dead(pid, path=None):
         os.remove(f)
     for f in glob.glob(os.path.join(path, 'gauge_liveall_{0}.db'.format(pid))):
         os.remove(f)
+    for f in glob.glob(os.path.join(path, 'gauge_all_{0}.db'.format(worker.pid))):
+        os.remove(f)
+    for f in glob.glob(os.path.join(path, 'histogram_{0}.db'.format(worker.pid))):
+        os.remove(f)
+    for f in glob.glob(os.path.join(path, 'counter_{0}.db'.format(worker.pid))):
+        os.remove(f)


### PR DESCRIPTION
When Gunicorn is used as multiple processes,
Added code to delete the actual generated Guage file when the worker exits.

guage_all_{pid}.db
histogram_{pid}.db
counter_{pid}.db