### PR TITLE
Update setup.py to produce universal wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,5 @@ setup(
         "Topic :: System :: Monitoring",
         "License :: OSI Approved :: Apache Software License",
     ],
+    options={'bdist_wheel': {'universal': '1'}},
 )


### PR DESCRIPTION
To ease the transition to #457:

    `python setup.py sdist bdist_wheel`

will produce the universal wheel in addition to the sdist.