### PR TITLE
Remove Support for Python < 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,6 @@ workflows:
           matrix:
             parameters:
                python:
-                 - "3.6"
-                 - "3.7"
                  - "3.8"
                  - "3.9"
                  - "3.10"
@@ -90,4 +88,4 @@ workflows:
           matrix:
             parameters:
                python:
-                 - "3.7"
+                 - "3.8"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'twisted': ['twisted'],
     },
     test_suite="tests",
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -38,8 +38,6 @@ setup(
         "Intended Audience :: System Administrators",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-envlist = coverage-clean,py3.6,py3.7,py3.8,py3.9,py3.10,py3.11,pypy3.7,py3.9-nooptionals,coverage-report,flake8,isort,mypy
+envlist = coverage-clean,py3.8,py3.9,py3.10,py3.11,pypy3.8,py3.9-nooptionals,coverage-report,flake8,isort,mypy
 
 [testenv]
 deps =
     coverage
     pytest
     attrs
-    {py3.7,pypy3.7}: twisted
-    py3.7: asgiref
+    {py3.8,pypy3.8}: twisted
+    py3.8: asgiref
     # See https://github.com/django/asgiref/issues/393 for why we need to pin asgiref for pypy
-    pypy3.7: asgiref==3.6.0
+    pypy3.8: asgiref==3.6.0
 commands = coverage run --parallel -m pytest {posargs}
 
 [testenv:py3.9-nooptionals]


### PR DESCRIPTION
Python 3.7 is now end of lifed, which allows additional features from the core typings library.

I am going to leave this up for a couple days to see if there are significant objections.