### PR TITLE
Added _delta in Histogram and Summary

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -412,12 +412,15 @@ class Summary(MetricWrapperBase):
         self._count = values.ValueClass(self._type, self._name, self._name + '_count', self._labelnames,
                                         self._labelvalues)
         self._sum = values.ValueClass(self._type, self._name, self._name + '_sum', self._labelnames, self._labelvalues)
+        self._delta = 0.0
         self._created = time.time()
+
 
     def observe(self, amount):
         """Observe the given amount."""
         self._count.inc(1)
         self._sum.inc(amount)
+        self._delta = amount
 
     def time(self):
         """Time a block of code or function, and observe the duration in seconds.
@@ -430,7 +433,8 @@ class Summary(MetricWrapperBase):
         return (
             ('_count', {}, self._count.get()),
             ('_sum', {}, self._sum.get()),
-            ('_created', {}, self._created))
+            ('_created', {}, self._created),
+            ('_delta', {}, self._delta))
 
 
 class Histogram(MetricWrapperBase):
@@ -511,6 +515,7 @@ class Histogram(MetricWrapperBase):
     def _metric_init(self):
         self._buckets = []
         self._created = time.time()
+        self._delta = 0.0
         bucket_labelnames = self._labelnames + ('le',)
         self._sum = values.ValueClass(self._type, self._name, self._name + '_sum', self._labelnames, self._labelvalues)
         for b in self._upper_bounds:
@@ -525,6 +530,7 @@ class Histogram(MetricWrapperBase):
     def observe(self, amount):
         """Observe the given amount."""
         self._sum.inc(amount)
+        self._delta = amount
         for i, bound in enumerate(self._upper_bounds):
             if amount <= bound:
                 self._buckets[i].inc(1)
@@ -546,6 +552,8 @@ class Histogram(MetricWrapperBase):
         samples.append(('_count', {}, acc))
         samples.append(('_sum', {}, self._sum.get()))
         samples.append(('_created', {}, self._created))
+        samples.append(('_delta', {}, self._delta))
+
         return tuple(samples)
 
 

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -61,6 +61,7 @@ class TestGenerateText(unittest.TestCase):
 ss_count{a="c",b="d"} 1.0
 ss_sum{a="c",b="d"} 17.0
 ss_created{a="c",b="d"} 123.456
+ss_delta{a="c",b="d"} 17.0
 # EOF
 """, generate_latest(self.registry))
 
@@ -88,6 +89,7 @@ hh_bucket{le="+Inf"} 1.0
 hh_count 1.0
 hh_sum 0.05
 hh_created 123.456
+hh_delta 0.05
 # EOF
 """, generate_latest(self.registry))
 

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -82,6 +82,7 @@ cc_created 123.456
 # TYPE ss summary
 ss_count{a="c",b="d"} 1.0
 ss_sum{a="c",b="d"} 17.0
+ss_delta{a="c",b="d"} 17.0
 # TYPE ss_created gauge
 ss_created{a="c",b="d"} 123.456
 """, generate_latest(self.registry))
@@ -109,6 +110,7 @@ hh_bucket{le="10.0"} 1.0
 hh_bucket{le="+Inf"} 1.0
 hh_count 1.0
 hh_sum 0.05
+hh_delta 0.05
 # TYPE hh_created gauge
 hh_created 123.456
 """, generate_latest(self.registry))


### PR DESCRIPTION
@brian-brazil 
Added a new field in Summary and Histogram named "_delta". As, "_sum" is cumulative, it's difficult to get the value("amount" in this case) by which the graph has increased and use those values for plotting a graph. Hence, "_delta" will contain the "amount" which can be used for plotting a graph and gaining much better insights.