### PR TITLE
Drop unneeded shebangs

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from __future__ import unicode_literals
 
 import base64

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from __future__ import unicode_literals
 
 import gc

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from __future__ import unicode_literals
 
 from collections import defaultdict

--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from __future__ import unicode_literals
 
 import re

--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8
 from __future__ import unicode_literals
 

--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from __future__ import unicode_literals
 
 import os


### PR DESCRIPTION
Those files are not executable, nor have any __main__ function.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>