### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 cache:
   directories:
@@ -22,11 +23,15 @@ matrix:
       env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37
-      dist: xenial
       sudo: true
     - python: "3.7"
       env: TOXENV=py37-nooptionals
-      dist: xenial
+      sudo: true
+    - python: "3.8"
+      env: TOXENV=py38
+      sudo: true
+    - python: "3.8"
+      env: TOXENV=py38-nooptionals
       sudo: true
     - python: "pypy"
       env: TOXENV=pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
     - python: "3.7"
       env: TOXENV=py37
       sudo: true
-    - python: "3.7"
-      env: TOXENV=py37-nooptionals
-      sudo: true
     - python: "3.8"
       env: TOXENV=py38
       sudo: true

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Monitoring",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py26,py27,py34,py35,py36,py37,py38,pypy,pypy3,{py27,py37,py38}-nooptionals,coverage-report,flake8
+envlist = coverage-clean,py26,py27,py34,py35,py36,py37,py38,pypy,pypy3,{py27,py38}-nooptionals,coverage-report,flake8
 
 
 [base]
@@ -39,7 +39,7 @@ deps =
     futures
 commands = coverage run --parallel -m pytest {posargs}
 
-[testenv:py37-nooptionals]
+[testenv:py38-nooptionals]
 commands = coverage run --parallel -m pytest {posargs}
 
 [testenv:coverage-clean]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py26,py27,py34,py35,py36,py37,pypy,pypy3,{py27,py37}-nooptionals,coverage-report,flake8
+envlist = coverage-clean,py26,py27,py34,py35,py36,py37,py38,pypy,pypy3,{py27,py37,py38}-nooptionals,coverage-report,flake8
 
 
 [base]


### PR DESCRIPTION
Python 3.8 was released recently. This runs tests and adds the classifer to indicate Python 3.8 is supported.