### PR TITLE
Remove choose_formatter before 0.15.0 release

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -15,7 +15,6 @@ from urllib.request import (
     BaseHandler, build_opener, HTTPHandler, HTTPRedirectHandler, HTTPSHandler,
     Request,
 )
-import warnings
 from wsgiref.simple_server import make_server, WSGIRequestHandler, WSGIServer
 
 from .openmetrics import exposition as openmetrics
@@ -247,15 +246,6 @@ def choose_encoder(accept_header: str) -> Tuple[Callable[[CollectorRegistry], by
             return (openmetrics.generate_latest,
                     openmetrics.CONTENT_TYPE_LATEST)
     return generate_latest, CONTENT_TYPE_LATEST
-
-
-def choose_formatter(accept_header: str) -> Tuple[Callable[[CollectorRegistry], bytes], str]:
-    warnings.warn(
-        "choose_formatter is deprecated and will be removed in 0.15.0, please use choose_encoder instead",
-        DeprecationWarning,
-        stacklevel=2
-    )
-    return choose_encoder(accept_header)
 
 
 def gzip_accepted(accept_encoding_header: str) -> bool:

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -3,7 +3,6 @@ import os
 import threading
 import time
 import unittest
-import warnings
 
 import pytest
 
@@ -14,8 +13,8 @@ from prometheus_client import (
 )
 from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp
 from prometheus_client.exposition import (
-    basic_auth_handler, choose_encoder, choose_formatter, default_handler,
-    MetricsHandler, passthrough_redirect_handler, tls_auth_handler,
+    basic_auth_handler, choose_encoder, default_handler, MetricsHandler,
+    passthrough_redirect_handler, tls_auth_handler,
 )
 import prometheus_client.openmetrics.exposition as openmetrics
 
@@ -478,14 +477,6 @@ def test_choose_encoder():
     assert choose_encoder(None) == (generate_latest, CONTENT_TYPE_LATEST)
     assert choose_encoder(CONTENT_TYPE_LATEST) == (generate_latest, CONTENT_TYPE_LATEST)
     assert choose_encoder(openmetrics.CONTENT_TYPE_LATEST) == (openmetrics.generate_latest, openmetrics.CONTENT_TYPE_LATEST)
-
-
-def test_choose_formatter():
-    with warnings.catch_warnings(record=True) as w:
-        assert choose_formatter('') == (generate_latest, CONTENT_TYPE_LATEST)
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
-        assert "choose_formatter is deprecated" in str(w[-1].message)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The original choose_encoder function was accidentally renamed in 0.14.0 to choose_formatter. In 0.14.1 we left both functions but with choose_formatter marked deprecated and to be removed by 0.15.0.