### PR TITLE
Add target_info to registries

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -664,6 +664,9 @@ class TestCollectorRegistry(unittest.TestCase):
         # The name of the histogram itself isn't taken.
         Gauge('h', 'help', registry=registry)
 
+        Info('i', 'help', registry=registry)
+        self.assertRaises(ValueError, Gauge, 'i_info', 'help', registry=registry)
+
     def test_unregister_works(self):
         registry = CollectorRegistry()
         s = Summary('s', 'help', registry=registry)
@@ -695,6 +698,34 @@ class TestCollectorRegistry(unittest.TestCase):
         m = Metric('s', 'help', 'summary')
         m.samples = [Sample('s_sum', {}, 7)]
         self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())
+
+    def test_target_info_injected(self):
+        registry = CollectorRegistry(target_info={'foo': 'bar'})
+        self.assertEqual(1, registry.get_sample_value('target_info', {'foo': 'bar'}))
+
+    def test_target_info_duplicate_detected(self):
+        registry = CollectorRegistry(target_info={'foo': 'bar'})
+        self.assertRaises(ValueError, Info, 'target', 'help', registry=registry)
+
+        registry.set_target_info({})
+        i = Info('target', 'help', registry=registry)
+        registry.set_target_info({})
+        self.assertRaises(ValueError, Info, 'target', 'help', registry=registry)
+        self.assertRaises(ValueError, registry.set_target_info, {'foo': 'bar'})
+        registry.unregister(i)
+        registry.set_target_info({'foo': 'bar'})
+
+    def test_target_info_restricted_registry(self):
+        registry = CollectorRegistry(target_info={'foo': 'bar'})
+        Summary('s', 'help', registry=registry).observe(7)
+
+        m = Metric('s', 'help', 'summary')
+        m.samples = [Sample('s_sum', {}, 7)]
+        self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())
+
+        m = Metric('target', 'Target metadata', 'info')
+        m.samples = [Sample('target_info', {'foo': 'bar'}, 1)]
+        self.assertEquals([m], registry.restricted_registry(['target_info']).collect())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows target labels as needed by push-based systems to be
provided, in a way that doesn't mess up Prometheus's own
top-down pull based approach to SD.

@SuperQ @RichiH @robskillington @sumeer Here's roughly what I'm thinking. Needs unittests etc.

@beorn7 Your input would be appreciated on the pgw front. https://github.com/OpenObservability/OpenMetrics/issues/63 is the general background. Pgw could continue to do this out of band for grouping labels (potentially with the client library using this as a default), or have this as an option.