### PR TITLE
Add a clear() method to metric objects to remove all labelsets

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -186,6 +186,11 @@ class MetricWrapperBase(object):
         with self._lock:
             del self._metrics[labelvalues]
 
+    def clear(self):
+        """Remove all labelsets from the metric"""
+        with self._lock:
+            self._metrics = {}
+
     def _samples(self):
         if self._is_parent():
             return self._multi_samples()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -456,6 +456,15 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertEqual(None, self.registry.get_sample_value('c_total', {'l': 'x'}))
         self.assertEqual(2, self.registry.get_sample_value('c_total', {'l': 'y'}))
 
+    def test_clear(self):
+        self.counter.labels('x').inc()
+        self.counter.labels('y').inc(2)
+        self.assertEqual(1, self.registry.get_sample_value('c_total', {'l': 'x'}))
+        self.assertEqual(2, self.registry.get_sample_value('c_total', {'l': 'y'}))
+        self.counter.clear()
+        self.assertEqual(None, self.registry.get_sample_value('c_total', {'l': 'x'}))
+        self.assertEqual(None, self.registry.get_sample_value('c_total', {'l': 'y'}))
+
     def test_incorrect_label_count_raises(self):
         self.assertRaises(ValueError, self.counter.labels)
         self.assertRaises(ValueError, self.counter.labels, 'a', 'b')


### PR DESCRIPTION
Hello @brian-brazil, 

I wanted to test metric values in my application unit tests but I didn't figured out how to do it (I probably missed something). That's why I propose to add this simple `reset()` method. Do you think it can be useful? Or is there a better way to test than reseting metrics at the beginning of the test?

And thank you for this very useful lib!