### PR TITLE
Add example for initializing metrics with labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ c.labels(method='post', endpoint='/submit').inc()
 ```
 
 Metrics with labels are not initialized when declared, because the client can't
-know what values the label can have. It is reccommended to initialize the label
+know what values the label can have. It is recommended to initialize the label
 values by calling the `.label()` method alone:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -222,17 +222,13 @@ c.labels(method='post', endpoint='/submit').inc()
 
 Metrics with labels are not initialized when declared, because the client can't
 know what values the label can have. It is recommended to initialize the label
-values by calling the `.label()` method alone:
+values by calling the `.labels()` method alone:
 
 ```python
 from prometheus_client import Counter
 c = Counter('my_requests_total', 'HTTP Failures', ['method', 'endpoint'])
-# initialize the label values
 c.labels('get', '/')
 c.labels('post', '/submit')
-# then use the metrics as normal
-c.labels('get', '/').inc()
-c.labels('post', '/submit').inc()
 ```
 
 ### Process Collector

--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ Taking a counter as an example:
 ```python
 from prometheus_client import Counter
 c = Counter('my_requests_total', 'HTTP Failures', ['method', 'endpoint'])
+# when using labels, metrics are not initialized at creation
+# to initialize them (highly reccommended) use .labels() without e.g. .inc()
+c.labels('get', '/')
+c.labels('post', '/submit')
+# then use the metrics as normal
 c.labels('get', '/').inc()
 c.labels('post', '/submit').inc()
 ```

--- a/README.md
+++ b/README.md
@@ -207,11 +207,6 @@ Taking a counter as an example:
 ```python
 from prometheus_client import Counter
 c = Counter('my_requests_total', 'HTTP Failures', ['method', 'endpoint'])
-# when using labels, metrics are not initialized at creation
-# to initialize them (highly reccommended) use .labels() without e.g. .inc()
-c.labels('get', '/')
-c.labels('post', '/submit')
-# then use the metrics as normal
 c.labels('get', '/').inc()
 c.labels('post', '/submit').inc()
 ```
@@ -223,6 +218,21 @@ from prometheus_client import Counter
 c = Counter('my_requests_total', 'HTTP Failures', ['method', 'endpoint'])
 c.labels(method='get', endpoint='/').inc()
 c.labels(method='post', endpoint='/submit').inc()
+```
+
+Metrics with labels are not initialized when declared, because the client can't
+know what values the label can have. It is reccommended to initialize the label
+values by calling the `.label()` method alone:
+
+```python
+from prometheus_client import Counter
+c = Counter('my_requests_total', 'HTTP Failures', ['method', 'endpoint'])
+# initialize the label values
+c.labels('get', '/')
+c.labels('post', '/submit')
+# then use the metrics as normal
+c.labels('get', '/').inc()
+c.labels('post', '/submit').inc()
 ```
 
 ### Process Collector


### PR DESCRIPTION
I know metrics should be initialized, but I wasn't able to find how to do it if they have labels in this doc. I eventually found the answer in [Brian's blog](https://www.robustperception.io/existential-issues-with-metrics), which is always an amazing source.