### PR TITLE
using worker_id instead of pid will produce fewer db files

### DIFF
--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -95,6 +95,12 @@ def MultiProcessValue(_pidFunc=os.getpid):
 
     return MmapedValue
 
+def _get_worker_id():
+    try:
+        import uwsgi
+        return uwsgi.worker_id()
+    except:
+        return 0
 
 def get_value_class():
     # Should we enable multi-process mode?
@@ -102,7 +108,7 @@ def get_value_class():
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
     if 'prometheus_multiproc_dir' in os.environ:
-        return MultiProcessValue()
+        return MultiProcessValue(_get_worker_id)
     else:
         return MutexValue
 


### PR DESCRIPTION
As the program is restarted frequently, more and more db files will be generated. These files are cumbersome to manage, and aggregate metrics also consume resources.

If the worker id is used as the db file naming method, as long as the number of wokers is determined and the metric type is unchanged, the number of generated db files will not increase, but the values ​​in the file are changing.

![image](https://user-images.githubusercontent.com/19743705/59685465-c98a6b00-920e-11e9-90b9-ff66b9d2a29b.png)

this will slow down the prometheus scrape duration.