### PR TITLE
Fixed some handler issues in mmap_dict

### DIFF
--- a/prometheus_client/mmap_dict.py
+++ b/prometheus_client/mmap_dict.py
@@ -136,6 +136,9 @@ class MmapedDict(object):
             self._f.close()
             self._f = None
 
+    def __del__(self):
+        self.close()
+
 
 def mmap_key(metric_name, name, labelnames, labelvalues):
     """Format a key for use in the mmap file."""


### PR DESCRIPTION
Unit test from test_multiprocess were not working on windows, it was because shutil.rmtree were ending up with a Permission error because of some remaining mmap file handlers.
Added:
* __del__ that call close on mmap
* a retry_after_close_handler method for testing to make sure we can indeed delete tmp resources that display a warning in case some handler were closed