### PR TITLE
Cleaning up name before appending unit on name

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -27,12 +27,12 @@ def _build_full_name(metric_type, name, namespace, subsystem, unit):
     if subsystem:
         full_name += subsystem + '_'
     full_name += name
+    if metric_type == 'counter' and full_name.endswith('_total'):
+        full_name = full_name[:-6]  # Munge to OpenMetrics.
     if unit and not full_name.endswith("_" + unit):
         full_name += "_" + unit
     if unit and metric_type in ('info', 'stateset'):
         raise ValueError('Metric name is of a type that cannot have a unit: ' + full_name)
-    if metric_type == 'counter' and full_name.endswith('_total'):
-        full_name = full_name[:-6]  # Munge to OpenMetrics.
     return full_name
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -527,6 +527,11 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertRaises(ValueError, Info, 'foo', 'help', unit="x")
         self.assertRaises(ValueError, Enum, 'foo', 'help', unit="x")
 
+    def test_name_cleanup_before_unit_append(self):
+        self.assertEqual(self.counter._name, 'c')
+        self.c = Counter('c_total', 'help', unit="total", labelnames=['l'], registry=self.registry)
+        self.assertEqual(self.c._name, 'c_total')
+
 
 class TestMetricFamilies(unittest.TestCase):
     def setUp(self):

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -61,6 +61,17 @@ cc_total 1.0
 cc_created 123.456
 """, generate_latest(self.registry))
 
+    def test_counter_name_unit_append(self):
+        c = Counter('requests', 'Request counter', unit="total", registry=self.registry)
+        c.inc()
+        self.assertEqual(b"""# HELP requests_total_total Request counter
+# TYPE requests_total_total counter
+requests_total_total 1.0
+# HELP requests_total_created Request counter
+# TYPE requests_total_created gauge
+requests_total_created 123.456
+""", generate_latest(self.registry))
+
     def test_counter_total(self):
         c = Counter('cc_total', 'A counter', registry=self.registry)
         c.inc()


### PR DESCRIPTION
Unit append in the name were being removed when *_total* exists. This moves the clean up before appending the unit. 

Refs https://github.com/prometheus/client_python/issues/542

@brian-brazil Should this "repeated" unit raise an ValueError exception instead since this suffix is already append when dumping on WSGI.