### PR TITLE
[#674, #675] Mitigate performance regression by filtering restricted registry collections

### DIFF
--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -135,18 +135,16 @@ class RestrictedRegistry(object):
         self._registry = registry
 
     def collect(self):
-        names = copy.copy(self._name_set)
         collectors = set()
-        yield_target_info = False
+        target_info_metric = None
         with self._registry._lock:
-            if 'target_info' in names and self._registry._target_info:
-                yield_target_info = True
-                names.remove('target_info')
-            for name in names:
-                if name in self._registry._names_to_collectors:
+            if 'target_info' in self._name_set and self._registry._target_info:
+                target_info_metric = self._registry._target_info_metric()
+            for name in self._name_set:
+                if name != 'target_info' and name in self._registry._names_to_collectors:
                     collectors.add(self._registry._names_to_collectors[name])
-        if yield_target_info:
-            yield self._registry._target_info_metric()
+        if target_info_metric:
+            yield target_info_metric
         for collector in collectors:
             for metric in collector.collect():
                 m = metric._restricted_metric(self._name_set)

--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -137,13 +137,16 @@ class RestrictedRegistry(object):
     def collect(self):
         names = copy.copy(self._name_set)
         collectors = set()
+        yield_target_info = False
         with self._registry._lock:
             if 'target_info' in names and self._registry._target_info:
-                yield self._registry._target_info_metric()
+                yield_target_info = True
                 names.remove('target_info')
             for name in names:
                 if name in self._registry._names_to_collectors:
                     collectors.add(self._registry._names_to_collectors[name])
+        if yield_target_info:
+            yield self._registry._target_info_metric()
         for collector in collectors:
             for metric in collector.collect():
                 m = metric._restricted_metric(self._name_set)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 from concurrent.futures import ThreadPoolExecutor
+import sys
 import time
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -839,7 +839,9 @@ class TestCollectorRegistry(unittest.TestCase):
         m.samples = [Sample('target_info', {'foo': 'bar'}, 1)]
         self.assertEqual([m], list(registry.restricted_registry(['target_info']).collect()))
 
+    @unittest.skipIf(sys.version_info < (3, 3), "Test requires Python 3.3+.")
     def test_restricted_registry_does_not_call_extra(self):
+        from unittest.mock import MagicMock
         registry = CollectorRegistry()
         mock_collector = MagicMock()
         mock_collector.describe.return_value = [Metric('foo', 'help', 'summary')]


### PR DESCRIPTION
#675 introduces a significant performance regression in restricted registry collecting. This attempts to reduce the regression by re-introducing filter code removed in the previous version.