### PR TITLE
Change #!/usr/bin/python to #!/usr/bin/env python

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from . import (
     exposition, gc_collector, metrics, metrics_core, platform_collector,

--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import logging
 import re

--- a/prometheus_client/bridge/graphite.py
+++ b/prometheus_client/bridge/graphite.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 
 import logging
 import re

--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 
 from ..utils import floatToGoString

--- a/prometheus_client/openmetrics/parser.py
+++ b/prometheus_client/openmetrics/parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 
 import io as StringIO


### PR DESCRIPTION
This was creating python version issues during installation. usr/bin/python points to a different version of python, than used in virtual env. Somehow, due to restrictions, can't change usr/bin/python. So changed to #!/usr/bin/env python. Already have a PR merged for this issue.