### PR TITLE
Add __repr__ method to metric objects, make them debug friendly.

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -80,9 +80,12 @@ class MetricWrapperBase(object):
             metric.add_sample(self._name + suffix, labels, value)
         return [metric]
 
+    def __str__(self):
+        return "{0}:{1}".format(self._type, self._name)
+
     def __repr__(self):
         metric_type = type(self)
-        return "{0}.{1}:{2}".format(metric_type.__module__, metric_type.__name__, self._name)
+        return "{0}.{1}({2})".format(metric_type.__module__, metric_type.__name__, self._name)
 
     def __init__(self,
                  name,

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -80,6 +80,10 @@ class MetricWrapperBase(object):
             metric.add_sample(self._name + suffix, labels, value)
         return [metric]
 
+    def __repr__(self):
+        metric_type = type(self)
+        return "{0}.{1}:{2}".format(metric_type.__module__, metric_type.__name__, self._name)
+
     def __init__(self,
                  name,
                  documentation,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -30,9 +30,13 @@ class TestCounter(unittest.TestCase):
         self.assertEqual(1, self.registry.get_sample_value('c_total'))
         self.counter.inc(7)
         self.assertEqual(8, self.registry.get_sample_value('c_total'))
+    
+    def test_repr(self):
+        self.assertEqual(repr(self.counter), "prometheus_client.metrics.Counter:c")
 
     def test_negative_increment_raises(self):
         self.assertRaises(ValueError, self.counter.inc, -1)
+    
 
     def test_function_decorator(self):
         @self.counter.count_exceptions(ValueError)
@@ -83,6 +87,9 @@ class TestGauge(unittest.TestCase):
     def setUp(self):
         self.registry = CollectorRegistry()
         self.gauge = Gauge('g', 'help', registry=self.registry)
+    
+    def test_repr(self):
+        self.assertEqual(repr(self.gauge), "prometheus_client.metrics.Gauge:g")
 
     def test_gauge(self):
         self.assertEqual(0, self.registry.get_sample_value('g'))
@@ -180,6 +187,9 @@ class TestSummary(unittest.TestCase):
         self.registry = CollectorRegistry()
         self.summary = Summary('s', 'help', registry=self.registry)
 
+    def test_repr(self):
+        self.assertEqual(repr(self.summary), "prometheus_client.metrics.Summary:s")
+
     def test_summary(self):
         self.assertEqual(0, self.registry.get_sample_value('s_count'))
         self.assertEqual(0, self.registry.get_sample_value('s_sum'))
@@ -268,6 +278,10 @@ class TestHistogram(unittest.TestCase):
         self.registry = CollectorRegistry()
         self.histogram = Histogram('h', 'help', registry=self.registry)
         self.labels = Histogram('hl', 'help', ['l'], registry=self.registry)
+
+    def test_repr(self):
+        self.assertEqual(repr(self.histogram), "prometheus_client.metrics.Histogram:h")
+        self.assertEqual(repr(self.labels), "prometheus_client.metrics.Histogram:hl")
 
     def test_histogram(self):
         self.assertEqual(0, self.registry.get_sample_value('h_bucket', {'le': '1.0'}))
@@ -372,6 +386,10 @@ class TestInfo(unittest.TestCase):
         self.registry = CollectorRegistry()
         self.info = Info('i', 'help', registry=self.registry)
         self.labels = Info('il', 'help', ['l'], registry=self.registry)
+
+    def test_repr(self):
+        self.assertEqual(repr(self.info), "prometheus_client.metrics.Info:i")
+        self.assertEqual(repr(self.labels), "prometheus_client.metrics.Info:il")
 
     def test_info(self):
         self.assertEqual(1, self.registry.get_sample_value('i_info', {}))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,7 +32,7 @@ class TestCounter(unittest.TestCase):
         self.assertEqual(8, self.registry.get_sample_value('c_total'))
     
     def test_repr(self):
-        self.assertEqual(repr(self.counter), "prometheus_client.metrics.Counter:c")
+        self.assertEqual(repr(self.counter), "prometheus_client.metrics.Counter(c)")
 
     def test_negative_increment_raises(self):
         self.assertRaises(ValueError, self.counter.inc, -1)
@@ -89,7 +89,7 @@ class TestGauge(unittest.TestCase):
         self.gauge = Gauge('g', 'help', registry=self.registry)
     
     def test_repr(self):
-        self.assertEqual(repr(self.gauge), "prometheus_client.metrics.Gauge:g")
+        self.assertEqual(repr(self.gauge), "prometheus_client.metrics.Gauge(g)")
 
     def test_gauge(self):
         self.assertEqual(0, self.registry.get_sample_value('g'))
@@ -188,7 +188,7 @@ class TestSummary(unittest.TestCase):
         self.summary = Summary('s', 'help', registry=self.registry)
 
     def test_repr(self):
-        self.assertEqual(repr(self.summary), "prometheus_client.metrics.Summary:s")
+        self.assertEqual(repr(self.summary), "prometheus_client.metrics.Summary(s)")
 
     def test_summary(self):
         self.assertEqual(0, self.registry.get_sample_value('s_count'))
@@ -280,8 +280,8 @@ class TestHistogram(unittest.TestCase):
         self.labels = Histogram('hl', 'help', ['l'], registry=self.registry)
 
     def test_repr(self):
-        self.assertEqual(repr(self.histogram), "prometheus_client.metrics.Histogram:h")
-        self.assertEqual(repr(self.labels), "prometheus_client.metrics.Histogram:hl")
+        self.assertEqual(repr(self.histogram), "prometheus_client.metrics.Histogram(h)")
+        self.assertEqual(repr(self.labels), "prometheus_client.metrics.Histogram(hl)")
 
     def test_histogram(self):
         self.assertEqual(0, self.registry.get_sample_value('h_bucket', {'le': '1.0'}))
@@ -388,8 +388,8 @@ class TestInfo(unittest.TestCase):
         self.labels = Info('il', 'help', ['l'], registry=self.registry)
 
     def test_repr(self):
-        self.assertEqual(repr(self.info), "prometheus_client.metrics.Info:i")
-        self.assertEqual(repr(self.labels), "prometheus_client.metrics.Info:il")
+        self.assertEqual(repr(self.info), "prometheus_client.metrics.Info(i)")
+        self.assertEqual(repr(self.labels), "prometheus_client.metrics.Info(il)")
 
     def test_info(self):
         self.assertEqual(1, self.registry.get_sample_value('i_info', {}))


### PR DESCRIPTION
before:
![Screenshot 2019-10-25 18 44 10](https://user-images.githubusercontent.com/1268088/67612503-fd931100-f757-11e9-8a8e-0e8d8030081d.png)

after:
![Screenshot 2019-10-25 18 43 40](https://user-images.githubusercontent.com/1268088/67612502-fd931100-f757-11e9-9e50-86621bb82199.png)