### PR TITLE
Allow labelvalues and labelkwargs to be Any type

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -133,7 +133,7 @@ class MetricWrapperBase:
             if registry:
                 registry.register(self)
 
-    def labels(self: T, *labelvalues: str, **labelkwargs: str) -> T:
+    def labels(self: T, *labelvalues: Any, **labelkwargs: Any) -> T:
         """Return the child for the given labelset.
 
         All metrics can have labels, allowing grouping of related time series.


### PR DESCRIPTION
We will cast all labelvalues to be strings so we should not force a user
to cast to a string before passing the label.