### PR TITLE
Fix twisted test on Python3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ deps =
 [testenv]
 deps =
     {[base]deps}
-    {py27,py34,py35,py36,pypy,pypy3}: twisted
+    {py27,py35,py36,pypy,pypy3}: twisted
+    {py34}: twisted==19.2.0
 commands = coverage run --parallel -m pytest {posargs}
 
 ; Ensure test suite passes if no optional dependencies are present.


### PR DESCRIPTION
cf
https://github.com/twisted/twisted/commit/fc3be690fda845dc369366f1d6a7e7ff67db81dd
and twisted/twisted@8a47339 broke Python3.4 between 19.2.0 and 19.2.1

Signed-off-by: Xavier Fernandez <xavier.fernandez@polyconseil.fr>