### PR TITLE
Add type annotations to everything referenced in __init__.py

### DIFF
--- a/prometheus_client/asgi.py
+++ b/prometheus_client/asgi.py
@@ -1,10 +1,11 @@
+from typing import Callable
 from urllib.parse import parse_qs
 
 from .exposition import _bake_output
-from .registry import REGISTRY
+from .registry import CollectorRegistry, REGISTRY
 
 
-def make_asgi_app(registry=REGISTRY):
+def make_asgi_app(registry: CollectorRegistry = REGISTRY) -> Callable:
     """Create a ASGI app which serves the metrics from a registry."""
 
     async def prometheus_app(scope, receive, send):

--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -6,8 +6,9 @@ import socket
 import threading
 import time
 from timeit import default_timer
+from typing import Callable, Tuple
 
-from ..registry import REGISTRY
+from ..registry import CollectorRegistry, REGISTRY
 
 # Roughly, have to keep to what works as a file name.
 # We also remove periods, so labels can be distinguished.
@@ -45,14 +46,20 @@ class _RegularPush(threading.Thread):
 
 
 class GraphiteBridge:
-    def __init__(self, address, registry=REGISTRY, timeout_seconds=30, _timer=time.time, tags=False):
+    def __init__(self,
+                 address: Tuple[str, int],
+                 registry: CollectorRegistry = REGISTRY,
+                 timeout_seconds: float = 30,
+                 _timer: Callable[[], float] = time.time,
+                 tags: bool = False,
+                 ):
         self._address = address
         self._registry = registry
         self._tags = tags
         self._timeout = timeout_seconds
         self._timer = _timer
 
-    def push(self, prefix=''):
+    def push(self, prefix: str = '') -> None:
         now = int(self._timer())
         output = []
 
@@ -81,7 +88,7 @@ class GraphiteBridge:
         conn.sendall(''.join(output).encode('ascii'))
         conn.close()
 
-    def start(self, interval=60.0, prefix=''):
+    def start(self, interval: float = 60.0, prefix: str = '') -> None:
         t = _RegularPush(self, interval, prefix)
         t.daemon = True
         t.start()

--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -1,19 +1,20 @@
 import gc
 import platform
+from typing import Iterable
 
-from .metrics_core import CounterMetricFamily
-from .registry import REGISTRY
+from .metrics_core import CounterMetricFamily, Metric
+from .registry import Collector, CollectorRegistry, REGISTRY
 
 
-class GCCollector:
+class GCCollector(Collector):
     """Collector for Garbage collection statistics."""
 
-    def __init__(self, registry=REGISTRY):
+    def __init__(self, registry: CollectorRegistry = REGISTRY):
         if not hasattr(gc, 'get_stats') or platform.python_implementation() != 'CPython':
             return
         registry.register(self)
 
-    def collect(self):
+    def collect(self) -> Iterable[Metric]:
         collected = CounterMetricFamily(
             'python_gc_objects_collected',
             'Objects collected during gc',
@@ -31,8 +32,8 @@ class GCCollector:
             labels=['generation'],
         )
 
-        for generation, stat in enumerate(gc.get_stats()):
-            generation = str(generation)
+        for gen, stat in enumerate(gc.get_stats()):
+            generation = str(gen)
             collected.add_metric([generation], value=stat['collected'])
             uncollectable.add_metric([generation], value=stat['uncollectable'])
             collections.add_metric([generation], value=stat['collections'])

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -270,7 +270,7 @@ class Counter(MetricWrapperBase):
                                         self._labelvalues)
         self._created = time.time()
 
-    def inc(self, amount: float = 1, exemplar: Optional[Dict[str, str]] = None) -> None:
+    def inc(self, amount: Union[int, float] = 1, exemplar: Optional[Dict[str, str]] = None) -> None:
         """Increment counter by the given amount."""
         self._raise_if_not_observable()
         if amount < 0:
