### PR TITLE
Fix CI Failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - checkout
       - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
-      - run: pip install --user tox
+      - run: pip install --user tox "virtualenv<20.22.0"
       - run: tox
   test_nooptionals:
     parameters:

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,15 @@
 [tox]
 envlist = coverage-clean,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,pypy3.7,py3.9-nooptionals,coverage-report,flake8,isort,mypy
 
-[base]
+[testenv]
 deps =
     coverage
     pytest
     attrs
-
-[testenv]
-deps =
-    {[base]deps}
     {py3.7,pypy3.7}: twisted
-    {py3.7,pypy3.7}: asgiref
+    py3.7: asgiref
+    # See https://github.com/django/asgiref/issues/393 for why we need to pin asgiref for pypy
+    pypy3.7: asgiref==3.6.0
 commands = coverage run --parallel -m pytest {posargs}
 
 [testenv:py3.9-nooptionals]


### PR DESCRIPTION
The first failure looks to be an issue with pypy and asgiref typing, pinning asgiref to a specific version fixes it.

The second failure only shows up in py3.7 and py3.8 but involves tox not being able to run if too new of a version of virtualenv is installed. I am not sure exactly what the issue is but at least this keeps CI working for now. The error is:
```
AttributeError: module 'virtualenv.create.via_global_ref.builtin.cpython.mac_os' has no attribute 'CPython3macOsFramework
```