### PR TITLE
Travis CI: The sudo: tag is now fully deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 dist: xenial
-sudo: false
 cache:
   directories:
     - $HOME/.cache/pip
 
 language: python
 
-matrix:
+jobs:
   include:
     - python: "2.6"
       env: TOXENV=py26
@@ -23,13 +22,10 @@ matrix:
       env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37
-      sudo: true
     - python: "3.8"
       env: TOXENV=py38
-      sudo: true
     - python: "3.8"
       env: TOXENV=py38-nooptionals
-      sudo: true
     - python: "pypy"
       env: TOXENV=pypy
     - python: "pypy3"


### PR DESCRIPTION
__sudo:__ is now deprecated in Travis CI and it has been removed from the Travis docs.

Also: Travis CI has replaced the __matrix:__ keyword with __jobs:__