### PR TITLE
Add tags support to GraphiteBridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Graphite [tags](https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old
 ```python
 from prometheus_client.bridge.graphite import GraphiteBridge
 
-gb = GraphiteBridge(('graphite.your.org', 2003, tags=True))
+gb = GraphiteBridge(('graphite.your.org', 2003), tags=True)
 c = Counter('my_requests_total', 'HTTP Failures', ['method', 'endpoint'])
 c.labels('get', '/').inc()
 gb.push()

--- a/README.md
+++ b/README.md
@@ -440,11 +440,22 @@ Metrics are pushed over TCP in the Graphite plaintext format.
 ```python
 from prometheus_client.bridge.graphite import GraphiteBridge
 
-gb = GraphiteBridge(('graphite.your.org', 2003))
+gb = GraphiteBridge('graphite.your.org', 2003)
 # Push once.
 gb.push()
 # Push every 10 seconds in a daemon thread.
 gb.start(10.0)
+```
+
+Graphite [tags](https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old-dog-new-tricks/) are also supported.
+
+```python
+from prometheus_client.bridge.graphite import GraphiteBridge
+
+gb = GraphiteBridge('graphite.your.org', 2003, tags=True)
+c = Counter('my_requests_total', 'HTTP Failures', ['method', 'endpoint'])
+c.labels('get', '/').inc()
+gb.push()
 ```
 
 ## Custom Collectors

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Metrics are pushed over TCP in the Graphite plaintext format.
 ```python
 from prometheus_client.bridge.graphite import GraphiteBridge
 
-gb = GraphiteBridge('graphite.your.org', 2003)
+gb = GraphiteBridge(('graphite.your.org', 2003))
 # Push once.
 gb.push()
 # Push every 10 seconds in a daemon thread.
@@ -452,7 +452,7 @@ Graphite [tags](https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old
 ```python
 from prometheus_client.bridge.graphite import GraphiteBridge
 
-gb = GraphiteBridge('graphite.your.org', 2003, tags=True)
+gb = GraphiteBridge(('graphite.your.org', 2003, tags=True))
 c = Counter('my_requests_total', 'HTTP Failures', ['method', 'endpoint'])
 c.labels('get', '/').inc()
 gb.push()

--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -46,7 +46,7 @@ class _RegularPush(threading.Thread):
 
 
 class GraphiteBridge(object):
-    def __init__(self, address, registry=REGISTRY, tags=False, timeout_seconds=30, _timer=time.time):
+    def __init__(self, address, registry=REGISTRY, timeout_seconds=30, _timer=time.time, tags=False):
         self._address = address
         self._registry = registry
         self._tags = tags

--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -46,9 +46,10 @@ class _RegularPush(threading.Thread):
 
 
 class GraphiteBridge(object):
-    def __init__(self, address, registry=REGISTRY, timeout_seconds=30, _timer=time.time):
+    def __init__(self, address, registry=REGISTRY, tags=False, timeout_seconds=30, _timer=time.time):
         self._address = address
         self._registry = registry
+        self._tags = tags
         self._timeout = timeout_seconds
         self._timer = _timer
 
@@ -63,8 +64,14 @@ class GraphiteBridge(object):
         for metric in self._registry.collect():
             for s in metric.samples:
                 if s.labels:
-                    labelstr = '.' + '.'.join(
-                        ['{0}.{1}'.format(
+                    if self._tags:
+                        sep = ';'
+                        fmt = '{0}={1}'
+                    else:
+                        sep = '.'
+                        fmt = '{0}.{1}'
+                    labelstr = sep + sep.join(
+                        [fmt.format(
                             _sanitize(k), _sanitize(v))
                             for k, v in sorted(s.labels.items())])
                 else:


### PR DESCRIPTION
Graphite has support for tagged metrics with a syntax very similar to
the non-tagged format.  Update GraphiteBridge to support it.

Graphite's carbon tags format is explained here: https://grafana.com/blog/2018/01/11/graphite-1.1-teaching-an-old-dog-new-tricks

@brian-brazil 