### PR TITLE
include tests on pypi distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include tests *
+prune tests/__pycache__


### PR DESCRIPTION
I'm trying to update the OpenBSD port of this software and add tests in the process.

In the packaging process the regression tests are used in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball would make that much easier.