### PR TITLE
Add missing functions/classes to __all__

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 exclude = prometheus_client/decorator.py|prometheus_client/twisted|tests/test_twisted.py
+implicit_reexport = False
 
 [mypy-prometheus_client.decorator]
 follow_imports = skip

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -17,8 +17,35 @@ from .platform_collector import PLATFORM_COLLECTOR, PlatformCollector
 from .process_collector import PROCESS_COLLECTOR, ProcessCollector
 from .registry import CollectorRegistry, REGISTRY
 
-__all__ = ['Counter', 'Gauge', 'Summary', 'Histogram', 'Info', 'Enum', 'CollectorRegistry', 'REGISTRY']
-
+__all__ = (
+    'CollectorRegistry',
+    'REGISTRY',
+    'Metric',
+    'Counter',
+    'Gauge',
+    'Summary',
+    'Histogram',
+    'Info',
+    'Enum',
+    'CONTENT_TYPE_LATEST',
+    'generate_latest',
+    'MetricsHandler',
+    'make_wsgi_app',
+    'make_asgi_app',
+    'start_http_server',
+    'start_wsgi_server',
+    'write_to_textfile',
+    'push_to_gateway',
+    'pushadd_to_gateway',
+    'delete_from_gateway',
+    'instance_ip_grouping_key',
+    'ProcessCollector',
+    'PROCESS_COLLECTOR',
+    'PlatformCollector',
+    'PLATFORM_COLLECTOR',
+    'GCCollector',
+    'GC_COLLECTOR',
+)
 
 if __name__ == '__main__':
     c = Counter('cc', 'A counter')

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -17,7 +17,7 @@ from .platform_collector import PLATFORM_COLLECTOR, PlatformCollector
 from .process_collector import PROCESS_COLLECTOR, ProcessCollector
 from .registry import CollectorRegistry, REGISTRY
 
-__all__ = ['Counter', 'Gauge', 'Summary', 'Histogram', 'Info', 'Enum']
+__all__ = ['Counter', 'Gauge', 'Summary', 'Histogram', 'Info', 'Enum', 'CollectorRegistry', 'REGISTRY']
 
 
 if __name__ == '__main__':

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -17,6 +17,21 @@ from .openmetrics import exposition as openmetrics
 from .registry import REGISTRY
 from .utils import floatToGoString
 
+__all__ = (
+    'CONTENT_TYPE_LATEST',
+    'delete_from_gateway',
+    'generate_latest',
+    'instance_ip_grouping_key',
+    'make_asgi_app',
+    'make_wsgi_app',
+    'MetricsHandler',
+    'push_to_gateway',
+    'pushadd_to_gateway',
+    'start_http_server',
+    'start_wsgi_server',
+    'write_to_textfile',
+)
+
 CONTENT_TYPE_LATEST = 'text/plain; version=0.0.4; charset=utf-8'
 """Content type of the latest text format"""
 PYTHON376_OR_NEWER = sys.version_info > (3, 7, 5)


### PR DESCRIPTION
Hi,

`mypy==0.931.0` raises the following errors for `prometheus-client==0.13.0`:

![image](https://user-images.githubusercontent.com/664889/151420399-53b774db-7fd8-459b-947c-0f9e8d1af5c4.png)

Probably the reason of it are two things:
1. #747, https://github.com/prometheus/client_python/pull/747/files#diff-719659a170701715fc787a12f9ceb16910e3d9a5fbe2c5725f91fac76b29f0f1L10, https://github.com/prometheus/client_python/pull/747/files#diff-719659a170701715fc787a12f9ceb16910e3d9a5fbe2c5725f91fac76b29f0f1L11
2. As I know mypy relies on `__all__` declaration and I have no idea why it worked before.

I hope it is fine to include these two things to `__all__`, because of their wider usage compared to other classes/constants mentioned in #747.

Thanks.