### PR TITLE
Add `sum`, `livemin`, and `livemax` multiprocess modes for `Gauge`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,9 +614,12 @@ Gauges have several modes they can run in, which can be selected with the `multi
 
 - 'all': Default. Return a timeseries per process alive or dead.
 - 'liveall': Return a timeseries per process that is still alive.
+- 'sum': Return a single timeseries that is the sum of the values of all processes, alive or dead.
 - 'livesum': Return a single timeseries that is the sum of the values of alive processes.
 - 'max': Return a single timeseries that is the maximum of the values of all processes, alive or dead.
+- 'livemax': Return a single timeseries that is the maximum of the values of alive processes.
 - 'min': Return a single timeseries that is the minimum of the values of all processes, alive or dead.
+- 'livemin': Return a single timeseries that is the minimum of the values of alive processes.
 
 ```python
 from prometheus_client import Gauge

--- a/README.md
+++ b/README.md
@@ -609,17 +609,17 @@ def child_exit(server, worker):
 
 **4. Metrics tuning (Gauge)**:
 
-When `Gauge` metrics are used, additional tuning needs to be performed.
+When `Gauge`s are used in multiprocess applications,
+you must decide how to handle the metrics reported by each process.
 Gauges have several modes they can run in, which can be selected with the `multiprocess_mode` parameter.
 
-- 'all': Default. Return a timeseries per process alive or dead.
-- 'liveall': Return a timeseries per process that is still alive.
-- 'sum': Return a single timeseries that is the sum of the values of all processes, alive or dead.
-- 'livesum': Return a single timeseries that is the sum of the values of alive processes.
-- 'max': Return a single timeseries that is the maximum of the values of all processes, alive or dead.
-- 'livemax': Return a single timeseries that is the maximum of the values of alive processes.
-- 'min': Return a single timeseries that is the minimum of the values of all processes, alive or dead.
-- 'livemin': Return a single timeseries that is the minimum of the values of alive processes.
+- 'all': Default. Return a timeseries per process (alive or dead), tagged by the process's `pid` (the tag is added internally).
+- 'min': Return a single timeseries that is the minimum of the values of all processes (alive or dead).
+- 'max': Return a single timeseries that is the maximum of the values of all processes (alive or dead).
+- 'sum': Return a single timeseries that is the sum of the values of all processes (alive or dead).
+
+Prepend 'live' to the beginning of the mode to return the same result but only considering living processes
+(e.g., 'liveall, 'livesum', 'livemax', 'livemin').
 
 ```python
 from prometheus_client import Gauge

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ When `Gauge`s are used in multiprocess applications,
 you must decide how to handle the metrics reported by each process.
 Gauges have several modes they can run in, which can be selected with the `multiprocess_mode` parameter.
 
-- 'all': Default. Return a timeseries per process (alive or dead), tagged by the process's `pid` (the tag is added internally).
+- 'all': Default. Return a timeseries per process (alive or dead), labelled by the process's `pid` (the label is added internally).
 - 'min': Return a single timeseries that is the minimum of the values of all processes (alive or dead).
 - 'max': Return a single timeseries that is the maximum of the values of all processes (alive or dead).
 - 'sum': Return a single timeseries that is the sum of the values of all processes (alive or dead).

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -346,7 +346,7 @@ class Gauge(MetricWrapperBase):
         d.set_function(lambda: len(my_dict))
     """
     _type = 'gauge'
-    _MULTIPROC_MODES = frozenset(('min', 'max', 'livesum', 'liveall', 'all'))
+    _MULTIPROC_MODES = frozenset(('min', 'livemin', 'max', 'livemax', 'sum', 'livesum', 'all', 'liveall'))
 
     def __init__(self,
                  name: str,

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -346,7 +346,7 @@ class Gauge(MetricWrapperBase):
         d.set_function(lambda: len(my_dict))
     """
     _type = 'gauge'
-    _MULTIPROC_MODES = frozenset(('min', 'livemin', 'max', 'livemax', 'sum', 'livesum', 'all', 'liveall'))
+    _MULTIPROC_MODES = frozenset(('all', 'liveall', 'min', 'livemin', 'max', 'livemax', 'sum', 'livesum'))
 
     def __init__(self,
                  name: str,

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -132,6 +132,17 @@ class TestMultiProcess(unittest.TestCase):
         g2.set(2)
         self.assertEqual(1, self.registry.get_sample_value('g'))
 
+    def test_gauge_livemin(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='livemin')
+        values.ValueClass = MultiProcessValue(lambda: 456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='livemin')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value('g'))
+        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
+        self.assertEqual(2, self.registry.get_sample_value('g'))
+
     def test_gauge_max(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='max')
         values.ValueClass = MultiProcessValue(lambda: 456)
@@ -140,6 +151,28 @@ class TestMultiProcess(unittest.TestCase):
         g1.set(1)
         g2.set(2)
         self.assertEqual(2, self.registry.get_sample_value('g'))
+
+    def test_gauge_livemax(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='livemax')
+        values.ValueClass = MultiProcessValue(lambda: 456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='livemax')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(2)
+        g2.set(1)
+        self.assertEqual(2, self.registry.get_sample_value('g'))
+        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
+        self.assertEqual(1, self.registry.get_sample_value('g'))
+
+    def test_gauge_sum(self):
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='sum')
+        values.ValueClass = MultiProcessValue(lambda: 456)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='sum')
+        self.assertEqual(0, self.registry.get_sample_value('g'))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(3, self.registry.get_sample_value('g'))
+        mark_process_dead(123, os.environ['PROMETHEUS_MULTIPROC_DIR'])
+        self.assertEqual(3, self.registry.get_sample_value('g'))
 
     def test_gauge_livesum(self):
         g1 = Gauge('g', 'help', registry=None, multiprocess_mode='livesum')


### PR DESCRIPTION
Hi!

I work on a multiprocess Flask application and we recently found ourselves wanting the equivalent of the `max` multiprocessing mode, but only for live processes. I came here to poke around the code and also noticed this recent issue asking for a `sum` mode https://github.com/prometheus/client_python/issues/793 , so it seems like there's some interest in more multiprocess modes.

If I understand correctly, the core change needed to support this is actually around the deletion of the files when a process dies - files for `live*` metrics should be deleted, others should not. So I added the new modes with the same collection logic as their non-live counterparts and expanded the check in `mark_process_dead()` to automatically include any metric with `live` as part of its multiprocess mode name (this might be excessively fancy, but it seemed useful to reduce potential future changes).

I also added tests to cover these new modes based on the existing tests and updated the `README.md` to describe the new modes.