### PR TITLE
Allow Prometheus parser to handle missing space

### DIFF
--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -116,8 +116,8 @@ def _parse_sample(text):
         name = text[:label_start].strip()
         # We ignore the starting curly brace
         label = text[label_start + 1:label_end]
-        # The value is after the label end (ignoring curly brace and space)
-        value, timestamp = _parse_value_and_timestamp(text[label_end + 2:])
+        # The value is after the label end (ignoring curly brace)
+        value, timestamp = _parse_value_and_timestamp(text[label_end + 1:])
         return Sample(name, _parse_labels(label), value, timestamp)
 
     # We don't have labels

--- a/tests/openmetrics/test_parser.py
+++ b/tests/openmetrics/test_parser.py
@@ -642,6 +642,8 @@ bar_bucket{a="c",le="+Inf"} 0.0
             ('a{a""} 1\n# EOF\n'),
             ('a{a=} 1\n# EOF\n'),
             ('a{a="} 1\n# EOF\n'),
+            # Missing delimiters.
+            ('a{a="1"}1\n# EOF\n'),
             # Missing or extra commas.
             ('a{a="1"b="2"} 1\n# EOF\n'),
             ('a{a="1",,b="2"} 1\n# EOF\n'),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -146,6 +146,7 @@ a\t\t{\t\tfoo\t\t=\t\t"baz"\t\t}\t\t2
 a   {    foo   =  "buz"   }    3
 a\t {  \t foo\t = "biz"\t  } \t 4
 a \t{\t foo   = "boz"\t}\t 5
+a{foo="bez"}6
 """)
         metric_family = CounterMetricFamily("a", "help", labels=["foo"])
         metric_family.add_metric(["bar"], 1)
@@ -153,6 +154,7 @@ a \t{\t foo   = "boz"\t}\t 5
         metric_family.add_metric(["buz"], 3)
         metric_family.add_metric(["biz"], 4)
         metric_family.add_metric(["boz"], 5)
+        metric_family.add_metric(["bez"], 6)
         self.assertEqualMetrics([metric_family], list(families))
 
     def test_commas(self):


### PR DESCRIPTION
If there is no delimiter separating the labels and value when parsing the Prometheus format the parser currently will chop off the first digit of the value. Instead, allow a missing delimiter in the Prometheus format to align with what the Go parser does.

In addition, add a test to specifically check that a delimiter is still required in OpenMetrics.

Fixes: #871 