### PR TITLE
Fix AssertionError: Status must be a string

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -114,8 +114,8 @@ def make_wsgi_app(registry=REGISTRY):
         params = parse_qs(environ.get('QUERY_STRING', ''))
         if environ['PATH_INFO'] == '/favicon.ico':
             # Serve empty response for browsers
-            status = '200 OK'
-            header = ('', '')
+            status = str('200 OK')
+            header = (str(''), str(''))
             output = b''
         else:
             # Bake output


### PR DESCRIPTION
This is an alternative to https://github.com/prometheus/client_python/pull/679 which also covers the headers which will error with `AssertionError: Header names must be strings`.

Fixes #662 