### PR TITLE
Add checks for various other float formats.

### DIFF
--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -72,7 +72,7 @@ def _unescape_help(text):
 
 def _parse_value(value):
     value = ''.join(value)
-    if value != value.strip():
+    if value != value.strip() or '_' in value:
         raise ValueError("Invalid value: {0!r}".format(value))
     try:
         return int(value)
@@ -84,7 +84,7 @@ def _parse_timestamp(timestamp):
     timestamp = ''.join(timestamp)
     if not timestamp:
         return None
-    if timestamp != timestamp.strip():
+    if timestamp != timestamp.strip() or '_' in timestamp:
         raise ValueError("Invalid timestamp: {0!r}".format(timestamp))
     try:
         # Simple int.


### PR DESCRIPTION
Check for new stuff Go added in 1.13, and also
make sure leading 0s are permitted as some users
want to be able to do fixed-size output.

@SuperQ 