### PR TITLE
Ignore utf-8 errors in generate_latest

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -144,7 +144,7 @@ def generate_latest(registry=REGISTRY):
                                                        metric.documentation.replace('\\', r'\\').replace('\n', r'\n')))
             output.append('# TYPE {0}{1} gauge\n'.format(metric.name, suffix))
             output.extend(lines)
-    return ''.join(output).encode('utf-8')
+    return ''.join(output).encode('utf-8', errors='ignore')
 
 
 def choose_encoder(accept_header):


### PR DESCRIPTION
This little f*cker has almost cost us draining our monthly Sentry events limit in the beginning of the month. There was an incoming label or other text with broken Unicode, which resulted in

```
'utf-8' codec can't encode character '\udca0' in position 2210: surrogates not allowed
```

(the position is random, never repeats)

We `generate_latest()` every few seconds as the main part of server health checks. Python 3.8. Once it started erroring, it never stopped on multiple servers. So stressful.