### PR TITLE
Raise exception when setting state in non-observable Enum

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -656,6 +656,7 @@ class Enum(MetricWrapperBase):
 
     def state(self, state):
         """Set enum metric state."""
+        self._raise_if_not_observable()
         with self._lock:
             self._value = self._states.index(state)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -428,6 +428,7 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(0, self.registry.get_sample_value('el', {'l': 'a', 'el': 'a'}))
         self.assertEqual(0, self.registry.get_sample_value('el', {'l': 'a', 'el': 'b'}))
         self.assertEqual(1, self.registry.get_sample_value('el', {'l': 'a', 'el': 'c'}))
+        self.assertRaises(ValueError, self.labels.state, 'a')
 
     def test_overlapping_labels(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
A fix for #501.