### PR TITLE
Add support for gzip content-encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,14 @@ from prometheus_client import start_wsgi_server
 start_wsgi_server(8000)
 ```
 
+By default, the WSGI application will respect `Accept-Encoding:gzip` headers used by Prometheus
+and compress the response if such a header is present. This behaviour can be disabled by passing
+`disable_compression=True` when creating the app, like this:
+
+```python
+app = make_wsgi_app(disable_compression=True)
+```
+
 #### ASGI
 
 To use Prometheus with [ASGI](http://asgi.readthedocs.org/en/latest/), there is
@@ -350,6 +358,14 @@ app = make_asgi_app()
 ```
 Such an application can be useful when integrating Prometheus metrics with ASGI
 apps.
+
+By default, the WSGI application will respect `Accept-Encoding:gzip` headers used by Prometheus
+and compress the response if such a header is present. This behaviour can be disabled by passing 
+`disable_compression=True` when creating the app, like this:
+
+```python
+app = make_asgi_app(disable_compression=True)
+```
 
 #### Flask
 

--- a/prometheus_client/asgi.py
+++ b/prometheus_client/asgi.py
@@ -5,7 +5,7 @@ from .exposition import _bake_output
 from .registry import CollectorRegistry, REGISTRY
 
 
-def make_asgi_app(registry: CollectorRegistry = REGISTRY) -> Callable:
+def make_asgi_app(registry: CollectorRegistry = REGISTRY, disable_compression: bool = False) -> Callable:
     """Create a ASGI app which serves the metrics from a registry."""
 
     async def prometheus_app(scope, receive, send):
@@ -21,7 +21,7 @@ def make_asgi_app(registry: CollectorRegistry = REGISTRY) -> Callable:
             if name.decode("utf8").lower() == 'accept-encoding'
         ])
         # Bake output
-        status, headers, output = _bake_output(registry, accept_header, accept_encoding_header, params)
+        status, headers, output = _bake_output(registry, accept_header, accept_encoding_header, params, disable_compression)
         formatted_headers = []
         for header in headers:
             formatted_headers.append(tuple(x.encode('utf8') for x in header))

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -238,7 +238,7 @@ def generate_latest(registry: CollectorRegistry = REGISTRY) -> bytes:
 def choose_formatter(accept_header: str) -> Tuple[Callable[[CollectorRegistry], bytes], str]:
     accept_header = accept_header or ''
     for accepted in accept_header.split(','):
-        if accepted.split(';')[0].strip().lower() == 'application/openmetrics-text':
+        if accepted.split(';')[0].strip() == 'application/openmetrics-text':
             return (openmetrics.generate_latest,
                     openmetrics.CONTENT_TYPE_LATEST)
     return generate_latest, CONTENT_TYPE_LATEST

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -265,7 +265,7 @@ class MetricsHandler(BaseHTTPRequestHandler):
         accept_encoding_header = self.headers.get('Accept-Encoding')
         params = parse_qs(urlparse(self.path).query)
         # Bake output
-        status, headers, output = _bake_output(registry, accept_header, accept_encoding_header, params)
+        status, headers, output = _bake_output(registry, accept_header, accept_encoding_header, params, False)
         # Return output
         self.send_response(int(status.split(' ')[0]))
         for header in headers:

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,9 +1,14 @@
 import gzip
+import os
 from unittest import TestCase
 from wsgiref.util import setup_testing_defaults
 
-from prometheus_client import CollectorRegistry, Counter, make_wsgi_app
-from prometheus_client.exposition import _bake_output, CONTENT_TYPE_LATEST
+from prometheus_client import (
+    CollectorRegistry, Counter, exposition, make_wsgi_app,
+)
+from prometheus_client.exposition import (
+    _bake_output, _get_disable_compression, CONTENT_TYPE_LATEST,
+)
 
 
 class WSGITest(TestCase):
@@ -19,28 +24,40 @@ class WSGITest(TestCase):
         self.captured_status = status
         self.captured_headers = header
 
-    def validate_metrics(self, metric_name, help_text, increments):
-        """
-        WSGI app serves the metrics from the provided registry.
-        """
+    def increment_metrics(self, metric_name, help_text, increments):
         c = Counter(metric_name, help_text, registry=self.registry)
         for _ in range(increments):
             c.inc()
-        # Create and run WSGI app
-        app = make_wsgi_app(self.registry)
-        outputs = app(self.environ, self.capture)
-        # Assert outputs
+
+    def assert_outputs(self, outputs, metric_name, help_text, increments, compressed):
         self.assertEqual(len(outputs), 1)
-        output = outputs[0].decode('utf8')
+        if compressed:
+            output = gzip.decompress(outputs[0]).decode(encoding="utf-8")
+        else:
+            output = outputs[0].decode('utf8')
         # Status code
         self.assertEqual(self.captured_status, "200 OK")
         # Headers
-        self.assertEqual(len(self.captured_headers), 1)
-        self.assertEqual(self.captured_headers[0], ("Content-Type", CONTENT_TYPE_LATEST))
+        num_of_headers = 2 if compressed else 1
+        self.assertEqual(len(self.captured_headers), num_of_headers)
+        self.assertIn(("Content-Type", CONTENT_TYPE_LATEST), self.captured_headers)
+        if compressed:
+            self.assertIn(("Content-Encoding", "gzip"), self.captured_headers)
         # Body
         self.assertIn("# HELP " + metric_name + "_total " + help_text + "\n", output)
         self.assertIn("# TYPE " + metric_name + "_total counter\n", output)
         self.assertIn(metric_name + "_total " + str(increments) + ".0\n", output)
