### PR TITLE
Fix Package Name typo in pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The official Python 2 and 3 client for [Prometheus](http://prometheus.io).
 
 **One**: Install the client:
 ```
-pip install prometheus_client
+pip install prometheus-client
 ```
 
 **Two**: Paste the following into a Python interpreter:


### PR DESCRIPTION
Change package name in pip install instructions to match pypi with - instead of _