### PR TITLE
Support `_total` suffix for counter sample names, according to the spec

### DIFF
--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -158,7 +158,8 @@ def text_fd_to_metric_families(fd: TextIO) -> Iterable[Metric]:
             else:
                 new_samples = []
                 for s in samples:
-                    new_samples.append(Sample(s[0] + '_total', *s[1:]))
+                    sample_name = s.name if s.name.endswith('_total') else s.name + '_total'
+                    new_samples.append(Sample(sample_name, *s[1:]))
                     samples = new_samples
         metric = Metric(name, documentation, typ)
         metric.samples = samples
@@ -194,7 +195,7 @@ def text_fd_to_metric_families(fd: TextIO) -> Iterable[Metric]:
                     samples = []
                 typ = parts[3]
                 allowed_names = {
-                    'counter': [''],
+                    'counter': ['_total', ''],
                     'gauge': [''],
                     'summary': ['_count', '_sum', ''],
                     'histogram': ['_count', '_sum', '_bucket'],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,6 +25,13 @@ a 1
 """)
         self.assertEqualMetrics([CounterMetricFamily("a", "help", value=1)], list(families))
 
+    def test_counter_with_suffix(self):
+        families = text_string_to_metric_families("""# TYPE a counter
+# HELP a help
+a_total 1
+""")
+        self.assertEqualMetrics([CounterMetricFamily("a", "help", value=1)], list(families))
+
     def test_simple_gauge(self):
         families = text_string_to_metric_families("""# TYPE a gauge
 # HELP a help


### PR DESCRIPTION
I found out that the counter in the example given in this [section of the OpenMetrics spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#overall-structure) was not being parsed correctly by the parsing functions under `prometheus_client.parser`. Instead, it only works if the name of the sample matches the name of the metric family (if I get the terminology right).

This PR provides a simple fix for that. I'm aware that there's another parsing function under `prometheus_client.openmetrics.parser` which _does_ parse that correctly, but that one is also more strict in other ways, and depending on who's emitting the metrics it might not work.

@csmarchbanks 