+
+    def validate_metrics(self, metric_name, help_text, increments):
+        """
+        WSGI app serves the metrics from the provided registry.
+        """
+        self.increment_metrics(metric_name, help_text, increments)
+        # Create and run WSGI app
+        app = make_wsgi_app(self.registry)
+        outputs = app(self.environ, self.capture)
+        # Assert outputs
+        self.assert_outputs(outputs, metric_name, help_text, increments, compressed=False)
 
     def test_report_metrics_1(self):
         self.validate_metrics("counter", "A counter", 2)
@@ -77,24 +94,29 @@ class WSGITest(TestCase):
         metric_name = "counter"
         help_text = "A counter"
         increments = 2
-        c = Counter(metric_name, help_text, registry=self.registry)
-        for _ in range(increments):
-            c.inc()
+        self.increment_metrics(metric_name, help_text, increments)
         app = make_wsgi_app(self.registry)
         # Try accessing metrics using the gzip Accept-Content header.
         gzip_environ = dict(self.environ)
         gzip_environ['HTTP_ACCEPT_ENCODING'] = 'gzip'
         outputs = app(gzip_environ, self.capture)
         # Assert outputs
-        self.assertEqual(len(outputs), 1)
-        output = gzip.decompress(outputs[0]).decode(encoding="utf-8")
-        # Status code
-        self.assertEqual(self.captured_status, "200 OK")
-        # Headers
-        self.assertEqual(len(self.captured_headers), 2)
-        self.assertIn(("Content-Type", CONTENT_TYPE_LATEST), self.captured_headers)
-        self.assertIn(("Content-Encoding", "gzip"), self.captured_headers)
-        # Body
-        self.assertIn("# HELP " + metric_name + "_total " + help_text + "\n", output)
-        self.assertIn("# TYPE " + metric_name + "_total counter\n", output)
-        self.assertIn(metric_name + "_total " + str(increments) + ".0\n", output)
+        self.assert_outputs(outputs, metric_name, help_text, increments, compressed=True)
+
+    def test_gzip_disabled_by_env_var(self):
+        # Increment a metric
+        metric_name = "counter"
+        help_text = "A counter"
+        increments = 2
+        self.increment_metrics(metric_name, help_text, increments)
+        # Set the env var disabling compression.
+        os.environ["PROMETHEUS_DISABLE_COMPRESSION"] = 'True'
+        exposition._disable_compression = _get_disable_compression()
+        app = make_wsgi_app(self.registry)
+        # Try accessing metrics using the gzip Accept-Content header.
+        gzip_environ = dict(self.environ)
+        gzip_environ['HTTP_ACCEPT_ENCODING'] = 'gzip'
+        outputs = app(gzip_environ, self.capture)
+        # Assert outputs
+        self.assert_outputs(outputs, metric_name, help_text, increments, compressed=False)
+        os.environ.pop('PROMETHEUS_DISABLE_COMPRESSION', None)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,3 +1,4 @@
+import gzip
 from unittest import TestCase
 from wsgiref.util import setup_testing_defaults
 
@@ -70,3 +71,30 @@ class WSGITest(TestCase):
             # Try accessing normal paths
             app(self.environ, self.capture)
             self.assertEqual(mock.call_count, 1)
+
+    def test_gzip(self):
+        # Increment a metric
+        metric_name = "counter"
+        help_text = "A counter"
+        increments = 2
+        c = Counter(metric_name, help_text, registry=self.registry)
+        for _ in range(increments):
+            c.inc()
+        app = make_wsgi_app(self.registry)
+        # Try accessing metrics using the gzip Accept-Content header.
+        gzip_environ = dict(self.environ)
+        gzip_environ['HTTP_ACCEPT_ENCODING'] = 'gzip'
+        outputs = app(gzip_environ, self.capture)
+        # Assert outputs
+        self.assertEqual(len(outputs), 1)
+        output = gzip.decompress(outputs[0]).decode(encoding="utf-8")
+        # Status code
+        self.assertEqual(self.captured_status, "200 OK")
+        # Headers
+        self.assertEqual(len(self.captured_headers), 2)
+        self.assertIn(("Content-Type", CONTENT_TYPE_LATEST), self.captured_headers)
+        self.assertIn(("Content-Encoding", "gzip"), self.captured_headers)
+        # Body
+        self.assertIn("# HELP " + metric_name + "_total " + help_text + "\n", output)
+        self.assertIn("# TYPE " + metric_name + "_total counter\n", output)
+        self.assertIn(metric_name + "_total " + str(increments) + ".0\n", output)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -2,9 +2,7 @@ import gzip
 from unittest import TestCase
 from wsgiref.util import setup_testing_defaults
 
-from prometheus_client import (
-    CollectorRegistry, Counter, make_wsgi_app,
-)
+from prometheus_client import CollectorRegistry, Counter, make_wsgi_app
 from prometheus_client.exposition import _bake_output, CONTENT_TYPE_LATEST
 
 


### PR DESCRIPTION
Resolves https://github.com/prometheus/client_python/issues/775

If an `Accept-Encoding:gzip` header is present, will compress the output and set the correct `Content-Encoding` header in the response. Added tests for both the wsgi and asgi implementations.