### PR TITLE
Get rid of a confusing comment about time going backwards

### DIFF
--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from timeit import default_timer
+from time import monotonic
 
 from .decorator import decorate
 
@@ -51,11 +51,10 @@ class Timer(object):
         return self.__class__(self._callback)
 
     def __enter__(self):
-        self._start = default_timer()
+        self._start = monotonic()
 
     def __exit__(self, typ, value, traceback):
-        # Time can go backwards.
-        duration = max(default_timer() - self._start, 0)
+        duration = monotonic() - self._start
         self._callback(duration)
 
     def __call__(self, f):

--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from time import monotonic
+from monotonic import monotonic
 
 from .decorator import decorate
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist = coverage-clean,py26,py27,py34,py35,py36,py37,py38,pypy,pypy3,{py27,py3
 deps =
     coverage
     pytest
+    monotonic
 
 [testenv:py26]
 ; Last pytest and py version supported on py26 .

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
   pytest==2.9.2
   coverage
   futures
+  monotonic
 
 [testenv:py27]
 deps =


### PR DESCRIPTION
Use the monotonic timer to avoid issues with time going backwards, and a confusing comment. 