### PR TITLE
Add 'namespace' parameter to GCCollector and PlatformCollector

### DIFF
--- a/prometheus_client/gc_collector.py
+++ b/prometheus_client/gc_collector.py
@@ -9,25 +9,33 @@ from .registry import Collector, CollectorRegistry, REGISTRY
 class GCCollector(Collector):
     """Collector for Garbage collection statistics."""
 
-    def __init__(self, registry: CollectorRegistry = REGISTRY):
+    def __init__(self,
+                 registry: CollectorRegistry = REGISTRY,
+                 namespace: str = '',
+                 ):
+        if namespace:
+            self._prefix = namespace + '_python_gc_'
+        else:
+            self._prefix = 'python_gc_'
+
         if not hasattr(gc, 'get_stats') or platform.python_implementation() != 'CPython':
             return
         registry.register(self)
 
     def collect(self) -> Iterable[Metric]:
         collected = CounterMetricFamily(
-            'python_gc_objects_collected',
+            self._prefix + 'objects_collected',
             'Objects collected during gc',
             labels=['generation'],
         )
         uncollectable = CounterMetricFamily(
-            'python_gc_objects_uncollectable',
+            self._prefix + 'objects_uncollectable',
             'Uncollectable object found during GC',
             labels=['generation'],
         )
 
         collections = CounterMetricFamily(
-            'python_gc_collections',
+            self._prefix + 'collections',
             'Number of times this generation was collected',
             labels=['generation'],
         )

--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -11,14 +11,20 @@ class PlatformCollector(Collector):
     def __init__(self,
                  registry: CollectorRegistry = REGISTRY,
                  platform: Optional[Any] = None,
+                 namespace: str = '',
                  ):
+        if namespace:
+            name = namespace + '_python_info'
+        else:
+            name = "python_info"
+
         self._platform = pf if platform is None else platform
         info = self._info()
         system = self._platform.system()
         if system == "Java":
             info.update(self._java())
         self._metrics = [
-            self._add_metric("python_info", "Python platform information", info)
+            self._add_metric(name, "Python platform information", info)
         ]
         if registry:
             registry.register(self)

--- a/tests/test_gc_collector.py
+++ b/tests/test_gc_collector.py
@@ -51,5 +51,13 @@ class TestGCCollector(unittest.TestCase):
                                                labels={"generation": "0"})
         self.assertEqual(0, after - before)
 
+    def test_namespace(self):
+        GCCollector(registry=self.registry, namespace="foobar")
+        self.registry.collect()
+
+        self.assertIsNotNone(self.registry.get_sample_value('foobar_python_gc_objects_collected_total', labels={"generation": "0"}))
+        self.assertIsNotNone(self.registry.get_sample_value('foobar_python_gc_objects_uncollectable_total', labels={"generation": "0"}))
+        self.assertIsNotNone(self.registry.get_sample_value('foobar_python_gc_collections_total', labels={"generation": "0"}))
+
     def tearDown(self):
         gc.enable()

--- a/tests/test_platform_collector.py
+++ b/tests/test_platform_collector.py
@@ -18,6 +18,16 @@ class TestPlatformCollector(unittest.TestCase):
             "patchlevel": "pvt_patchlevel"
         })
 
+    def test_namespace(self):
+        PlatformCollector(registry=self.registry, platform=self.platform, namespace="foobar")
+        self.assertLabels("foobar_python_info", {
+            "version": "python_version",
+            "implementation": "python_implementation",
+            "major": "pvt_major",
+            "minor": "pvt_minor",
+            "patchlevel": "pvt_patchlevel"
+        })
+
     def test_system_info_java(self):
         self.platform._system = "Java"
         PlatformCollector(registry=self.registry, platform=self.platform)


### PR DESCRIPTION
This allow setting custom namespace when you need to export data using pushgateway.

Parameter was already there in `ProcessCollector`.