### PR TITLE
Add documentation for how to export exemplars

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,20 @@ h = Histogram('request_latency_seconds', 'Description of histogram')
 h.observe(4.7, {'trace_id': 'abc123'})
 ```
 
+Exemplars are only rendered in the OpenMetrics exposition format. If using the
+HTTP server or apps in this library, content negotiation can be used to specify
+OpenMetrics (which is done by default in Prometheus). Otherwise it will be
+necessary to use `generate_latest` from
+`prometheus_client.openmetrics.exposition` to view exemplars.
+
+To view exemplars in Prometheus it is also necessary to enable the the
+exemplar-storage feature flag:
+```
+--enable-feature=exemplar-storage
+```
+Additional information is available in [the Prometheus
+documentation](https://prometheus.io/docs/prometheus/latest/feature_flags/#exemplars-storage).
+
 ### Disabling `_created` metrics
 
 By default counters, histograms, and summaries export an additional series


### PR DESCRIPTION
Expand our exemplar documentation to include information for how to use the appropriate exposition code and mention the feature flag required in Prometheus to ingest exemplars.

Suggested in #932

cc: @mumrah would you be willing to take a look at this and see if it would have helped you?