### PR TITLE
Declare `registry` on `MetricWrapperBase` as `Optional`

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -677,7 +677,7 @@ class Enum(MetricWrapperBase):
                  namespace: str = '',
                  subsystem: str = '',
                  unit: str = '',
-                 registry: CollectorRegistry = REGISTRY,
+                 registry: Optional[CollectorRegistry] = REGISTRY,
                  _labelvalues: Optional[Sequence[str]] = None,
                  states: Optional[Sequence[str]] = None,
                  ):

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -107,7 +107,7 @@ class MetricWrapperBase:
                  namespace: str = '',
                  subsystem: str = '',
                  unit: str = '',
-                 registry: CollectorRegistry = REGISTRY,
+                 registry: Optional[CollectorRegistry] = REGISTRY,
                  _labelvalues: Optional[Sequence[str]] = None,
                  ) -> None:
         self._name = _build_full_name(self._type, name, namespace, subsystem, unit)


### PR DESCRIPTION
Dear maintainer @csmarchbanks,

The release of 0.13.0 yesterday appears to have caused us some type checking errors with Mypy (presumably this is a recent effort to annotate this library with types — thanks!).

I think this particular annotation is incomplete though — our code relies on passing `None` here and the code beneath says the following:
```python
            if registry:
                registry.register(self)
```
In other words, I think this was intended to be optional.

Thanks!

Signed-off-by: Olivier Wilkinson (reivilibre) <oliverw@matrix.org>