### PR TITLE
Return thread object from start_http_server

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -194,6 +194,7 @@ def start_http_server(port, addr='', registry=REGISTRY):
     t = threading.Thread(target=httpd.serve_forever)
     t.daemon = True
     t.start()
+    return t
 
 
 def write_to_textfile(path, registry):


### PR DESCRIPTION
Callers of start_http_server might want to know when the server has exited.
Return the thread object so that it can be join()ed for this purpose.