### PR TITLE
Allow to add labels inside a context manager

### DIFF
--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -56,7 +56,6 @@ class Timer:
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
         duration = max(default_timer() - self._start, 0)
-        self._metric._raise_if_not_observable()
         callback = getattr(self._metric, self._callback_name)
         callback(duration)
 

--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -55,6 +55,8 @@ class Timer:
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
         duration = max(default_timer() - self._start, 0)
+        instance = self._callback.__self__
+        instance._raise_if_not_observable()
         self._callback(duration)
 
     def labels(self, *args, **kw):

--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -42,11 +42,12 @@ class InprogressTracker:
 
 
 class Timer:
-    def __init__(self, callback):
-        self._callback = callback
+    def __init__(self, metric, callback_name):
+        self._metric = metric
+        self._callback_name = callback_name
 
     def _new_timer(self):
-        return self.__class__(self._callback)
+        return self.__class__(self._metric, self._callback_name)
 
     def __enter__(self):
         self._start = default_timer()
@@ -55,15 +56,12 @@ class Timer:
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
         duration = max(default_timer() - self._start, 0)
-        instance = self._callback.__self__
-        instance._raise_if_not_observable()
-        self._callback(duration)
+        self._metric._raise_if_not_observable()
+        callback = getattr(self._metric, self._callback_name)
+        callback(duration)
 
     def labels(self, *args, **kw):
-        instance = self._callback.__self__
-        self._callback = getattr(
-            instance.labels(*args, **kw),
-            self._callback.__name__)
+        self._metric = self._metric.labels(*args, **kw)
 
     def __call__(self, f):
         def wrapped(func, *args, **kwargs):

--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -50,11 +50,18 @@ class Timer:
 
     def __enter__(self):
         self._start = default_timer()
+        return self
 
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
         duration = max(default_timer() - self._start, 0)
         self._callback(duration)
+
+    def labels(self, *args, **kw):
+        instance = self._callback.__self__
+        self._callback = getattr(
+            instance.labels(*args, **kw),
+            self._callback.__name__)
 
     def __call__(self, f):
         def wrapped(func, *args, **kwargs):

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -396,7 +396,7 @@ class Gauge(MetricWrapperBase):
 
         Can be used as a function decorator or context manager.
         """
-        return Timer(self.set)
+        return Timer(self, 'set')
 
     def set_function(self, f):
         """Call the provided function to return the Gauge value.
@@ -474,7 +474,7 @@ class Summary(MetricWrapperBase):
 
         Can be used as a function decorator or context manager.
         """
-        return Timer(self.observe)
+        return Timer(self, 'observe')
 
     def _child_samples(self):
         return (
@@ -598,7 +598,7 @@ class Histogram(MetricWrapperBase):
 
         Can be used as a function decorator or context manager.
         """
-        return Timer(self.observe)
+        return Timer(self, 'observe')
 
     def _child_samples(self):
         samples = []

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -396,7 +396,6 @@ class Gauge(MetricWrapperBase):
 
         Can be used as a function decorator or context manager.
         """
-        self._raise_if_not_observable()
         return Timer(self.set)
 
     def set_function(self, f):
@@ -475,7 +474,6 @@ class Summary(MetricWrapperBase):
 
         Can be used as a function decorator or context manager.
         """
-        self._raise_if_not_observable()
         return Timer(self.observe)
 
     def _child_samples(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -435,6 +435,15 @@ class TestHistogram(unittest.TestCase):
         self.assertEqual(1, self.registry.get_sample_value('h_count'))
         self.assertEqual(1, self.registry.get_sample_value('h_bucket', {'le': '+Inf'}))
 
+    def test_block_decorator_with_label(self):
+        value = self.registry.get_sample_value
+        self.assertEqual(None, value('hl_count', {'l': 'a'}))
+        self.assertEqual(None, value('hl_bucket', {'le': '+Inf', 'l': 'a'}))
+        with self.labels.time() as metric:
+            metric.labels('a')
+        self.assertEqual(1, value('hl_count', {'l': 'a'}))
+        self.assertEqual(1, value('hl_bucket', {'le': '+Inf', 'l': 'a'}))
+
     def test_exemplar_invalid_label_name(self):
         self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={':o)': 'smile'})
         self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={'1': 'number'})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -222,13 +222,25 @@ class TestGauge(unittest.TestCase):
             time.sleep(.001)
         self.assertNotEqual(0, self.registry.get_sample_value('g'))
 
+    def test_time_block_decorator_with_label(self):
+        value = self.registry.get_sample_value
+        self.assertEqual(None, value('g2', {'label1': 'foo'}))
+        with self.gauge_with_label.time() as metric:
+            metric.labels('foo')
+        self.assertLess(0, value('g2', {'label1': 'foo'}))
+
     def test_track_in_progress_not_observable(self):
         g = Gauge('test', 'help', labelnames=('label',), registry=self.registry)
         assert_not_observable(g.track_inprogress)
 
     def test_timer_not_observable(self):
         g = Gauge('test', 'help', labelnames=('label',), registry=self.registry)
-        assert_not_observable(g.time)
+
+        def manager():
+            with g.time():
+                pass
+
+        assert_not_observable(manager)
 
 
 class TestSummary(unittest.TestCase):
@@ -318,10 +330,21 @@ class TestSummary(unittest.TestCase):
             pass
         self.assertEqual(1, self.registry.get_sample_value('s_count'))
 
+    def test_block_decorator_with_label(self):
+        value = self.registry.get_sample_value
+        self.assertEqual(None, value('s_with_labels_count', {'label1': 'foo'}))
+        with self.summary_with_labels.time() as metric:
+            metric.labels('foo')
+        self.assertEqual(1, value('s_with_labels_count', {'label1': 'foo'}))
+
     def test_timer_not_observable(self):
         s = Summary('test', 'help', labelnames=('label',), registry=self.registry)
 
-        assert_not_observable(s.time)
+        def manager():
+            with s.time():
+                pass
+
+        assert_not_observable(manager)
 
 
 class TestHistogram(unittest.TestCase):


### PR DESCRIPTION
This is an attempt to use `time()` as a context manager, but still be able to add labels with values that depend on the result of the timed operation. In our case we'd like to monitor the duration of a number of web requests, but still distinguish/label them by the returned HTTP error code. It didn't seem possible to use the provided `time()` helper in this case, but instead we would have to measure the time ourselves and then use something like `metric.labels(status=status_code).observe(duration)`.

Being able to add the label inside the context manager seemed a bit more convenient:
```python
from prometheus_client import Histogram
from requests import get

teapot = Histogram('teapot', 'A teapot', ['status'])
with teapot.time() as metric:
    response = get('https://httpbin.org/status/418')
    metric.labels(status=response.status_code)
```
This should now work with all three `time()` helpers. However, the 'observability' checks for 'gauge' and 'summary' metrics had to be deferred (to their respective `__exit__` methods; see 2b57f24c5f6879090b49443152675fd807951230), because there is no way to tell upfront if a label will in fact be added, making the metric 'observable'.

I hope that's an acceptable change. If so, the `track_inprogress()` helper should probably also be changed accordingly.