### PR TITLE
Add tests for Python 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       python:
         type: string
     docker:
-      - image: circleci/python:<< parameters.python >>
+      - image: cimg/python:<< parameters.python >>
     environment:
       TOXENV: "py<< parameters.python >>"
     steps:
@@ -80,6 +80,7 @@ workflows:
                  - "3.8"
                  - "3.9"
                  - "3.10"
+                 - "3.11"
       - test_nooptionals:
           matrix:
             parameters:

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Monitoring",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py3.6,py3.7,py3.8,py3.9,py3.10,pypy3.7,py3.9-nooptionals,coverage-report,flake8,isort,mypy
+envlist = coverage-clean,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,pypy3.7,py3.9-nooptionals,coverage-report,flake8,isort,mypy
 
 [base]
 deps =


### PR DESCRIPTION
The base image has also been moved to the new cimg repositories which are direct replacements for circleci.