### PR TITLE
Allow tuples of exceptions in ExceptionCounter

### DIFF
--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -1,7 +1,9 @@
 import sys
 from timeit import default_timer
 from types import TracebackType
-from typing import Any, Callable, Optional, Type, TYPE_CHECKING, TypeVar
+from typing import (
+    Any, Callable, Optional, Tuple, Type, TYPE_CHECKING, TypeVar, Union,
+)
 
 if sys.version_info >= (3, 8, 0):
     from typing import Literal
@@ -14,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class ExceptionCounter:
-    def __init__(self, counter: "Counter", exception: Type[BaseException]) -> None:
+    def __init__(self, counter: "Counter", exception: Union[Type[BaseException], Tuple[Type[BaseException], ...]]) -> None:
         self._counter = counter
         self._exception = exception
 

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -3,8 +3,8 @@ from threading import Lock
 import time
 import types
 from typing import (
-    Any, Callable, Dict, Iterable, List, Optional, Sequence, Type, TypeVar,
-    Union,
+    Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Type,
+    TypeVar, Union,
 )
 
 from . import values  # retain this import style for testability
@@ -288,7 +288,7 @@ class Counter(MetricWrapperBase):
             _validate_exemplar(exemplar)
             self._value.set_exemplar(Exemplar(exemplar, amount, time.time()))
 
-    def count_exceptions(self, exception: Type[BaseException] = Exception) -> ExceptionCounter:
+    def count_exceptions(self, exception: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = Exception) -> ExceptionCounter:
         """Count exceptions in a block of code or function.
 
         Can be used as a function decorator or context manager.


### PR DESCRIPTION
`ExceptionCounter.__exit__` kicks down to `isinstance`, which accepts either a single type or a tuple of types (or in Python 3.10, a UnionType).  Update type annotations to reflect this.