### PR TITLE
Extend type forwarding to other context managers

### DIFF
--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -46,7 +46,7 @@ class InprogressTracker:
     def __exit__(self, typ, value, traceback):
         self._gauge.dec()
 
-    def __call__(self, f):
+    def __call__(self, f: "F") -> "F":
         def wrapped(func, *args, **kwargs):
             with self:
                 return func(*args, **kwargs)
@@ -75,7 +75,7 @@ class Timer:
     def labels(self, *args, **kw):
         self._metric = self._metric.labels(*args, **kw)
 
-    def __call__(self, f):
+    def __call__(self, f : "F") -> "F":
         def wrapped(func, *args, **kwargs):
             # Obtaining new instance of timer every time
             # ensures thread safety and reentrancy.

--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -75,7 +75,7 @@ class Timer:
     def labels(self, *args, **kw):
         self._metric = self._metric.labels(*args, **kw)
 
-    def __call__(self, f : "F") -> "F":
+    def __call__(self, f: "F") -> "F":
         def wrapped(func, *args, **kwargs):
             # Obtaining new instance of timer every time
             # ensures thread safety and reentrancy.


### PR DESCRIPTION
It would be really nice to be able to use the various decorators without losing the type information of the decorated method.