### PR TITLE
Multiprocess environment variable in upper case

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ There's several steps to getting this working:
 
 **1. Gunicorn deployment**:
 
-The `prometheus_multiproc_dir` environment variable must be set to a directory
+The `PROMETHEUS_MULTIPROC_DIR` environment variable must be set to a directory
 that the client library can use for metrics. This directory must be wiped
 between Gunicorn runs (before startup is recommended).
 

--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ There's several steps to getting this working:
 
 **1. Gunicorn deployment**:
 
-The `PROMETHEUS_MULTIPROC_DIR` environment variable must be set to a directory
+The `prometheus_multiproc_dir` environment variable must be set to a directory
 that the client library can use for metrics. This directory must be wiped
 between Gunicorn runs (before startup is recommended).
 

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 import glob
 import json
 import os
+import warnings
 
 from .metrics_core import Metric
 from .mmap_dict import MmapedDict
@@ -23,6 +24,10 @@ class MultiProcessCollector(object):
 
     def __init__(self, registry, path=None):
         if path is None:
+            # This deprecation warning can go away in a few releases when removing the compatibility
+            if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
+                os.environ['PROMETHEUS_MULTIPROC_DIR'] = os.environ['prometheus_multiproc_dir']
+                warnings.warn("prometheus_multiproc_dir variable has been deprecated in favor of the upper case naming PROMETHEUS_MULTIPROC_DIR", DeprecationWarning)
             path = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
         if not path or not os.path.isdir(path):
             raise ValueError('env PROMETHEUS_MULTIPROC_DIR is not set or not a directory')

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -66,7 +66,7 @@ class MultiProcessCollector(object):
                     # the file is missing
                     continue
                 raise
-            for key, value, pos in file_values:
+            for key, value, _ in file_values:
                 metric_name, name, labels, labels_key = _parse_key(key)
 
                 metric = metrics.get(metric_name)

--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -23,9 +23,9 @@ class MultiProcessCollector(object):
 
     def __init__(self, registry, path=None):
         if path is None:
-            path = os.environ.get('prometheus_multiproc_dir')
+            path = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
         if not path or not os.path.isdir(path):
-            raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
+            raise ValueError('env PROMETHEUS_MULTIPROC_DIR is not set or not a directory')
         self._path = path
         if registry:
             registry.register(self)
@@ -152,7 +152,7 @@ class MultiProcessCollector(object):
 def mark_process_dead(pid, path=None):
     """Do bookkeeping for when one process dies in a multi-process setup."""
     if path is None:
-        path = os.environ.get('prometheus_multiproc_dir')
+        path = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
     for f in glob.glob(os.path.join(path, 'gauge_livesum_{0}.db'.format(pid))):
         os.remove(f)
     for f in glob.glob(os.path.join(path, 'gauge_liveall_{0}.db'.format(pid))):

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -54,10 +54,10 @@ def MultiProcessValue(process_identifier=os.getpid):
             self._params = typ, metric_name, name, labelnames, labelvalues, multiprocess_mode
             # This deprecation warning can go away in a few releases when removing the compatibility
             if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
-                warnings.warn("You have declared both env variable in upper case and lower case, keep the upper case only PROMETHEUS_MULTIPROC_DIR'", DeprecationWarning)
+                warnings.warn("You have declared both env variable in upper case and lower case, keep the upper case only PROMETHEUS_MULTIPROC_DIR", DeprecationWarning)
             if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
                 os.environ['PROMETHEUS_MULTIPROC_DIR'] = os.environ['prometheus_multiproc_dir']
-                warnings.warn("You should declare the env variable in upper case PROMETHEUS_MULTIPROC_DIR'", DeprecationWarning)
+                warnings.warn("You should declare the env variable in upper case PROMETHEUS_MULTIPROC_DIR", DeprecationWarning)
             with lock:
                 self.__check_for_pid_change()
                 self.__reset()

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os
 from threading import Lock
+import warnings
 
 from .mmap_dict import mmap_key, MmapedDict
 
@@ -64,7 +65,7 @@ def MultiProcessValue(process_identifier=os.getpid):
                 file_prefix = typ
             if file_prefix not in files:
                 filename = os.path.join(
-                    os.environ['prometheus_multiproc_dir'],
+                    os.environ.get('PROMETHEUS_MULTIPROC_DIR'),
                     '{0}_{1}.db'.format(file_prefix, pid['value']))
 
                 files[file_prefix] = MmapedDict(filename)
@@ -108,7 +109,10 @@ def get_value_class():
     # This needs to be chosen before the first metric is constructed,
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
-    if 'prometheus_multiproc_dir' in os.environ:
+    if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
+        os.environ['PROMETHEUS_MULTIPROC_DIR'] = os.environ['prometheus_multiproc_dir']
+        warnings.warn("You should declare the env variable in upper case PROMETHEUS_MULTIPROC_DIR'", DeprecationWarning)
+    if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
         return MultiProcessValue()
     else:
         return MutexValue

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -52,6 +52,12 @@ def MultiProcessValue(process_identifier=os.getpid):
 
         def __init__(self, typ, metric_name, name, labelnames, labelvalues, multiprocess_mode='', **kwargs):
             self._params = typ, metric_name, name, labelnames, labelvalues, multiprocess_mode
