### PR TITLE
Multiprocess exposition speed boost

### DIFF
--- a/prometheus_client/mmap_dict.py
+++ b/prometheus_client/mmap_dict.py
@@ -37,9 +37,11 @@ class MmapedDict(object):
     def __init__(self, filename, read_mode=False):
         self._f = open(filename, 'rb' if read_mode else 'a+b')
         self._fname = filename
-        if os.fstat(self._f.fileno()).st_size == 0:
+        capacity = os.fstat(self._f.fileno()).st_size
+        if capacity == 0:
             self._f.truncate(_INITIAL_MMAP_SIZE)
-        self._capacity = os.fstat(self._f.fileno()).st_size
+            capacity = _INITIAL_MMAP_SIZE
+        self._capacity = capacity
         self._m = mmap.mmap(self._f.fileno(), self._capacity,
                             access=mmap.ACCESS_READ if read_mode else mmap.ACCESS_WRITE)
 

--- a/prometheus_client/mmap_dict.py
+++ b/prometheus_client/mmap_dict.py
@@ -81,7 +81,6 @@ class MmapedDict(object):
         # on every loop iteration
         used = self._used
         data = self._m
-        unpack_from = struct.unpack_from
 
         while pos < used:
             encoded_len = _unpack_integer(data, pos)[0]
@@ -90,11 +89,11 @@ class MmapedDict(object):
                 msg = 'Read beyond file size detected, %s is corrupted.'
                 raise RuntimeError(msg % self._fname)
             pos += 4
-            encoded = unpack_from(('%ss' % encoded_len).encode(), data, pos)[0]
+            encoded_key = data[pos : pos + encoded_len]
             padded_len = encoded_len + (8 - (encoded_len + 4) % 8)
             pos += padded_len
             value = _unpack_double(data, pos)[0]
-            yield encoded.decode('utf-8'), value, pos
+            yield encoded_key.decode('utf-8'), value, pos
             pos += 8
 
     def read_all_values(self):

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -33,6 +33,11 @@ class MultiProcessCollector(object):
         But if writing the merged data back to mmap files, use
         accumulate=False to avoid compound accumulation.
         """
+        metrics = MultiProcessCollector._read_metrics(files)
+        return MultiProcessCollector._accumulate_metrics(metrics, accumulate)
+
+    @staticmethod
+    def _read_metrics(files):
         metrics = {}
         for f in files:
             parts = os.path.basename(f).split('_')
@@ -55,7 +60,10 @@ class MultiProcessCollector(object):
                     # The duplicates and labels are fixed in the next for.
                     metric.add_sample(name, labels_key, value)
             d.close()
+        return metrics
 
+    @staticmethod
+    def _accumulate_metrics(metrics, accumulate):
         for metric in metrics.values():
             samples = defaultdict(float)
             buckets = {}

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -54,8 +54,7 @@ class MultiProcessCollector(object):
         for f in files:
             parts = os.path.basename(f).split('_')
             typ = parts[0]
-            d = MmapedDict(f, read_mode=True)
-            for key, value in d.read_all_values():
+            for key, value, pos in MmapedDict.read_all_values_from_file(f):
                 metric_name, name, labels, labels_key = _parse_key(key)
 
                 metric = metrics.get(metric_name)
@@ -70,7 +69,6 @@ class MultiProcessCollector(object):
                 else:
                     # The duplicates and labels are fixed in the next for.
                     metric.add_sample(name, labels_key, value)
-            d.close()
         return metrics
 
     @staticmethod


### PR DESCRIPTION
Hey there!

We at @valohai are still (#367, #368) bumping into situations where a long-lived multiproc (uWSGI) app's metric exposition steadily gets slower and slower, until it starts clogging up all workers and bumping into Prometheus's deadlines, and things break in a decidedly ungood way.

I figured I could take a little look at what exactly is taking time there, and I'm delighted to say I managed to eke out a roughly 5.8-fold speed increase in my test case (2857 files in the multiproc dir, totaling 2.8 GiB).

By far the largest boost here came from actually not using `mmap()` at all (f0319fa) when we're only reading the file; instead, simply reading the file fully into memory and parsing things from the memory buffer is much, much faster. Given each file (in my case anyway) is about 1 meg a pop, it shouldn't cause too much momentary memory pressure either.

Another decent optimization (0d8b870) came from looking at `vmprof`'s output (and remembering python-babel/babel#571); it said a lot of time was spent in small, numerous memory allocations within Python, and the trail led to `json.loads()`. Since the JSON blobs in the files are written with `sort_keys=True`, we can be fairly certain that there's going to be plenty of string duplication. Simply adding an unbounded `lru_cache()` to where the JSON strings are being parsed into (nicely immutable!) objects gave a nice speed boost and probably also reduced memory churn since the same objects get reused.  Calling `cache_info()` on the lru_cache validated the guess of duplication: `CacheInfo(hits=573057, misses=3229, maxsize=None, currsize=3229)`

A handful of other micro-optimizations brought the speed up a little more still.

My benchmark code was essentially 5 iterations of

```python
registry = prometheus_client.CollectorRegistry()
multiprocess.MultiProcessCollector(registry)
metrics_page = prometheus_client.generate_latest(registry)
assert metrics_page
```

and on my machine it took 22.478 seconds on 5132fd2 and 3.885 on 43cc95c91. 🎉 