### PR TITLE
Changelog: None Type Handling

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -90,6 +90,8 @@ def generate_latest(registry=REGISTRY):
 
     def sample_line(line):
         if line.labels:
+            if 'method' in line.labels and line.labels['method'] is None:
+                line.labels['method'] = "GET request"
             labelstr = '{{{0}}}'.format(','.join(
                 ['{0}="{1}"'.format(
                     k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))


### PR DESCRIPTION
Handing None Type error from prometheus_client/exposition.py.
Error appears when using locust_requests where the method return a None type in line

{'path': 'Aggregated', 'method': None}

