### PR TITLE
Annotate few functions and methods

### DIFF
--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -1,21 +1,30 @@
 from timeit import default_timer
+from types import TracebackType
+from typing import (
+    Any, Callable, Literal, Optional, Type, TYPE_CHECKING, TypeVar,
+)
 
 from .decorator import decorate
 
+if TYPE_CHECKING:
+    from . import Counter
+    F = TypeVar("F", bound=Callable[..., Any])
+
 
 class ExceptionCounter:
-    def __init__(self, counter, exception):
+    def __init__(self, counter: "Counter", exception: Type[BaseException]) -> None:
         self._counter = counter
         self._exception = exception
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         pass
 
-    def __exit__(self, typ, value, traceback):
+    def __exit__(self, typ: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> Literal[False]:
         if isinstance(value, self._exception):
             self._counter.inc()
+        return False
 
-    def __call__(self, f):
+    def __call__(self, f: "F") -> "F":
         def wrapped(func, *args, **kwargs):
             with self:
                 return func(*args, **kwargs)

--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -1,18 +1,13 @@
 #!/usr/bin/python
 
 
+import io as StringIO
 import math
 import re
 
 from ..metrics_core import Metric, METRIC_LABEL_NAME_RE
 from ..samples import Exemplar, Sample, Timestamp
 from ..utils import floatToGoString
-
-try:
-    import StringIO
-except ImportError:
-    # Python 3
-    import io as StringIO
 
 
 def text_string_to_metric_families(text):

--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -1,13 +1,8 @@
+import io as StringIO
 import re
 
 from .metrics_core import Metric
 from .samples import Sample
-
-try:
-    import StringIO
-except ImportError:
-    # Python 3
-    import io as StringIO
 
 
 def text_string_to_metric_families(text):

--- a/prometheus_client/samples.py
+++ b/prometheus_client/samples.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from typing import Dict, NamedTuple, Optional
 
 
 class Timestamp:
@@ -36,8 +36,15 @@ class Timestamp:
 # Timestamp can be a float containing a unixtime in seconds,
 # a Timestamp object, or None.
 # Exemplar can be an Exemplar object, or None.
-Sample = namedtuple('Sample', ['name', 'labels', 'value', 'timestamp', 'exemplar'])
-Sample.__new__.__defaults__ = (None, None)
+class Exemplar(NamedTuple):
+    labels: Dict[str, str]
+    value: float
+    timestamp: Optional[float] = None
 
-Exemplar = namedtuple('Exemplar', ['labels', 'value', 'timestamp'])
-Exemplar.__new__.__defaults__ = (None,)
+
+class Sample(NamedTuple):
+    name: str
+    labels: Dict[str, str]
+    value: float
+    timestamp: Optional[float] = None
+    exemplar: Optional[Exemplar] = None

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
         'prometheus_client.openmetrics',
         'prometheus_client.twisted',
     ],
+    package_data={
+        'prometheus_client': ['py.typed']
+    },
     extras_require={
         'twisted': ['twisted'],
     },


### PR DESCRIPTION
This is related to https://github.com/prometheus/client_python/issues/491, it doesn't resolve it, but it could be a step into that direction.

This theoretically should not break python 2.7