### PR TITLE
Add separate handling of the /favicon.ico path in the default wsgi implementation

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -49,8 +49,14 @@ def make_wsgi_app(registry=REGISTRY):
         # Prepare parameters
         accept_header = environ.get('HTTP_ACCEPT')
         params = parse_qs(environ.get('QUERY_STRING', ''))
-        # Bake output
-        status, header, output = _bake_output(registry, accept_header, params)
+        if environ['PATH_INFO'] == '/favicon.ico':
+            # Serve empty response for browsers
+            status = '200 OK'
+            header = ('', '')
+            output = b''
+        else:
+            # Bake output
+            status, header, output = _bake_output(registry, accept_header, params)
         # Return output
         start_response(status, [header])
         return [output]


### PR DESCRIPTION
By default many browsers will attempt to load a /favicon.ico resource from the server. Currently the default wsgi implementation serves metrics on any path and thus will incorrectly return metrics when being asked for a favicon. This PR fixes this behavior by serving an empty response.