### PR TITLE
avoid installing __pycache__ directories

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
-recursive-include tests *
-prune tests/__pycache__
+graft tests
+global-exclude *.py[cod]
+prune __pycache__
+prune */__pycache__


### PR DESCRIPTION
the current prometheus wheels include `__pycache__` directories in their package data files.