### PR TITLE
Adding uppercase PROMETHEUS_MULTIPROC_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .tox
 .*cache
 htmlcov
+.idea

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ There's several steps to getting this working:
 
 **One**: Gunicorn deployment
 
-The `prometheus_multiproc_dir` environment variable must be set to a directory
+The `prometheus_multiproc_dir` or `PROMETHEUS_MULTIPROC_DIR` environment variable must be set to a directory
 that the client library can use for metrics. This directory must be wiped
 between Gunicorn runs (before startup is recommended).
 

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -23,7 +23,7 @@ class MultiProcessCollector(object):
 
     def __init__(self, registry, path=None):
         if path is None:
-            path = os.environ.get('prometheus_multiproc_dir')
+            path = os.environ.get('prometheus_multiproc_dir') or os.environ.get('PROMETHEUS_MULTIPROC_DIR')
         if not path or not os.path.isdir(path):
             raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
         self._path = path


### PR DESCRIPTION
Allowed both prometheus_multiproc_dir and PROMETHEUS_MULTIPROC_DIR
as valid environment variables

It's been a common point of confusion for our users,  as most environment variables are uppercase  they believe they have set the variable, when in fact they forgot to lowercase it.