### PR TITLE
Added Quart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,40 @@ uwsgi --http 127.0.0.1:8000 --wsgi-file myapp.py --callable app_dispatch
 
 Visit http://localhost:8000/metrics to see the metrics
 
+#### Quart
+
+To use Prometheus with [Quart](https://pgjones.gitlab.io/quart/) we need to
+serve metrics through a Prometheus ASGI application. This can be achieved using
+[Hypercorn's application dispatching](https://pgjones.gitlab.io/hypercorn/dispatch_apps.html).
+Below is a working example.
+
+Save the snippet below in a `myapp.py` file
+
+```python
+from quart import Quart
+from hypercorn.middleware import DispatcherMiddleware
+from prometheus_client import make_asgi_app
+
+# Create my app
+app = Quart(__name__)
+
+# Add Prometheus ASGI app to route /metrics
+app_dispatch = DispatcherMiddleware({
+    "/metrics": make_asgi_app(),
+    "/": app
+})
+```
+
+Run the example web application like this
+
+```bash
+# Install daphne if you do not have it
+pip install daphne
+daphne myapp:app_dispatch
+```
+
+Visit http://localhost:8000/ to see the metrics
+
 ### Node exporter textfile collector
 
 The [textfile collector](https://github.com/prometheus/node_exporter#textfile-collector)

--- a/README.md
+++ b/README.md
@@ -306,6 +306,32 @@ from prometheus_client import start_wsgi_server
 start_wsgi_server(8000)
 ```
 
+#### ASGI
+
+To use Prometheus with [ASGI](http://asgi.readthedocs.org/en/latest/), there is
+`make_asgi_app` which creates an ASGI application.
+
+Save the snippet below in a `myapp.py` file
+
+```python
+from prometheus_client import make_asgi_app
+
+app = make_asgi_app()
+```
+Such an application can be useful when integrating Prometheus metrics with ASGI
+apps.
+
+The app can be used to serve the metrics through an ASGI implementation, such
+as [daphne](https://github.com/django/daphne) or
+[uvicorn](https://www.uvicorn.org/).
+```bash
+# Install daphne if you do not have it
+pip install daphne
+daphne myapp:app
+```
+
+Visit http://localhost:8000/ to see the metrics
+
 #### Flask
 
 To use Prometheus with [Flask](http://flask.pocoo.org/) we need to serve metrics through a Prometheus WSGI application. This can be achieved using [Flask's application dispatching](http://flask.pocoo.org/docs/latest/patterns/appdispatch/). Below is a working example.

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -24,6 +24,11 @@ CONTENT_TYPE_LATEST = exposition.CONTENT_TYPE_LATEST
 generate_latest = exposition.generate_latest
 MetricsHandler = exposition.MetricsHandler
 make_wsgi_app = exposition.make_wsgi_app
+try:
+    # Python >3.5 only
+    make_asgi_app = exposition.make_asgi_app
+except:
+    pass
 start_http_server = exposition.start_http_server
 start_wsgi_server = exposition.start_wsgi_server
 write_to_textfile = exposition.write_to_textfile

--- a/prometheus_client/asgi.py
+++ b/prometheus_client/asgi.py
@@ -1,0 +1,34 @@
+from urllib.parse import parse_qs
+
+from .exposition import choose_encoder
+from .registry import REGISTRY
+
+
+def make_asgi_app(registry=REGISTRY):
+    """Create a ASGI app which serves the metrics from a registry."""
+
+    async def prometheus_app(scope, receive, send):
+        assert scope.get("type") == "http"
+        params = parse_qs(scope.get('query_string', b''))
+        r = registry
+        accept_header = "Accept: " + ",".join([
+            value.decode("utf8") for (name, value) in scope.get('headers')
+            if name.decode("utf8") == 'accept'
+        ])
+        encoder, content_type = choose_encoder(accept_header)
+        if 'name[]' in params:
+            r = r.restricted_registry(params['name[]'])
+        output = encoder(r)
+
+        payload = await receive()
+        if payload.get("type") == "http.request":
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [[b"Content-Type", content_type.encode('utf8')]],
+                }
+            )
+            await send({"type": "http.response.body", "body": output})
+
+    return prometheus_app

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -31,6 +31,7 @@ CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
 PYTHON26_OR_OLDER = sys.version_info < (2, 7)
 PYTHON376_OR_NEWER = sys.version_info > (3, 7, 5)
 
+
 def make_wsgi_app(registry=REGISTRY):
     """Create a WSGI app which serves the metrics from a registry."""
 
@@ -378,3 +379,10 @@ def instance_ip_grouping_key():
     with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as s:
         s.connect(('localhost', 0))
         return {'instance': s.getsockname()[0]}
+
+
+try:
+    # Python >3.5 only
+    from .asgi import make_asgi_app
+except:
+    pass


### PR DESCRIPTION
This PR builds ontop #512.

This PR introduces a Quart counterpart to the current Flask example.

This example is split off from the other PR as it currently does not work.
See: https://gitlab.com/pgjones/quart/issues/300
And the corresponding (but yet unreleased fix): https://gitlab.com/pgjones/hypercorn/commit/7da4c8e2542d702f9df11a5c8960d1181e079fb5