### PR TITLE
Make `Gauge.set_function` multiprocess-compatible

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -399,7 +399,9 @@ class Gauge(MetricWrapperBase):
         self._raise_if_not_observable()
 
         def samples(self):
-            return (('', {}, float(f())),)
+            value = f()
+            self.set(value)
+            return (('', {}, float(value)),)
 
         self._child_samples = create_bound_method(samples, self)
 


### PR DESCRIPTION
This makes the `_child_samples()` callback that `Gauge.set_function` genereates
stash the callback's value in the `_value`, so that you can make a
callback-based Gauge in a subprocess and expect it to be visible in other
processes' metrics collection.