### PR TITLE
Add usage with Bottle framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,21 @@ uwsgi --http 127.0.0.1:8000 --wsgi-file myapp.py --callable app_dispatch
 
 Visit http://localhost:8000/metrics to see the metrics
 
+#### Bottle
+
+To use Prometheus with [Bottle](https://bottlepy.org/) we need to serve metrics through a Prometheus WSGI application. This can be achieved using [Bottle's `mount` API](https://bottlepy.org/docs/dev/api.html#bottle.Bottle.mount). Below is a working example.
+
+```python
+from bottle import Bottle
+from prometheus_client import make_wsgi_app
+
+app = Bottle()
+app.mount("/metrics", make_wsgi_app())
+app.run(host='localhost', port=8000)
+```
+
+Visit http://localhost:8000/metrics to see the metrics.
+
 ### Node exporter textfile collector
 
 The [textfile collector](https://github.com/prometheus/node_exporter#textfile-collector)


### PR DESCRIPTION
There was an issue which asks how to use client_python with Bottle framework (#122) but it wasn't documented in `README.md`. For convenience of users, I'm proposing to add an example with Bottle to README. This example is different from what was proposed in #122 and closer to one for Flask.