### PR TITLE
Simplify type annotations for number types

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -270,7 +270,7 @@ class Counter(MetricWrapperBase):
                                         self._labelvalues)
         self._created = time.time()
 
-    def inc(self, amount: Union[int, float] = 1, exemplar: Optional[Dict[str, str]] = None) -> None:
+    def inc(self, amount: float = 1, exemplar: Optional[Dict[str, str]] = None) -> None:
         """Increment counter by the given amount."""
         self._raise_if_not_observable()
         if amount < 0:
@@ -369,17 +369,17 @@ class Gauge(MetricWrapperBase):
             multiprocess_mode=self._multiprocess_mode
         )
 
-    def inc(self, amount: Union[int, float] = 1) -> None:
+    def inc(self, amount: float = 1) -> None:
         """Increment gauge by the given amount."""
         self._raise_if_not_observable()
         self._value.inc(amount)
 
-    def dec(self, amount: Union[int, float] = 1) -> None:
+    def dec(self, amount: float = 1) -> None:
         """Decrement gauge by the given amount."""
         self._raise_if_not_observable()
         self._value.inc(-amount)
 
-    def set(self, value: Union[int, float]) -> None:
+    def set(self, value: float) -> None:
         """Set gauge to the given value."""
         self._raise_if_not_observable()
         self._value.set(float(value))
@@ -462,7 +462,7 @@ class Summary(MetricWrapperBase):
         self._sum = values.ValueClass(self._type, self._name, self._name + '_sum', self._labelnames, self._labelvalues)
         self._created = time.time()
 
-    def observe(self, amount: Union[int, float]) -> None:
+    def observe(self, amount: float) -> None:
         """Observe the given amount.
 
         The amount is usually positive or zero. Negative values are
@@ -539,7 +539,7 @@ class Histogram(MetricWrapperBase):
                  unit: str = '',
                  registry: Optional[CollectorRegistry] = REGISTRY,
                  _labelvalues: Optional[Sequence[str]] = None,
-                 buckets: Sequence[Union[float, int, str]] = DEFAULT_BUCKETS,
+                 buckets: Sequence[Union[float, str]] = DEFAULT_BUCKETS,
                  ):
         self._prepare_buckets(buckets)
         super().__init__(
@@ -554,7 +554,7 @@ class Histogram(MetricWrapperBase):
         )
         self._kwargs['buckets'] = buckets
 
-    def _prepare_buckets(self, source_buckets: Sequence[Union[float, int, str]]) -> None:
+    def _prepare_buckets(self, source_buckets: Sequence[Union[float, str]]) -> None:
         buckets = [float(b) for b in source_buckets]
         if buckets != sorted(buckets):
             # This is probably an error on the part of the user,
@@ -580,7 +580,7 @@ class Histogram(MetricWrapperBase):
                 self._labelvalues + (floatToGoString(b),))
             )
 
-    def observe(self, amount: Union[int, float], exemplar: Optional[Dict[str, str]] = None) -> None:
+    def observe(self, amount: float, exemplar: Optional[Dict[str, str]] = None) -> None:
         """Observe the given amount.
 
         The amount is usually positive or zero. Negative values are

--- a/prometheus_client/metrics_core.py
+++ b/prometheus_client/metrics_core.py
@@ -36,7 +36,7 @@ class Metric:
         self.type: str = typ
         self.samples: List[Sample] = []
 
-    def add_sample(self, name: str, labels: Dict[str, str], value: Union[int, float], timestamp: Optional[Union[Timestamp, float]] = None, exemplar: Optional[Exemplar] = None) -> None:
+    def add_sample(self, name: str, labels: Dict[str, str], value: float, timestamp: Optional[Union[Timestamp, float]] = None, exemplar: Optional[Exemplar] = None) -> None:
         """Add a sample to the metric.
 
         Internal-only, do not use."""
