### PR TITLE
Make OM code effectively 100% covered.

### DIFF
--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -529,10 +529,7 @@ def text_fd_to_metric_families(fd):
             if parts[1] == 'HELP':
                 if documentation is not None:
                     raise ValueError("More than one HELP for metric: " + line)
-                if len(parts) == 4:
-                    documentation = _unescape_help(parts[3])
-                elif len(parts) == 3:
-                    raise ValueError("Invalid line: " + line)
+                documentation = _unescape_help(parts[3])
             elif parts[1] == 'TYPE':
                 if typ is not None:
                     raise ValueError("More than one TYPE for metric: " + line)

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -48,6 +48,12 @@ class TestGenerateText(unittest.TestCase):
         self.assertEqual(b'# HELP cc A counter\n# TYPE cc counter\ncc_total 1.0\ncc_created 123.456\n# EOF\n',
                          generate_latest(self.registry))
 
+    def test_counter_unit(self):
+        c = Counter('cc_seconds', 'A counter', registry=self.registry, unit="seconds")
+        c.inc()
+        self.assertEqual(b'# HELP cc_seconds A counter\n# TYPE cc_seconds counter\n# UNIT cc_seconds seconds\ncc_seconds_total 1.0\ncc_seconds_created 123.456\n# EOF\n',
+                         generate_latest(self.registry))
+
     def test_gauge(self):
         g = Gauge('gg', 'A gauge', registry=self.registry)
         g.set(17)


### PR DESCRIPTION
Also remove some dead code. The untaken branches claimed by coverage are
due to loops that always iterate at least once, or because state
machines only ever have known states.

@robskillington this is mostly testing the parser implementation, but this caught some missing general cases too.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>