### PR TITLE
Disable exporting of _created metrics via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ h = Histogram('request_latency_seconds', 'Description of histogram')
 h.observe(4.7, {'trace_id': 'abc123'})
 ```
 
+### Disabling `_created` metrics
+
+By default counters, histograms, and summaries export an additional series
+suffixed with `_created` and a value of the unix timestamp for when the metric
+was created. If this information is not helpful, it can be disabled by setting
+the environment variable `PROMETHEUS_DISABLE_CREATED_SERIES=True`.
+
 ### Process Collector
 
 The Python client automatically exports metrics about process CPU usage, RAM,


### PR DESCRIPTION
Users can disable the automatic creation of _created metrics by
specifying the environment variable PROMETHEUS_DISABLE_CREATED_SERIES.
This is controlled by an environment variable as an end user may not
have control over which registry is being used/when metrics are created.

Alternatively, we could force this to be done on the registry level and filter the metrics out
but that would not help users with custom registries. Happy to hear feedback that another
approach should be taken though.

Closes: #672  