### PR TITLE
Allow adding arbitrary labels to metrics when generating output

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -929,6 +929,13 @@ class TestCollectorRegistry(unittest.TestCase):
         for _ in registry.restricted_registry(['target_info', 's_sum']).collect():
             self.assertFalse(registry._lock.locked())
 
+    def test_labelled_registry(self):
+        extra_labels = {'label1': 'value1'}
+        registry = CollectorRegistry(extra_labels)
+        Counter('c_total', 'help', registry=registry)
+        metrics = list(registry.labelled_registry(extra_labels).collect())
+        self.assertEqual(metrics[0].samples[0].labels, extra_labels)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It's useful to be able to apply a label across all metrics, for
example when using a multi-processing framework to apply a
label for worker ID to all metrics (including from builtin
collector types). This change adds a new Registry type that
applies a dictionary of labels when metrics are collected.

Signed-off-by: Will Newton <will.newton@gmail.com>