### PR TITLE
Implement redirect handler option.

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -10,7 +10,7 @@ from wsgiref.simple_server import make_server, WSGIRequestHandler, WSGIServer
 
 from .openmetrics import exposition as openmetrics
 from .registry import REGISTRY
-from .utils import floatToGoString
+from .utils import floatToGoString, PrometheusRedirectHandler
 
 try:
     from urllib import quote_plus
@@ -141,7 +141,7 @@ def generate_latest(registry=REGISTRY):
             raise
 
         for suffix, lines in sorted(om_samples.items()):
-            output.append('# HELP {0}{1} {2}\n'.format(metric.name, suffix, 
+            output.append('# HELP {0}{1} {2}\n'.format(metric.name, suffix,
                                                        metric.documentation.replace('\\', r'\\').replace('\n', r'\n')))
             output.append('# TYPE {0}{1} gauge\n'.format(metric.name, suffix))
             output.extend(lines)
@@ -205,22 +205,41 @@ def write_to_textfile(path, registry):
     os.rename(tmppath, path)
 
 
-def default_handler(url, method, timeout, headers, data):
-    """Default handler that implements HTTP/HTTPS connections.
-
-    Used by the push_to_gateway functions. Can be re-used by other handlers."""
+def _make_handler(url, method, timeout, headers, data, base_handler):
 
     def handle():
         request = Request(url, data=data)
         request.get_method = lambda: method
         for k, v in headers:
             request.add_header(k, v)
-        resp = build_opener(HTTPHandler).open(request, timeout=timeout)
+        resp = build_opener(base_handler).open(request, timeout=timeout)
         if resp.code >= 400:
             raise IOError("error talking to pushgateway: {0} {1}".format(
                 resp.code, resp.msg))
 
     return handle
+
+
+def default_handler(url, method, timeout, headers, data):
+    """Default handler that implements HTTP/HTTPS connections.
+
+    Used by the push_to_gateway functions. Can be re-used by other handlers."""
+
+    return _make_handler(url, method, timeout, headers, data, HTTPHandler)
+
+
+def passthrough_redirect_handler(url, method, timeout, headers, data):
+    """
+    Handler that automatically trusts redirect responses for all HTTP methods.
+
+    Augments standard HTTPRedirectHandler capability by permitting PUT requests,
+    preserving the method upon redirect, and passing through all headers and
+    data from the original request. Only use this handler if you control or
+    trust the source of redirect responses you encounter when making requests
+    via the Prometheus client. This handler will simply repeat the identical
+    request, including same method and data, to the new redirect URL."""
+
+    return _make_handler(url, method, timeout, headers, data, PrometheusRedirectHandler)
 
 
 def basic_auth_handler(url, method, timeout, headers, data, username=None, password=None):

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -17,7 +17,9 @@ try:
 
     from BaseHTTPServer import BaseHTTPRequestHandler
     from SocketServer import ThreadingMixIn
-    from urllib2 import build_opener, HTTPError, HTTPHandler, HTTPRedirectHandler, Request
+    from urllib2 import (
+        build_opener, HTTPError, HTTPHandler, HTTPRedirectHandler, Request,
+    )
     from urlparse import parse_qs, urlparse
 except ImportError:
     # Python 3
@@ -25,7 +27,9 @@ except ImportError:
     from socketserver import ThreadingMixIn
     from urllib.error import HTTPError
     from urllib.parse import parse_qs, quote_plus, urlparse
-    from urllib.request import build_opener, HTTPHandler, HTTPRedirectHandler, Request
+    from urllib.request import (
+        build_opener, HTTPHandler, HTTPRedirectHandler, Request,
+    )
 
 CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
 """Content type of the latest text format"""

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -33,7 +33,7 @@ except ImportError:
 
 CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
 """Content type of the latest text format"""
-PYTHON27_OR_OLDER = sys.version_info <= (2, 7)
+PYTHON27_OR_OLDER = sys.version_info < (3, )
 PYTHON26_OR_OLDER = sys.version_info < (2, 7)
 PYTHON376_OR_NEWER = sys.version_info > (3, 7, 5)
 

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -10,27 +10,87 @@ from wsgiref.simple_server import make_server, WSGIRequestHandler, WSGIServer
 
 from .openmetrics import exposition as openmetrics
 from .registry import REGISTRY
-from .utils import floatToGoString, PrometheusRedirectHandler
+from .utils import floatToGoString
 
 try:
     from urllib import quote_plus
 
     from BaseHTTPServer import BaseHTTPRequestHandler
     from SocketServer import ThreadingMixIn
-    from urllib2 import build_opener, HTTPHandler, Request
+    from urllib2 import build_opener, HTTPError, HTTPHandler, HTTPRedirectHandler, Request
     from urlparse import parse_qs, urlparse
 except ImportError:
     # Python 3
     from http.server import BaseHTTPRequestHandler
     from socketserver import ThreadingMixIn
+    from urllib.error import HTTPError
     from urllib.parse import parse_qs, quote_plus, urlparse
-    from urllib.request import build_opener, HTTPHandler, Request
+    from urllib.request import build_opener, HTTPHandler, HTTPRedirectHandler, Request
 
 CONTENT_TYPE_LATEST = str('text/plain; version=0.0.4; charset=utf-8')
 """Content type of the latest text format"""
-
+PYTHON27_OR_OLDER = sys.version_info <= (2, 7)
 PYTHON26_OR_OLDER = sys.version_info < (2, 7)
 PYTHON376_OR_NEWER = sys.version_info > (3, 7, 5)
+
+
+class _PrometheusRedirectHandler(HTTPRedirectHandler):
+    """
+    Allow additional methods (e.g. PUT) and data forwarding in redirects.
+
+    Use of this class constitute a user's explicit agreement to the
+    redirect responses the Prometheus client will receive when using it.
+    You should only use this class if you control or otherwise trust the
+    redirect behavior involved and are certain it is safe to full transfer
+    the original request (method and data) to the redirected URL. For
+    example, if you know there is a cosmetic URL redirect in front of a
+    local deployment of a Prometheus server, and all redirects are safe,
+    this is the class to use to handle redirects in that case.
+
+    The standard HTTPRedirectHandler does not forward request data nor
+    does it allow redirected PUT requests (which Prometheus uses for some
+    operations, for example `push_to_gateway`) because these cannot
+    generically guarantee no violations of HTTP RFC 2616 requirements for
+    the user to explicitly confirm redirects that could have unexpected
+    side effects (such as rendering a PUT request non-idempotent or
+    creating multiple resources not named in the original request).
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        """
+        Apply redirect logic to a request.
+
+        See parent HTTPRedirectHandler.redirect_request for parameter info.
+
+        If the redirect is disallowed, this raises the corresponding HTTP error.
+        If the redirect can't be determined, return None to allow other handlers
+        to try. If the redirect is allowed, return the new request.
+
+        This method specialized for the case when (a) the user knows that the
+        redirect will not cause unacceptable side effects for any request method,
+        and (b) the user knows that any request data should be passed through to
+        the redirect. If either condition is not met, this should not be used.
+        """
+        # note that requests being provided by a handler will use get_method to
+        # indicate the method, by monkeypatching this, instead of setting the
+        # Request object's method attribute.
+        m = getattr(req, "method", req.get_method())
+        if not (code in (301, 302, 303, 307) and m in ("GET", "HEAD")
+                or code in (301, 302, 303) and m in ("POST", "PUT")):
+            raise HTTPError(req.full_url, code, msg, headers, fp)
+        new_request = Request(
+            newurl.replace(' ', '%20'),  # space escaping in new url if needed.
+            headers=req.headers,
+            origin_req_host=req.origin_req_host,
+            unverifiable=True,
+            data=req.data,
+        )
+        if PYTHON27_OR_OLDER:
+            # the `method` attribute did not exist for Request in Python 2.7.
+            new_request.get_method = lambda: m
+        else:
+            new_request.method = m
+        return new_request
 
 
 def _bake_output(registry, accept_header, params):
@@ -239,7 +299,7 @@ def passthrough_redirect_handler(url, method, timeout, headers, data):
     via the Prometheus client. This handler will simply repeat the identical
     request, including same method and data, to the new redirect URL."""
 
-    return _make_handler(url, method, timeout, headers, data, PrometheusRedirectHandler)
+    return _make_handler(url, method, timeout, headers, data, _PrometheusRedirectHandler)
 
 
 def basic_auth_handler(url, method, timeout, headers, data, username=None, password=None):

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -1,14 +1,5 @@
 import math
-import sys
 
-try:
-    from urllib2 import HTTPError, HTTPRedirectHandler, Request
-except ImportError:
-    # Python 3
-    from urllib.error import HTTPError
-    from urllib.request import HTTPRedirectHandler, Request
-
-PYTHON27_OR_OLDER = sys.version_info <= (2, 7)
 INF = float("inf")
 MINUS_INF = float("-inf")
 NaN = float("NaN")
@@ -31,62 +22,3 @@ def floatToGoString(d):
             mantissa = '{0}.{1}{2}'.format(s[0], s[1:dot], s[dot + 1:]).rstrip('0.')
             return '{0}e+0{1}'.format(mantissa, dot - 1)
         return s
-
-
-class PrometheusRedirectHandler(HTTPRedirectHandler):
-    """
-    Allow additional methods (e.g. PUT) and data forwarding in redirects.
-
-    Use of this class constitute a user's explicit agreement to the
-    redirect responses the Prometheus client will receive when using it.
-    You should only use this class if you control or otherwise trust the
-    redirect behavior involved and are certain it is safe to full transfer
-    the original request (method and data) to the redirected URL. For
-    example, if you know there is a cosmetic URL redirect in front of a
-    local deployment of a Prometheus server, and all redirects are safe,
-    this is the class to use to handle redirects in that case.
-
-    The standard HTTPRedirectHandler does not forward request data nor
-    does it allow redirected PUT requests (which Prometheus uses for some
-    operations, for example `push_to_gateway`) because these cannot
-    generically guarantee no violations of HTTP RFC 2616 requirements for
-    the user to explicitly confirm redirects that could have unexpected
-    side effects (such as rendering a PUT request non-idempotent or
-    creating multiple resources not named in the original request).
-    """
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        """
-        Apply redirect logic to a request.
-
-        See parent HTTPRedirectHandler.redirect_request for parameter info.
-
-        If the redirect is disallowed, this raises the corresponding HTTP error.
-        If the redirect can't be determined, return None to allow other handlers
-        to try. If the redirect is allowed, return the new request.
-
-        This method specialized for the case when (a) the user knows that the
-        redirect will not cause unacceptable side effects for any request method,
-        and (b) the user knows that any request data should be passed through to
-        the redirect. If either condition is not met, this should not be used.
-        """
-        # note that requests being provided by a handler will use get_method to
-        # indicate the method, by monkeypatching this, instead of setting the
-        # Request object's method attribute.
-        m = getattr(req, "method", req.get_method())
-        if not (code in (301, 302, 303, 307) and m in ("GET", "HEAD")
-                or code in (301, 302, 303) and m in ("POST", "PUT")):
-            raise HTTPError(req.full_url, code, msg, headers, fp)
-        new_request = Request(
-            newurl.replace(' ', '%20'),  # space escaping in new url if needed.
-            headers=req.headers,
-            origin_req_host=req.origin_req_host,
-            unverifiable=True,
-            data=req.data,
-        )
-        if PYTHON27_OR_OLDER:
-            # the `method` attribute did not exist for Request in Python 2.7.
-            new_request.get_method = lambda: m
-        else:
-            new_request.method = m
-        return new_request

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -1,5 +1,12 @@
 import math
 
+try:
+    from urllib2 import HTTPError, HTTPRedirectHandler, Request
+except ImportError:
+    # Python 3
+    from urllib.error import HTTPError
+    from urllib.request import HTTPRedirectHandler, Request
+
 INF = float("inf")
 MINUS_INF = float("-inf")
 NaN = float("NaN")
@@ -22,3 +29,57 @@ def floatToGoString(d):
             mantissa = '{0}.{1}{2}'.format(s[0], s[1:dot], s[dot + 1:]).rstrip('0.')
             return '{0}e+0{1}'.format(mantissa, dot - 1)
         return s
+
+
+class PrometheusRedirectHandler(HTTPRedirectHandler):
+    """
+    Allow additional methods (e.g. PUT) and data forwarding in redirects.
+
+    Use of this class constitute a user's explicit agreement to the
+    redirect responses the Prometheus client will receive when using it.
+    You should only use this class if you control or otherwise trust the
+    redirect behavior involved and are certain it is safe to full transfer
+    the original request (method and data) to the redirected URL. For
+    example, if you know there is a cosmetic URL redirect in front of a
+    local deployment of a Prometheus server, and all redirects are safe,
+    this is the class to use to handle redirects in that case.
+
+    The standard HTTPRedirectHandler does not forward request data nor
+    does it allow redirected PUT requests (which Prometheus uses for some
+    operations, for example `push_to_gateway`) because these cannot
+    generically guarantee no violations of HTTP RFC 2616 requirements for
+    the user to explicitly confirm redirects that could have unexpected
+    side effects (such as rendering a PUT request non-idempotent or
+    creating multiple resources not named in the original request).
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        """
+        Apply redirect logic to a request.
+
+        See parent HTTPRedirectHandler.redirect_request for parameter info.
+
+        If the redirect is disallowed, this raises the corresponding HTTP error.
+        If the redirect can't be determined, return None to allow other handlers
+        to try. If the redirect is allowed, return the new request.
+
+        This method specialized for the case when (a) the user knows that the
+        redirect will not cause unacceptable side effects for any request method,
+        and (b) the user knows that any request data should be passed through to
+        the redirect. If either condition is not met, this should not be used.
+        """
+        # note that requests being provided by a handler will use get_method to
+        # indicate the method, by monkeypatching this, instead of setting the
+        # Request object's method attribute.
+        m = getattr(req, "method", req.get_method())
+        if not (code in (301, 302, 303, 307) and m in ("GET", "HEAD")
+                or code in (301, 302, 303) and m in ("POST", "PUT")):
+            raise HTTPError(req.full_url, code, msg, headers, fp)
+        return Request(
+            newurl.replace(' ', '%20'),  # space escaping in new url if needed.
+            headers=req.headers,
+            origin_req_host=req.origin_req_host,
+            unverifiable=True,
+            data=req.data,
+            method=m
+        )

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -13,7 +13,8 @@ from prometheus_client import (
 )
 from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp
 from prometheus_client.exposition import (
-    basic_auth_handler, default_handler, MetricsHandler, passthrough_redirect_handler
+    basic_auth_handler, default_handler, MetricsHandler,
+    passthrough_redirect_handler,
 )
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
This fixes https://github.com/prometheus/client_python/issues/131 and a significant amount of content is discussed in that issue.

This PR adds a new redirect handler utility class that deliberately forwards an unmodified request to the `Location` header provided by a redirect, while preserving the method, headers and data of the original request. As discussed in comments of the PR, HTTP RFC 2616 requires explicit user approval for redirects in certain situations that may alter the meaning or effect of the request. Given this, the default `HTTPRedirectHandler` in `urllib` does not honor redirects for `PUT` and does not preserve all headers and data.

In the case of Prometheus, many users will have some type of in-house "private" deployment of a Prometheus pushgateway server, and e.g. in a deployment infrastructure like Kubernetes where the ultimate IP-based host address could change often, there may be a need for a purely cosmetic redirect that fronts this host address with an easier static URL. In that case, the user would like to "opt in" to trusted pass-through redirects for all method types (including PUT).

This PR provides `passthrough_redirect_handler` to support this specific redirect option. Use of this special redirect handler would constitute the user's explicit approval for RFC2616.

Additionally, this PR adds a new "redirect" HTTPD server to the unit tests for the pushgateway, in order to simulate a real redirect during testing and confirm it is handled as expected. I've locally validated all testing and flake8 instructions - and will work to resolve any requested changes or build issues.