@@ -369,17 +369,17 @@ class Gauge(MetricWrapperBase):
             multiprocess_mode=self._multiprocess_mode
         )
 
-    def inc(self, amount: float = 1) -> None:
+    def inc(self, amount: Union[int, float] = 1) -> None:
         """Increment gauge by the given amount."""
         self._raise_if_not_observable()
         self._value.inc(amount)
 
-    def dec(self, amount: float = 1) -> None:
+    def dec(self, amount: Union[int, float] = 1) -> None:
         """Decrement gauge by the given amount."""
         self._raise_if_not_observable()
         self._value.inc(-amount)
 
-    def set(self, value: float) -> None:
+    def set(self, value: Union[int, float]) -> None:
         """Set gauge to the given value."""
         self._raise_if_not_observable()
         self._value.set(float(value))
@@ -462,7 +462,7 @@ class Summary(MetricWrapperBase):
         self._sum = values.ValueClass(self._type, self._name, self._name + '_sum', self._labelnames, self._labelvalues)
         self._created = time.time()
 
-    def observe(self, amount: float) -> None:
+    def observe(self, amount: Union[int, float]) -> None:
         """Observe the given amount.
 
         The amount is usually positive or zero. Negative values are
@@ -580,7 +580,7 @@ class Histogram(MetricWrapperBase):
                 self._labelvalues + (floatToGoString(b),))
             )
 
-    def observe(self, amount: float, exemplar: Optional[Dict[str, str]] = None) -> None:
+    def observe(self, amount: Union[int, float], exemplar: Optional[Dict[str, str]] = None) -> None:
         """Observe the given amount.
 
         The amount is usually positive or zero. Negative values are

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -2,7 +2,8 @@ from threading import Lock
 import time
 import types
 from typing import (
-    Any, Callable, Dict, Iterable, Optional, Sequence, Type, TypeVar, Union,
+    Any, Callable, Dict, Iterable, List, Optional, Sequence, Type, TypeVar,
+    Union,
 )
 
 from . import values  # retain this import style for testability
@@ -11,7 +12,7 @@ from .metrics_core import (
     Metric, METRIC_LABEL_NAME_RE, METRIC_NAME_RE,
     RESERVED_METRIC_LABEL_NAME_RE,
 )
-from .registry import CollectorRegistry, REGISTRY
+from .registry import Collector, CollectorRegistry, REGISTRY
 from .samples import Exemplar, Sample
 from .utils import floatToGoString, INF
 
@@ -61,7 +62,7 @@ def _validate_exemplar(exemplar):
         raise ValueError('Exemplar labels have %d UTF-8 characters, exceeding the limit of 128')
 
 
-class MetricWrapperBase:
+class MetricWrapperBase(Collector):
     _type: Optional[str] = None
     _reserved_labelnames: Sequence[str] = ()
 
@@ -84,19 +85,19 @@ class MetricWrapperBase:
     def _get_metric(self):
         return Metric(self._name, self._documentation, self._type, self._unit)
 
-    def describe(self):
+    def describe(self) -> Iterable[Metric]:
         return [self._get_metric()]
 
-    def collect(self):
+    def collect(self) -> Iterable[Metric]:
         metric = self._get_metric()
         for suffix, labels, value, timestamp, exemplar in self._samples():
             metric.add_sample(self._name + suffix, labels, value, timestamp, exemplar)
         return [metric]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self._type}:{self._name}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         metric_type = type(self)
         return f"{metric_type.__module__}.{metric_type.__name__}({self._name})"
 
@@ -188,7 +189,7 @@ class MetricWrapperBase:
                 )
             return self._metrics[labelvalues]
 
-    def remove(self, *labelvalues):
+    def remove(self, *labelvalues: Any) -> None:
         if not self._labelnames:
             raise ValueError('No label names were set when constructing %s' % self)
 
@@ -566,7 +567,7 @@ class Histogram(MetricWrapperBase):
         self._upper_bounds = buckets
 
     def _metric_init(self) -> None:
