### PR TITLE
Removed usr/bin/python from bridge/graphite.py

### DIFF
--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import logging
 import re

--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 
 import logging
 import re


### PR DESCRIPTION
This was creating python version issues during installation. usr/bin/python points to a different version of python, than used in virtual env. Somehow, due to restrictions, can't change usr/bin/python. So removed this line. This won't cause any problem to other users.