### PR TITLE
Upgrade development dependencies, fix some types

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -370,8 +370,8 @@ def basic_auth_handler(
         timeout: Optional[float],
         headers: List[Tuple[str, str]],
         data: bytes,
-        username: str = None,
-        password: str = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
 ) -> Callable[[], None]:
     """Handler that implements HTTP/HTTPS connections with Basic Auth.
 

--- a/prometheus_client/metrics_core.py
+++ b/prometheus_client/metrics_core.py
@@ -113,7 +113,7 @@ class CounterMetricFamily(Metric):
                  name: str,
                  documentation: str,
                  value: Optional[float] = None,
-                 labels: Sequence[str] = None,
+                 labels: Optional[Sequence[str]] = None,
                  created: Optional[float] = None,
                  unit: str = '',
                  ):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = coverage-clean,py3.6,py3.7,py3.8,py3.9,py3.10,pypy3.7,py3.9-nooptionals,coverage-report,flake8,isort,mypy
 
-
 [base]
 deps =
     coverage
@@ -23,7 +22,6 @@ deps = coverage
 skip_install = true
 commands = coverage erase
 
-
 [testenv:coverage-report]
 deps = coverage
 skip_install = true
@@ -31,19 +29,18 @@ commands =
     coverage combine
     coverage report
 
-
 [testenv:flake8]
 deps =
-    flake8==3.7.8
-    flake8-docstrings==1.5.0
-    flake8-import-order==0.18.1
+    flake8==6.0.0
+    flake8-docstrings==1.6.0
+    flake8-import-order==0.18.2
 skip_install = true
 commands =
     flake8 prometheus_client/ tests/ setup.py
 
 [testenv:isort]
 deps =
-    isort==5.5.4
+    isort==5.10.1
 skip_install = true
 commands =
     isort --check prometheus_client/ tests/ setup.py
@@ -52,7 +49,7 @@ commands =
 deps =
     pytest
     asgiref
-    mypy==0.910
+    mypy==0.991
 skip_install = true
 commands =
     mypy --install-types --non-interactive prometheus_client/ tests/
@@ -76,7 +73,6 @@ ignore =
 per-file-ignores = prometheus_client/__init__.py:F401
 import-order-style = google
 application-import-names = prometheus_client
-
 
 [isort]
 force_alphabetical_sort_within_sections = True


### PR DESCRIPTION
Hello ✋🏻 I decided to fix one problem in the library, but along the way I ran into another problem - flake8 did not work.

<details>
  <summary>Traceback here</summary>
  
  ```
evgenymarkov@hellroot python-prometheus % python -m tox -e flake8
flake8 recreate: /Users/evgenymarkov/Personal/python-prometheus/.tox/flake8
flake8 installdeps: flake8==3.7.8, flake8-docstrings==1.5.0, flake8-import-order==0.18.1
flake8 installed: entrypoints==0.3,flake8==3.7.8,flake8-docstrings==1.5.0,flake8-import-order==0.18.1,mccabe==0.6.1,pycodestyle==2.5.0,pydocstyle==6.1.1,pyflakes==2.1.1,snowballstemmer==2.2.0
flake8 run-test-pre: PYTHONHASHSEED='1913327212'
flake8 run-test: commands[0] | flake8 prometheus_client/ tests/ setup.py
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/Users/evgenymarkov/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/Users/evgenymarkov/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/checker.py", line 666, in _run_checks
    return checker.run_checks()
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/checker.py", line 598, in run_checks
    self.run_ast_checks()
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/checker.py", line 502, in run_ast_checks
    for (line_number, offset, text, check) in runner:
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8_import_order/flake8_linter.py", line 91, in run
    for error in self.check_order():
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8_import_order/checker.py", line 55, in check_order
    style_entry_point = self.options['import_order_style']
TypeError: 'NoneType' object is not subscriptable
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/main/cli.py", line 18, in main
    app.run(argv)
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/main/application.py", line 393, in run
    self._run(argv)
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/main/application.py", line 381, in _run
    self.run_checks()
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/main/application.py", line 300, in run_checks
    self.file_checker_manager.run()
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/checker.py", line 329, in run
    self.run_parallel()
  File "/Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/lib/python3.10/site-packages/flake8/checker.py", line 293, in run_parallel
    for ret in pool_map:
  File "/Users/evgenymarkov/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/pool.py", line 451, in <genexpr>
    return (item for chunk in result for item in chunk)
  File "/Users/evgenymarkov/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/pool.py", line 873, in next
    raise value
TypeError: 'NoneType' object is not subscriptable
ERROR: InvocationError for command /Users/evgenymarkov/Personal/python-prometheus/.tox/flake8/bin/flake8 prometheus_client/ tests/ setup.py (exited with code 1)
____________________________________________________________ summary _____________________________________________________________
ERROR:   flake8: commands failed
  ```
  
</details>

I managed to fix this by updating Flake8 to the latest version. I also updated Mypy to the latest version and it found some typing errors. I fixed it.