-        self._buckets = []
+        self._buckets: List[values.ValueClass] = []
         self._created = time.time()
         bucket_labelnames = self._labelnames + ('le',)
         self._sum = values.ValueClass(self._type, self._name, self._name + '_sum', self._labelnames, self._labelvalues)
@@ -608,7 +609,7 @@ class Histogram(MetricWrapperBase):
 
     def _child_samples(self) -> Iterable[Sample]:
         samples = []
-        acc = 0
+        acc = 0.0
         for i, bound in enumerate(self._upper_bounds):
             acc += self._buckets[i].get()
             samples.append(Sample('_bucket', {'le': floatToGoString(bound)}, acc, None, self._buckets[i].get_exemplar()))
@@ -642,7 +643,7 @@ class Info(MetricWrapperBase):
         self._lock = Lock()
         self._value = {}
 
-    def info(self, val):
+    def info(self, val: Dict[str, str]) -> None:
         """Set info metric."""
         if self._labelname_set.intersection(val.keys()):
             raise ValueError('Overlapping labels for Info metric, metric: {} child: {}'.format(

--- a/prometheus_client/metrics_core.py
+++ b/prometheus_client/metrics_core.py
@@ -36,7 +36,7 @@ class Metric:
         self.type: str = typ
         self.samples: List[Sample] = []
 
-    def add_sample(self, name: str, labels: Dict[str, str], value: float, timestamp: Optional[Union[Timestamp, float]] = None, exemplar: Optional[Exemplar] = None) -> None:
+    def add_sample(self, name: str, labels: Dict[str, str], value: Union[int, float], timestamp: Optional[Union[Timestamp, float]] = None, exemplar: Optional[Exemplar] = None) -> None:
         """Add a sample to the metric.
 
         Internal-only, do not use."""
@@ -77,7 +77,7 @@ class UnknownMetricFamily(Metric):
     def __init__(self,
                  name: str,
                  documentation: str,
-                 value: Optional[float] = None,
+                 value: Optional[Union[int, float]] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -90,7 +90,7 @@ class UnknownMetricFamily(Metric):
         if value is not None:
             self.add_metric([], value)
 
-    def add_metric(self, labels: Sequence[str], value: float, timestamp: Optional[Union[Timestamp, float]] = None) -> None:
+    def add_metric(self, labels: Sequence[str], value: Union[int, float], timestamp: Optional[Union[Timestamp, float]] = None) -> None:
         """Add a metric to the metric family.
         Args:
         labels: A list of label values
@@ -112,7 +112,7 @@ class CounterMetricFamily(Metric):
     def __init__(self,
                  name: str,
                  documentation: str,
-                 value: Optional[float] = None,
+                 value: Optional[Union[int, float]] = None,
                  labels: Sequence[str] = None,
                  created: Optional[float] = None,
                  unit: str = '',
@@ -131,7 +131,7 @@ class CounterMetricFamily(Metric):
 
     def add_metric(self,
                    labels: Sequence[str],
-                   value: float,
+                   value: Union[int, float],
                    created: Optional[float] = None,
                    timestamp: Optional[Union[Timestamp, float]] = None,
                    ) -> None:
@@ -156,7 +156,7 @@ class GaugeMetricFamily(Metric):
     def __init__(self,
                  name: str,
                  documentation: str,
-                 value: Optional[float] = None,
+                 value: Optional[Union[int, float]] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -169,7 +169,7 @@ class GaugeMetricFamily(Metric):
         if value is not None:
             self.add_metric([], value)
 
-    def add_metric(self, labels: Sequence[str], value: float, timestamp: Optional[Union[Timestamp, float]] = None) -> None:
+    def add_metric(self, labels: Sequence[str], value: Union[int, float], timestamp: Optional[Union[Timestamp, float]] = None) -> None:
         """Add a metric to the metric family.
 
         Args:
@@ -188,8 +188,8 @@ class SummaryMetricFamily(Metric):
     def __init__(self,
                  name: str,
                  documentation: str,
-                 count_value: Optional[float] = None,
-                 sum_value: Optional[float] = None,
+                 count_value: Optional[int] = None,
+                 sum_value: Optional[Union[int, float]] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -207,8 +207,8 @@ class SummaryMetricFamily(Metric):
 
     def add_metric(self,
                    labels: Sequence[str],
-                   count_value: float,
-                   sum_value: float,
+                   count_value: int,
+                   sum_value: Union[int, float],
                    timestamp:
                    Optional[Union[float, Timestamp]] = None
                    ) -> None:
@@ -233,7 +233,7 @@ class HistogramMetricFamily(Metric):
                  name: str,
                  documentation: str,
                  buckets: Optional[Sequence[Tuple[str, float, Optional[Exemplar]]]] = None,
-                 sum_value: Optional[float] = None,
+                 sum_value: Optional[Union[int, float]] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -251,7 +251,7 @@ class HistogramMetricFamily(Metric):
     def add_metric(self,
                    labels: Sequence[str],
                    buckets: Sequence[Tuple[str, float, Optional[Exemplar]]],
-                   sum_value: Optional[float],
+                   sum_value: Optional[Union[int, float]],
                    timestamp: Optional[Union[Timestamp, float]] = None) -> None:
         """Add a metric to the metric family.
 
@@ -295,7 +295,7 @@ class GaugeHistogramMetricFamily(Metric):
                  name: str,
                  documentation: str,
                  buckets: Optional[Sequence[Tuple[str, float]]] = None,
-                 gsum_value: Optional[float] = None,
+                 gsum_value: Optional[Union[int, float]] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -311,7 +311,7 @@ class GaugeHistogramMetricFamily(Metric):
     def add_metric(self,
                    labels: Sequence[str],
                    buckets: Sequence[Tuple[str, float]],
-                   gsum_value: Optional[float],
+                   gsum_value: Optional[Union[int, float]],
                    timestamp: Optional[Union[float, Timestamp]] = None,
                    ) -> None:
         """Add a metric to the metric family.

--- a/prometheus_client/metrics_core.py
+++ b/prometheus_client/metrics_core.py
@@ -232,7 +232,7 @@ class HistogramMetricFamily(Metric):
     def __init__(self,
                  name: str,
                  documentation: str,
-                 buckets: Optional[Sequence[Tuple[str, float, Optional[Exemplar]]]] = None,
+                 buckets: Optional[Sequence[Union[Tuple[str, float], Tuple[str, float, Exemplar]]]] = None,
                  sum_value: Optional[Union[int, float]] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
@@ -250,7 +250,7 @@ class HistogramMetricFamily(Metric):
 
     def add_metric(self,
                    labels: Sequence[str],
-                   buckets: Sequence[Tuple[str, float, Optional[Exemplar]]],
+                   buckets: Sequence[Union[Tuple[str, float], Tuple[str, float, Exemplar]]],
                    sum_value: Optional[Union[int, float]],
                    timestamp: Optional[Union[Timestamp, float]] = None) -> None:
         """Add a metric to the metric family.
@@ -267,7 +267,7 @@ class HistogramMetricFamily(Metric):
             bucket, value = b[:2]
             exemplar = None
             if len(b) == 3:
-                exemplar = b[2]
+                exemplar = b[2]  # type: ignore
             self.samples.append(Sample(
                 self.name + '_bucket',
                 dict(list(zip(self._labelnames, labels)) + [('le', bucket)]),

--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -1,13 +1,17 @@
 import platform as pf
+from typing import Any, Iterable, Optional
 
-from .metrics_core import GaugeMetricFamily
-from .registry import REGISTRY
+from .metrics_core import GaugeMetricFamily, Metric
+from .registry import Collector, CollectorRegistry, REGISTRY
 
 
-class PlatformCollector:
+class PlatformCollector(Collector):
     """Collector for python platform information"""
 
-    def __init__(self, registry=REGISTRY, platform=None):
+    def __init__(self,
+                 registry: CollectorRegistry = REGISTRY,
+                 platform: Optional[Any] = None,
+                 ):
         self._platform = pf if platform is None else platform
         info = self._info()
         system = self._platform.system()
@@ -19,7 +23,7 @@ class PlatformCollector:
         if registry:
             registry.register(self)
 
-    def collect(self):
+    def collect(self) -> Iterable[Metric]:
         return self._metrics
 
     @staticmethod

--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -1,7 +1,8 @@
 import os
+from typing import Callable, Iterable, Union
 
-from .metrics_core import CounterMetricFamily, GaugeMetricFamily
-from .registry import REGISTRY
+from .metrics_core import CounterMetricFamily, GaugeMetricFamily, Metric
+from .registry import Collector, CollectorRegistry, REGISTRY
 
 try:
     import resource
@@ -12,10 +13,14 @@ except ImportError:
     _PAGESIZE = 4096
 
 
-class ProcessCollector:
+class ProcessCollector(Collector):
     """Collector for Standard Exports such as cpu and memory."""
 
-    def __init__(self, namespace='', pid=lambda: 'self', proc='/proc', registry=REGISTRY):
+    def __init__(self,
+                 namespace: str = '',
+                 pid: Callable[[], Union[int, str]] = lambda: 'self',
+                 proc: str = '/proc',
+                 registry: CollectorRegistry = REGISTRY):
         self._namespace = namespace
         self._pid = pid
         self._proc = proc
@@ -46,7 +51,7 @@ class ProcessCollector:
                 if line.startswith(b'btime '):
                     return float(line.split()[1])
 
-    def collect(self):
+    def collect(self) -> Iterable[Metric]:
         if not self._btime:
             return []
 

--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -1,10 +1,24 @@
+from abc import ABC, abstractmethod
 import copy
 from threading import Lock
+from typing import Dict, Iterable, List, Optional
 
 from .metrics_core import Metric
 
 
-class CollectorRegistry:
+# Ideally this would be a Protocol, but Protocols are only available in Python >= 3.8.
+class Collector(ABC):
+    @abstractmethod
+    def collect(self) -> Iterable[Metric]:
+        pass
+
+
+class _EmptyCollector(Collector):
+    def collect(self) -> Iterable[Metric]:
+        return []
+
+
+class CollectorRegistry(Collector):
     """Metric collector registry.
 
     Collectors must have a no-argument method 'collect' that returns a list of
@@ -12,15 +26,15 @@ class CollectorRegistry:
     exposition formats.
     """
 
-    def __init__(self, auto_describe=False, target_info=None):
-        self._collector_to_names = {}
-        self._names_to_collectors = {}
+    def __init__(self, auto_describe: bool = False, target_info: Optional[Dict[str, str]] = None):
+        self._collector_to_names: Dict[Collector, List[str]] = {}
+        self._names_to_collectors: Dict[str, Collector] = {}
         self._auto_describe = auto_describe
         self._lock = Lock()
-        self._target_info = {}
+        self._target_info: Optional[Dict[str, str]] = {}
         self.set_target_info(target_info)
 
-    def register(self, collector):
+    def register(self, collector: Collector) -> None:
         """Add a collector to the registry."""
         with self._lock:
             names = self._get_names(collector)
@@ -33,7 +47,7 @@ class CollectorRegistry:
                 self._names_to_collectors[name] = collector
             self._collector_to_names[collector] = names
 
-    def unregister(self, collector):
+    def unregister(self, collector: Collector) -> None:
         """Remove a collector from the registry."""
         with self._lock:
             for name in self._collector_to_names[collector]:
@@ -69,7 +83,7 @@ class CollectorRegistry:
                 result.append(metric.name + suffix)
         return result
 
-    def collect(self):
+    def collect(self) -> Iterable[Metric]:
         """Yields metrics from the collectors in the registry."""
         collectors = None
         ti = None
@@ -82,7 +96,7 @@ class CollectorRegistry:
         for collector in collectors:
             yield from collector.collect()
 
-    def restricted_registry(self, names):
+    def restricted_registry(self, names: Iterable[str]) -> "RestrictedRegistry":
         """Returns object that only collects some metrics.
 
         Returns an object which upon collect() will return
@@ -95,17 +109,17 @@ class CollectorRegistry:
         names = set(names)
         return RestrictedRegistry(names, self)
 
-    def set_target_info(self, labels):
+    def set_target_info(self, labels: Optional[Dict[str, str]]) -> None:
         with self._lock:
             if labels:
                 if not self._target_info and 'target_info' in self._names_to_collectors:
                     raise ValueError('CollectorRegistry already contains a target_info metric')
-                self._names_to_collectors['target_info'] = None
+                self._names_to_collectors['target_info'] = _EmptyCollector()
             elif self._target_info:
                 self._names_to_collectors.pop('target_info', None)
             self._target_info = labels
 
-    def get_target_info(self):
+    def get_target_info(self) -> Optional[Dict[str, str]]:
         with self._lock:
             return self._target_info
 
@@ -114,7 +128,7 @@ class CollectorRegistry:
         m.add_sample('target_info', self._target_info, 1)
         return m
 
-    def get_sample_value(self, name, labels=None):
+    def get_sample_value(self, name: str, labels: Optional[Dict[str, str]] = None) -> Optional[float]:
         """Returns the sample value, or None if not found.
 
         This is inefficient, and intended only for use in unittests.
@@ -129,11 +143,11 @@ class CollectorRegistry:
 
 
 class RestrictedRegistry:
-    def __init__(self, names, registry):
+    def __init__(self, names: Iterable[str], registry: CollectorRegistry):
         self._name_set = set(names)
         self._registry = registry
 
-    def collect(self):
+    def collect(self) -> Iterable[Metric]:
         collectors = set()
         target_info_metric = None
         with self._registry._lock:

--- a/prometheus_client/samples.py
+++ b/prometheus_client/samples.py
@@ -4,30 +4,30 @@ from typing import Dict, NamedTuple, Optional, Union
 class Timestamp:
     """A nanosecond-resolution timestamp."""
 
-    def __init__(self, sec, nsec):
+    def __init__(self, sec: Union[int, float], nsec: Union[int, float]) -> None:
         if nsec < 0 or nsec >= 1e9:
             raise ValueError(f"Invalid value for nanoseconds in Timestamp: {nsec}")
         if sec < 0:
             nsec = -nsec
-        self.sec = int(sec)
-        self.nsec = int(nsec)
+        self.sec: int = int(sec)
+        self.nsec: int = int(nsec)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.sec}.{self.nsec:09d}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Timestamp({self.sec}, {self.nsec})"
 
-    def __float__(self):
+    def __float__(self) -> float:
         return float(self.sec) + float(self.nsec) / 1e9
 
-    def __eq__(self, other):
-        return type(self) == type(other) and self.sec == other.sec and self.nsec == other.nsec
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Timestamp) and self.sec == other.sec and self.nsec == other.nsec
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
-    def __gt__(self, other):
+    def __gt__(self, other: "Timestamp") -> bool:
         return self.sec > other.sec or self.nsec > other.nsec
 
 
@@ -45,6 +45,6 @@ class Exemplar(NamedTuple):
 class Sample(NamedTuple):
     name: str
     labels: Dict[str, str]
-    value: float
+    value: Union[int, float]
     timestamp: Optional[Union[float, Timestamp]] = None
     exemplar: Optional[Exemplar] = None


### PR DESCRIPTION
Fixes: #760 

This should cover most of the public surface area used by others. There is more typing work to be done before we can enable stricter types, but this will be a good next step.