### PR TITLE
updated README installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ other information about the process for free!
 ## Installation
 
 ```
-pip install prometheus_client
+pip install prometheus-client
 ```
 
 This package can be found on


### PR DESCRIPTION
The command says pip install prometheus_client (underscore) but the steps above and PyPi says prometheus-client (dash) 

Signed-off-by: Alexa Griffith  <agriffith96@gmail.com>