+            # This deprecation warning can go away in a few releases when removing the compatibility
+            if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+                warnings.warn("You have declared both env variable in upper case and lower case, keep the upper case only PROMETHEUS_MULTIPROC_DIR'", DeprecationWarning)
+            if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
+                os.environ['PROMETHEUS_MULTIPROC_DIR'] = os.environ['prometheus_multiproc_dir']
+                warnings.warn("You should declare the env variable in upper case PROMETHEUS_MULTIPROC_DIR'", DeprecationWarning)
             with lock:
                 self.__check_for_pid_change()
                 self.__reset()
@@ -109,10 +115,7 @@ def get_value_class():
     # This needs to be chosen before the first metric is constructed,
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
-    if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
-        os.environ['PROMETHEUS_MULTIPROC_DIR'] = os.environ['prometheus_multiproc_dir']
-        warnings.warn("You should declare the env variable in upper case PROMETHEUS_MULTIPROC_DIR'", DeprecationWarning)
-    if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+    if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
         return MultiProcessValue()
     else:
         return MutexValue

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -53,11 +53,9 @@ def MultiProcessValue(process_identifier=os.getpid):
         def __init__(self, typ, metric_name, name, labelnames, labelvalues, multiprocess_mode='', **kwargs):
             self._params = typ, metric_name, name, labelnames, labelvalues, multiprocess_mode
             # This deprecation warning can go away in a few releases when removing the compatibility
-            if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
-                warnings.warn("You have declared both env variable in upper case and lower case, keep the upper case only PROMETHEUS_MULTIPROC_DIR", DeprecationWarning)
             if 'prometheus_multiproc_dir' in os.environ and 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
                 os.environ['PROMETHEUS_MULTIPROC_DIR'] = os.environ['prometheus_multiproc_dir']
-                warnings.warn("You should declare the env variable in upper case PROMETHEUS_MULTIPROC_DIR", DeprecationWarning)
+                warnings.warn("prometheus_multiproc_dir variable has been deprecated in favor of the upper case naming PROMETHEUS_MULTIPROC_DIR", DeprecationWarning)
             with lock:
                 self.__check_for_pid_change()
                 self.__reset()

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -48,19 +48,6 @@ class TestMultiProcessDeprecation(unittest.TestCase):
             assert issubclass(w[-1].category, DeprecationWarning)
             assert "PROMETHEUS_MULTIPROC_DIR" in str(w[-1].message)
 
-    def test_both_variables_priority(self):
-        os.environ['prometheus_multiproc_dir'] = 'should not be picked'
-        os.environ['PROMETHEUS_MULTIPROC_DIR'] = self.tempdir
-        with warnings.catch_warnings(record=True) as w:
-            values.ValueClass = get_value_class()
-            registry = CollectorRegistry()
-            collector = MultiProcessCollector(registry, self.tempdir)
-            Counter('c', 'help', registry=None)
-
-            assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
-            assert "both" in str(w[-1].message)
-
 
 class TestMultiProcess(unittest.TestCase):
     def setUp(self):

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -14,7 +14,9 @@ from prometheus_client.core import (
 from prometheus_client.multiprocess import (
     mark_process_dead, MultiProcessCollector,
 )
-from prometheus_client.values import get_value_class, MultiProcessValue, MutexValue
+from prometheus_client.values import (
+    get_value_class, MultiProcessValue, MutexValue,
+)
 
 if sys.version_info < (2, 7):
     # We need the skip decorators from unittest2 on Python 2.6.

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -40,7 +40,7 @@ class TestMultiProcessDeprecation(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             values.ValueClass = get_value_class()
             registry = CollectorRegistry()
-            collector = MultiProcessCollector(registry, self.tempdir)
+            collector = MultiProcessCollector(registry)
             Counter('c', 'help', registry=None)
 
             assert os.environ['PROMETHEUS_MULTIPROC_DIR'] == self.tempdir
@@ -55,7 +55,7 @@ class TestMultiProcess(unittest.TestCase):
         os.environ['PROMETHEUS_MULTIPROC_DIR'] = self.tempdir
         values.ValueClass = MultiProcessValue(lambda: 123)
         self.registry = CollectorRegistry()
-        self.collector = MultiProcessCollector(self.registry, self.tempdir)
+        self.collector = MultiProcessCollector(self.registry)
 
     @property
     def _value_class(self):
@@ -107,7 +107,7 @@ class TestMultiProcess(unittest.TestCase):
         self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
         g1.set(1)
         g2.set(2)
-        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
+        mark_process_dead(123)
         self.assertEqual(1, self.registry.get_sample_value('g', {'pid': '123'}))
         self.assertEqual(2, self.registry.get_sample_value('g', {'pid': '456'}))
 

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -14,7 +14,7 @@ from prometheus_client.core import (
 from prometheus_client.multiprocess import (
     mark_process_dead, MultiProcessCollector,
 )
-from prometheus_client.values import MultiProcessValue, MutexValue, get_value_class
+from prometheus_client.values import get_value_class, MultiProcessValue, MutexValue
 
 if sys.version_info < (2, 7):
     # We need the skip decorators from unittest2 on Python 2.6.


### PR DESCRIPTION
I would like to propose a change to move the `prometheus_multiproc_dir` env variable in upper case to follow the convention of such variable. It feels strange to have to declare it in lower case.

The code adds a deprecation warning to inform the user about the change and transform it to upper case if needed. It also take care of precedence in case both are declared.