@@ -77,7 +77,7 @@ class UnknownMetricFamily(Metric):
     def __init__(self,
                  name: str,
                  documentation: str,
-                 value: Optional[Union[int, float]] = None,
+                 value: Optional[float] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -90,7 +90,7 @@ class UnknownMetricFamily(Metric):
         if value is not None:
             self.add_metric([], value)
 
-    def add_metric(self, labels: Sequence[str], value: Union[int, float], timestamp: Optional[Union[Timestamp, float]] = None) -> None:
+    def add_metric(self, labels: Sequence[str], value: float, timestamp: Optional[Union[Timestamp, float]] = None) -> None:
         """Add a metric to the metric family.
         Args:
         labels: A list of label values
@@ -112,7 +112,7 @@ class CounterMetricFamily(Metric):
     def __init__(self,
                  name: str,
                  documentation: str,
-                 value: Optional[Union[int, float]] = None,
+                 value: Optional[float] = None,
                  labels: Sequence[str] = None,
                  created: Optional[float] = None,
                  unit: str = '',
@@ -131,7 +131,7 @@ class CounterMetricFamily(Metric):
 
     def add_metric(self,
                    labels: Sequence[str],
-                   value: Union[int, float],
+                   value: float,
                    created: Optional[float] = None,
                    timestamp: Optional[Union[Timestamp, float]] = None,
                    ) -> None:
@@ -156,7 +156,7 @@ class GaugeMetricFamily(Metric):
     def __init__(self,
                  name: str,
                  documentation: str,
-                 value: Optional[Union[int, float]] = None,
+                 value: Optional[float] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -169,7 +169,7 @@ class GaugeMetricFamily(Metric):
         if value is not None:
             self.add_metric([], value)
 
-    def add_metric(self, labels: Sequence[str], value: Union[int, float], timestamp: Optional[Union[Timestamp, float]] = None) -> None:
+    def add_metric(self, labels: Sequence[str], value: float, timestamp: Optional[Union[Timestamp, float]] = None) -> None:
         """Add a metric to the metric family.
 
         Args:
@@ -189,7 +189,7 @@ class SummaryMetricFamily(Metric):
                  name: str,
                  documentation: str,
                  count_value: Optional[int] = None,
-                 sum_value: Optional[Union[int, float]] = None,
+                 sum_value: Optional[float] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -208,7 +208,7 @@ class SummaryMetricFamily(Metric):
     def add_metric(self,
                    labels: Sequence[str],
                    count_value: int,
-                   sum_value: Union[int, float],
+                   sum_value: float,
                    timestamp:
                    Optional[Union[float, Timestamp]] = None
                    ) -> None:
@@ -233,7 +233,7 @@ class HistogramMetricFamily(Metric):
                  name: str,
                  documentation: str,
                  buckets: Optional[Sequence[Union[Tuple[str, float], Tuple[str, float, Exemplar]]]] = None,
-                 sum_value: Optional[Union[int, float]] = None,
+                 sum_value: Optional[float] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -251,7 +251,7 @@ class HistogramMetricFamily(Metric):
     def add_metric(self,
                    labels: Sequence[str],
                    buckets: Sequence[Union[Tuple[str, float], Tuple[str, float, Exemplar]]],
-                   sum_value: Optional[Union[int, float]],
+                   sum_value: Optional[float],
                    timestamp: Optional[Union[Timestamp, float]] = None) -> None:
         """Add a metric to the metric family.
 
@@ -295,7 +295,7 @@ class GaugeHistogramMetricFamily(Metric):
                  name: str,
                  documentation: str,
                  buckets: Optional[Sequence[Tuple[str, float]]] = None,
-                 gsum_value: Optional[Union[int, float]] = None,
+                 gsum_value: Optional[float] = None,
                  labels: Optional[Sequence[str]] = None,
                  unit: str = '',
                  ):
@@ -311,7 +311,7 @@ class GaugeHistogramMetricFamily(Metric):
     def add_metric(self,
                    labels: Sequence[str],
                    buckets: Sequence[Tuple[str, float]],
-                   gsum_value: Optional[Union[int, float]],
+                   gsum_value: Optional[float],
                    timestamp: Optional[Union[float, Timestamp]] = None,
                    ) -> None:
         """Add a metric to the metric family.

--- a/prometheus_client/samples.py
+++ b/prometheus_client/samples.py
@@ -4,7 +4,7 @@ from typing import Dict, NamedTuple, Optional, Union
 class Timestamp:
     """A nanosecond-resolution timestamp."""
 
-    def __init__(self, sec: Union[int, float], nsec: Union[int, float]) -> None:
+    def __init__(self, sec: float, nsec: float) -> None:
         if nsec < 0 or nsec >= 1e9:
             raise ValueError(f"Invalid value for nanoseconds in Timestamp: {nsec}")
         if sec < 0:
@@ -45,6 +45,6 @@ class Exemplar(NamedTuple):
 class Sample(NamedTuple):
     name: str
     labels: Dict[str, str]
-    value: Union[int, float]
+    value: float
     timestamp: Optional[Union[float, Timestamp]] = None
     exemplar: Optional[Exemplar] = None


### PR DESCRIPTION
@csmarchbanks Thanks for maintaining the project! A small patch to improve the readability of type annotations:

int values are acceptable to float variables:
https://www.python.org/dev/peps/pep-0484/#the-numeric-tower

Signed-off-by: Yiyang Zhan <pon.zhan@gmail.com>