### PR TITLE
Change to imports to fix go-to-declaration in editors

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -7,37 +7,37 @@ from . import (
 
 __all__ = ['Counter', 'Gauge', 'Summary', 'Histogram', 'Info', 'Enum']
 
-CollectorRegistry = registry.CollectorRegistry
-REGISTRY = registry.REGISTRY
-Metric = metrics_core.Metric
-Counter = metrics.Counter
-Gauge = metrics.Gauge
-Summary = metrics.Summary
-Histogram = metrics.Histogram
-Info = metrics.Info
-Enum = metrics.Enum
+from .registry import CollectorRegistry
+from .registry import REGISTRY
+from .metrics_core import Metric
+from .metrics import Counter
+from .metrics import Gauge
+from .metrics import Summary
+from .metrics import Histogram
+from .metrics import Info
+from .metrics import Enum
 
-CONTENT_TYPE_LATEST = exposition.CONTENT_TYPE_LATEST
-generate_latest = exposition.generate_latest
-MetricsHandler = exposition.MetricsHandler
-make_wsgi_app = exposition.make_wsgi_app
-make_asgi_app = exposition.make_asgi_app
-start_http_server = exposition.start_http_server
-start_wsgi_server = exposition.start_wsgi_server
-write_to_textfile = exposition.write_to_textfile
-push_to_gateway = exposition.push_to_gateway
-pushadd_to_gateway = exposition.pushadd_to_gateway
-delete_from_gateway = exposition.delete_from_gateway
-instance_ip_grouping_key = exposition.instance_ip_grouping_key
+from .exposition import CONTENT_TYPE_LATEST
+from .exposition import generate_latest
+from .exposition import MetricsHandler
+from .exposition import make_wsgi_app
+from .exposition import make_asgi_app
+from .exposition import start_http_server
+from .exposition import start_wsgi_server
+from .exposition import write_to_textfile
+from .exposition import push_to_gateway
+from .exposition import pushadd_to_gateway
+from .exposition import delete_from_gateway
+from .exposition import instance_ip_grouping_key
 
-ProcessCollector = process_collector.ProcessCollector
-PROCESS_COLLECTOR = process_collector.PROCESS_COLLECTOR
+from .process_collector import ProcessCollector
+from .process_collector import PROCESS_COLLECTOR
 
-PlatformCollector = platform_collector.PlatformCollector
-PLATFORM_COLLECTOR = platform_collector.PLATFORM_COLLECTOR
+from .platform_collector import PlatformCollector
+from .platform_collector import PLATFORM_COLLECTOR
 
-GCCollector = gc_collector.GCCollector
-GC_COLLECTOR = gc_collector.GC_COLLECTOR
+from .gc_collector import GCCollector
+from .gc_collector import GC_COLLECTOR
 
 if __name__ == '__main__':
     c = Counter('cc', 'A counter')

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -4,40 +4,21 @@ from . import (
     exposition, gc_collector, metrics, metrics_core, platform_collector,
     process_collector, registry,
 )
+from .exposition import (
+    CONTENT_TYPE_LATEST, delete_from_gateway, generate_latest,
+    instance_ip_grouping_key, make_asgi_app, make_wsgi_app, MetricsHandler,
+    push_to_gateway, pushadd_to_gateway, start_http_server, start_wsgi_server,
+    write_to_textfile,
+)
+from .gc_collector import GC_COLLECTOR, GCCollector
+from .metrics import Counter, Enum, Gauge, Histogram, Info, Summary
+from .metrics_core import Metric
+from .platform_collector import PLATFORM_COLLECTOR, PlatformCollector
+from .process_collector import PROCESS_COLLECTOR, ProcessCollector
+from .registry import CollectorRegistry, REGISTRY
 
 __all__ = ['Counter', 'Gauge', 'Summary', 'Histogram', 'Info', 'Enum']
 
-from .registry import CollectorRegistry
-from .registry import REGISTRY
-from .metrics_core import Metric
-from .metrics import Counter
-from .metrics import Gauge
-from .metrics import Summary
-from .metrics import Histogram
-from .metrics import Info
-from .metrics import Enum
-
-from .exposition import CONTENT_TYPE_LATEST
-from .exposition import generate_latest
-from .exposition import MetricsHandler
-from .exposition import make_wsgi_app
-from .exposition import make_asgi_app
-from .exposition import start_http_server
-from .exposition import start_wsgi_server
-from .exposition import write_to_textfile
-from .exposition import push_to_gateway
-from .exposition import pushadd_to_gateway
-from .exposition import delete_from_gateway
-from .exposition import instance_ip_grouping_key
-
-from .process_collector import ProcessCollector
-from .process_collector import PROCESS_COLLECTOR
-
-from .platform_collector import PlatformCollector
-from .platform_collector import PLATFORM_COLLECTOR
-
-from .gc_collector import GCCollector
-from .gc_collector import GC_COLLECTOR
 
 if __name__ == '__main__':
     c = Counter('cc', 'A counter')

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ ignore =
     E129,
     E731
 
+per-file-ignores = prometheus_client/__init__.py:F401
 import-order-style = google
 application-import-names = prometheus_client
 


### PR DESCRIPTION
@csmarchbanks Just a small tweak to improve how prometheus_client behaves with IDEs/editors:

In PyCharm, when ctrl-clicking functions/classes of this library to go to their declaration, it takes me to `prometheus_client/__init__.py` instead of where the function/class was actually defined. This seems to happen because `__init__.py` uses assignments instead of imports to re-export members, so I've changed them all to imports.