### PR TITLE
allow textfile to be overwritten on windows

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -271,8 +271,20 @@ def write_to_textfile(path, registry):
     tmppath = '%s.%s.%s' % (path, os.getpid(), threading.current_thread().ident)
     with open(tmppath, 'wb') as f:
         f.write(generate_latest(registry))
-    # rename(2) is atomic.
-    os.rename(tmppath, path)
+    
+    # rename(2) is atomic but fails on Windows if the destination file exists
+    if os.name == 'posix':
+        os.rename(tmppath, path)
+    else:
+        if sys.version_info <= (3,3):
+            # Unable to guarantee atomic rename on Windows and Python<3.3
+            # Remove and rename instead (risks losing the file)
+            os.remove(path)
+            os.rename(tmppath, path)
+        else:
+            # os.replace is introduced in Python 3.3 but there is some dispute whether
+            # it is a truly atomic file operation: https://bugs.python.org/issue8828
+            os.replace(tmppath, path)
 
 
 def _make_handler(url, method, timeout, headers, data, base_handler):

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -276,7 +276,7 @@ def write_to_textfile(path, registry):
     if os.name == 'posix':
         os.rename(tmppath, path)
     else:
-        if sys.version_info <= (3,3):
+        if sys.version_info <= (3, 3):
             # Unable to guarantee atomic rename on Windows and Python<3.3
             # Remove and rename instead (risks losing the file)
             os.remove(path)

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -277,7 +277,11 @@ def write_to_textfile(path, registry):
         if sys.version_info <= (3, 3):
             # Unable to guarantee atomic rename on Windows and Python<3.3
             # Remove and rename instead (risks losing the file)
-            os.remove(path)
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
             os.rename(tmppath, path)
         else:
             # os.replace is introduced in Python 3.3 but there is some dispute whether

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -273,9 +273,7 @@ def write_to_textfile(path, registry):
         f.write(generate_latest(registry))
     
     # rename(2) is atomic but fails on Windows if the destination file exists
-    if os.name == 'posix':
-        os.rename(tmppath, path)
-    else:
+    if os.name == 'nt':
         if sys.version_info <= (3, 3):
             # Unable to guarantee atomic rename on Windows and Python<3.3
             # Remove and rename instead (risks losing the file)
@@ -285,6 +283,8 @@ def write_to_textfile(path, registry):
             # os.replace is introduced in Python 3.3 but there is some dispute whether
             # it is a truly atomic file operation: https://bugs.python.org/issue8828
             os.replace(tmppath, path)
+    else:
+        os.rename(tmppath, path)
 
 
 def _make_handler(url, method, timeout, headers, data, base_handler):


### PR DESCRIPTION
This is a prospective fix for issue #649 

For POSIX installations, nothing changes. For Windows installations, if python>=3.3 is detected, it will use `os.replace`, else it will do a double operation of `os.remove` followed by `os.rename`, either of which may fail and result in (temporarily or permanently) broken metrics.

This can be refined to catch such errors.