### PR TITLE
Create multiprocess files with process uuid

### DIFF
--- a/prometheus_client/mmap_dict.py
+++ b/prometheus_client/mmap_dict.py
@@ -134,6 +134,13 @@ class MmapedDict(object):
             self._m.close()
             self._m = None
             self._f.close()
+            try:
+                # Given that we're using uuid for the process we can safely
+                # remove the file because is not going to be shared by other process
+                os.remove(self._f.name)
+            except OSError:
+                # In windows if the file is in use raises an error
+                pass
             self._f = None
 
 

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -1,4 +1,7 @@
 import math
+import sys
+
+import psutil
 
 INF = float("inf")
 MINUS_INF = float("-inf")
@@ -22,3 +25,16 @@ def floatToGoString(d):
             mantissa = '{0}.{1}{2}'.format(s[0], s[1:dot], s[dot + 1:]).rstrip('0.')
             return '{0}e+0{1}'.format(mantissa, dot - 1)
         return s
+
+def get_process_data(pid):
+    try:
+        process = psutil.Process(pid)
+        return process.__hash__()
+    except psutil.NoSuchProcess:
+        print('Calling process {0} is not running'.format(pid), file=sys.stderr)
+        raise
+    except psutil.AccessDenied:
+        print('Not enough permissions to access process {0}'.format(pid), file=sys.stderr)
+        raise
+
+

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
         'prometheus_client.openmetrics',
         'prometheus_client.twisted',
     ],
+    install_requires=[
+        'psutil'
+    ],
     extras_require={
         'twisted': ['twisted'],
     },


### PR DESCRIPTION
### **This is a draft open to discussion**

In order to be able to clean-up the process files once it's stopped or destroyed, we need to identify those files with a UUID. If not, those files are going to be processed and collected and will keep growing until we restart the server or master process to perform the cleanup of the metrics directory

This change uses the psutil library that gives a hash based on PID+Process creation time in order to differentiate two processes with the same PID but those are different.

I have some questions about the feasibility of this change:

- Is the approach ok? Mainly is respectful in case of exception and even though some files could be left behind is not the same situation as we have now. Also, there is an improvement that I can add and is marking those files I couldn't delete as "type_pid_uuid_defunct" so we can do something to directly remove those files
- Is it ok to start using an external library? I've seen you're trying to avoid it
- Tests are failing because the test process is not running and the unittest.mock library is only from 3.3 it's ok to move all the multiprocess tests to required that version to run?

This change aims to fix https://github.com/prometheus/client_python/issues/568

// @csmarchbanks

Signed-off-by: Mario de Frutos <mario@defrutos.org>