### PR TITLE
Remove trailing slash from pushgateway URLs

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -448,6 +448,8 @@ def _use_gateway(method, gateway, job, registry, grouping_key, timeout, handler)
             and gateway_url.scheme not in ['http', 'https']
     ):
         gateway = 'http://{0}'.format(gateway)
+
+    gateway = gateway.rstrip('/')
     url = '{0}/metrics/{1}/{2}'.format(gateway, *_escape_grouping_key("job", job))
 
     data = b''

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -369,6 +369,12 @@ class TestPushGateway(unittest.TestCase):
         # ensure the redirect took place at the expected redirect location.
         self.assertEqual(self.requests[1][0].path, "/" + self.redirect_flag)
 
+    def test_push_with_trailing_slash(self):
+        address = self.address + '/'
+        push_to_gateway(address, "my_job_with_trailing_slash", self.registry)
+
+        self.assertNotIn('//', self.requests[0][0].path)
+
     def test_instance_ip_grouping_key(self):
         self.assertTrue('' != instance_ip_grouping_key()['instance'])
 


### PR DESCRIPTION
When using the push gateway, URLs may be submitted as host or URL.

When using an URL scheme, in case user submits URL with a trailing slash
(eg: `http://localhost:9091/`), the pushgateway server will reply with a
301 (or 307 depending on the version) redirect that is not handled by
the default handler. Leading to a traceback

Simply remove any trailing slash from the base URL