### PR TITLE
Do not use attrs 21.1.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist = coverage-clean,py2.7,py3.4,py3.5,py3.6,py3.7,py3.8,py3.9,pypy2.7,pypy3
 deps =
     coverage
     pytest
+; Python 3.4 fails if using 21.1.0.
+    attrs!=21.1.0
 
 [testenv:py2.7]
 deps =


### PR DESCRIPTION
Attrs 21.1.0 does not work with Python 3.4. The release has been yanked
from pypi, but will still get used sometimes, so specify not to install
21.1.0.

Signed-off-by: Chris Marchbanks <csmarchbanks@gmail.com>