### PR TITLE
very small change to fix errors when handling datetime object from aws

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -75,7 +75,7 @@ def generate_latest(registry=REGISTRY):
         if line.labels:
             labelstr = '{{{0}}}'.format(','.join(
                 ['{0}="{1}"'.format(
-                    k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))
+                    k, str(v).replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))
                     for k, v in sorted(line.labels.items())]))
         else:
             labelstr = ''


### PR DESCRIPTION
Hi, I am trying to export CreateDate using the[ aws-prometheus-exporter ](https://github.com/movio/aws-prometheus-exporter) the exporter fails because of an error in [exposition.py ]

there seems to be an type error in this function, when v is expected to be a string, however sometimes aws return datas as an datetime object, which cause `v.replace('\\', r'\\')` errors out.
![image](https://user-images.githubusercontent.com/15177124/58977949-a9bf6580-877f-11e9-85fa-02ea5aa03af7.png)

i found that this can be fixed by minimally changing line 78 in exposition.py to `k, str(v).replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))` 
