### PR TITLE
mark_process_dead respects old env var

### DIFF
--- a/prometheus_client/multiprocess.py
+++ b/prometheus_client/multiprocess.py
@@ -157,7 +157,7 @@ class MultiProcessCollector(object):
 def mark_process_dead(pid, path=None):
     """Do bookkeeping for when one process dies in a multi-process setup."""
     if path is None:
-        path = os.environ.get('PROMETHEUS_MULTIPROC_DIR')
+        path = os.environ.get('PROMETHEUS_MULTIPROC_DIR', os.environ.get('prometheus_multiproc_dir'))
     for f in glob.glob(os.path.join(path, 'gauge_livesum_{0}.db'.format(pid))):
         os.remove(f)
     for f in glob.glob(os.path.join(path, 'gauge_liveall_{0}.db'.format(pid))):

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -30,8 +30,8 @@ class TestMultiProcessDeprecation(unittest.TestCase):
         self.tempdir = tempfile.mkdtemp()
 
     def tearDown(self):
-        del os.environ['prometheus_multiproc_dir']
-        del os.environ['PROMETHEUS_MULTIPROC_DIR']
+        os.environ.pop('prometheus_multiproc_dir', None)
+        os.environ.pop('PROMETHEUS_MULTIPROC_DIR', None)
         values.ValueClass = MutexValue
         shutil.rmtree(self.tempdir)
 
@@ -47,6 +47,12 @@ class TestMultiProcessDeprecation(unittest.TestCase):
             assert len(w) == 1
             assert issubclass(w[-1].category, DeprecationWarning)
             assert "PROMETHEUS_MULTIPROC_DIR" in str(w[-1].message)
+
+    def test_mark_process_dead_respects_lowercase(self):
+        os.environ['prometheus_multiproc_dir'] = self.tempdir
+        # Just test that this does not raise with a lowercase env var. The
+        # logic is tested elsewhere.
+        mark_process_dead(123)
 
 
 class TestMultiProcess(unittest.TestCase):


### PR DESCRIPTION
Some users use mark_process_dead without going through any of the
`__init__()` logic which sets the new environment variable.

I chose not to put in the warnings in another place as a user will go
through the deprecation path somewhere already.

Fixes #643 