### PR TITLE
add lock() and unlock() methods to registry class

### DIFF
--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -149,5 +149,11 @@ class CollectorRegistry(object):
                     return s.value
         return None
 
+    def lock(self):
+        self._lock.acquire()
+
+    def unlock(self):
+        self._lock.release()
+
 
 REGISTRY = CollectorRegistry(auto_describe=True)


### PR DESCRIPTION
I write code that polls a large number of devices via threads and then feed the complete set of results into the registry as a big chunk and want all the data consistent at each scrape and that requires locking.  To that end, I have been using a wrapper class to implement locking for a while and thought others might find it helpful if the internal locking were presented directly.