### PR TITLE
Fix python3 deprecation warnings

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -753,7 +753,7 @@ class TestCollectorRegistry(unittest.TestCase):
 
         m = Metric('s', 'help', 'summary')
         m.samples = [Sample('s_sum', {}, 7)]
-        self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())
+        self.assertEqual([m], registry.restricted_registry(['s_sum']).collect())
 
     def test_target_info_injected(self):
         registry = CollectorRegistry(target_info={'foo': 'bar'})
@@ -777,11 +777,11 @@ class TestCollectorRegistry(unittest.TestCase):
 
         m = Metric('s', 'help', 'summary')
         m.samples = [Sample('s_sum', {}, 7)]
-        self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())
+        self.assertEqual([m], registry.restricted_registry(['s_sum']).collect())
 
         m = Metric('target', 'Target metadata', 'info')
         m.samples = [Sample('target_info', {'foo': 'bar'}, 1)]
-        self.assertEquals([m], registry.restricted_registry(['target_info']).collect())
+        self.assertEqual([m], registry.restricted_registry(['target_info']).collect())
 
 
 if __name__ == '__main__':

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from concurrent.futures import ThreadPoolExecutor
-import inspect
 import time
 
 import pytest
@@ -12,6 +11,7 @@ from prometheus_client.core import (
     HistogramMetricFamily, Info, InfoMetricFamily, Metric, Sample,
     StateSetMetricFamily, Summary, SummaryMetricFamily, UntypedMetricFamily,
 )
+from prometheus_client.decorator import getargspec
 
 try:
     import unittest2 as unittest
@@ -46,7 +46,7 @@ class TestCounter(unittest.TestCase):
             else:
                 raise TypeError
 
-        self.assertEqual((["r"], None, None, None), inspect.getargspec(f))
+        self.assertEqual((["r"], None, None, None), getargspec(f))
 
         try:
             f(False)
@@ -107,7 +107,7 @@ class TestGauge(unittest.TestCase):
         def f():
             self.assertEqual(1, self.registry.get_sample_value('g'))
 
-        self.assertEqual(([], None, None, None), inspect.getargspec(f))
+        self.assertEqual(([], None, None, None), getargspec(f))
 
         f()
         self.assertEqual(0, self.registry.get_sample_value('g'))
@@ -134,7 +134,7 @@ class TestGauge(unittest.TestCase):
         def f():
             time.sleep(.001)
 
-        self.assertEqual(([], None, None, None), inspect.getargspec(f))
+        self.assertEqual(([], None, None, None), getargspec(f))
 
         f()
         self.assertNotEqual(0, self.registry.get_sample_value('g'))
@@ -204,7 +204,7 @@ class TestSummary(unittest.TestCase):
         def f():
             pass
 
-        self.assertEqual(([], None, None, None), inspect.getargspec(f))
+        self.assertEqual(([], None, None, None), getargspec(f))
 
         f()
         self.assertEqual(1, self.registry.get_sample_value('s_count'))
@@ -345,7 +345,7 @@ class TestHistogram(unittest.TestCase):
         def f():
             pass
 
-        self.assertEqual(([], None, None, None), inspect.getargspec(f))
+        self.assertEqual(([], None, None, None), getargspec(f))
 
         f()
         self.assertEqual(1, self.registry.get_sample_value('h_count'))


### PR DESCRIPTION
Fix DeprecationWarning for `inspect.getargspec()` and `assertEquals`.

travis [build](https://travis-ci.org/github/prometheus/client_python/jobs/727362680) warnings.
```
=============================== warnings summary ===============================

tests/test_core.py::TestCounter::test_function_decorator

  /home/travis/build/prometheus/client_python/tests/test_core.py:49: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()

    self.assertEqual((["r"], None, None, None), inspect.getargspec(f))

tests/test_core.py::TestGauge::test_inprogress_function_decorator

  /home/travis/build/prometheus/client_python/tests/test_core.py:110: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()

    self.assertEqual(([], None, None, None), inspect.getargspec(f))

tests/test_core.py::TestGauge::test_time_function_decorator

  /home/travis/build/prometheus/client_python/tests/test_core.py:137: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()

    self.assertEqual(([], None, None, None), inspect.getargspec(f))

tests/test_core.py::TestSummary::test_function_decorator

  /home/travis/build/prometheus/client_python/tests/test_core.py:207: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()

    self.assertEqual(([], None, None, None), inspect.getargspec(f))

tests/test_core.py::TestHistogram::test_function_decorator

  /home/travis/build/prometheus/client_python/tests/test_core.py:348: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()

    self.assertEqual(([], None, None, None), inspect.getargspec(f))

tests/test_core.py::TestCollectorRegistry::test_restricted_registry

  /home/travis/build/prometheus/client_python/tests/test_core.py:755: DeprecationWarning: Please use assertEqual instead.

    self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())

tests/test_core.py::TestCollectorRegistry::test_target_info_restricted_registry

  /home/travis/build/prometheus/client_python/tests/test_core.py:779: DeprecationWarning: Please use assertEqual instead.

    self.assertEquals([m], registry.restricted_registry(['s_sum']).collect())

tests/test_core.py::TestCollectorRegistry::test_target_info_restricted_registry

  /home/travis/build/prometheus/client_python/tests/test_core.py:783: DeprecationWarning: Please use assertEqual instead.

    self.assertEquals([m], registry.restricted_registry(['target_info']).collect())

-- Docs: https://docs.pytest.org/en/stable/warnings.html

================== 251 passed, 5 skipped, 8 warnings in 4.38s ==================
```