### PR TITLE
except OSError

### DIFF
--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -30,7 +30,7 @@ class ProcessCollector(object):
         self._ticks = 100.0
         try:
             self._ticks = os.sysconf('SC_CLK_TCK')
-        except (ValueError, TypeError, AttributeError):
+        except (ValueError, TypeError, AttributeError, OSError):
             pass
 
         # This is used to test if we can access /proc.


### PR DESCRIPTION
I'm trying to use this on Google App Engine standard (python 2.7) just to export some custom metrics.  This line throws an OSError.

I also had some trouble with the multiprocess mmap stuff.  Just dropping something into sys.modules['prometheus_client.mmap_dict'] seems to work well enough to solve that one, though.