### PR TITLE
Filter `readBody` deprecation notice in tests

### DIFF
--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -3,9 +3,9 @@ from unittest import skipUnless
 from prometheus_client import CollectorRegistry, Counter, generate_latest
 
 try:
-    from twisted.internet import reactor
+    from twisted.internet import defer, protocol, reactor
     from twisted.trial.unittest import TestCase
-    from twisted.web.client import Agent, readBody
+    from twisted.web.client import Agent
     from twisted.web.resource import Resource
     from twisted.web.server import Site
 
@@ -23,24 +23,44 @@ class MetricsResourceTest(TestCase):
     def setUp(self):
         self.registry = CollectorRegistry()
 
-    def test_reports_metrics(self):
-        """
-        ``MetricsResource`` serves the metrics from the provided registry.
-        """
-        c = Counter('cc', 'A counter', registry=self.registry)
-        c.inc()
+    @staticmethod
+    def _read_response_body(response):
+        class BodyReaderProtocol(protocol.Protocol):
+            def __init__(self, finished):
+                self.finished = finished
+                self.data = b""
 
-        root = Resource()
-        root.putChild(b'metrics', MetricsResource(registry=self.registry))
-        server = reactor.listenTCP(0, Site(root))
-        self.addCleanup(server.stopListening)
+            def dataReceived(self, data):
+                self.data += data
 
-        agent = Agent(reactor)
-        port = server.getHost().port
-        url = f"http://localhost:{port}/metrics"
-        d = agent.request(b"GET", url.encode("ascii"))
+            def connectionLost(self, reason):
+                self.finished.callback(self.data)
 
-        d.addCallback(readBody)
-        d.addCallback(self.assertEqual, generate_latest(self.registry))
+        finished = defer.Deferred()
+        response.deliverBody(BodyReaderProtocol(finished))
+        return finished
 
-        return d
+    if HAVE_TWISTED:
+        @defer.inlineCallbacks
+        def test_reports_metrics(self):
+            """
+            ``MetricsResource`` serves the metrics from the provided registry.
+            """
+            c = Counter('cc', 'A counter', registry=self.registry)
+            c.inc()
+
+            root = Resource()
+            root.putChild(b'metrics', MetricsResource(registry=self.registry))
+            server = reactor.listenTCP(0, Site(root))
+            self.addCleanup(server.stopListening)
+
+            agent = Agent(reactor)
+            port = server.getHost().port
+            url = f"http://localhost:{port}/metrics"
+            response = yield agent.request(b"GET", url.encode("ascii"))
+            body = yield self._read_response_body(response)
+
+            self.assertEqual(body, generate_latest(self.registry))
+    else:
+        def test_reports_metrics(self):
+            pass

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -42,7 +42,10 @@ class MetricsResourceTest(TestCase):
         url = f"http://localhost:{port}/metrics"
         d = agent.request(b"GET", url.encode("ascii"))
 
-        filterwarnings('ignore', category=DeprecationWarning)
+        # Ignore expected DeprecationWarning.
+        filterwarnings("ignore", category=DeprecationWarning, message="Using readBody "
+                       "with a transport that does not have an abortConnection method")
+
         d.addCallback(readBody)
         d.addCallback(self.assertEqual, generate_latest(self.registry))
 

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -3,6 +3,8 @@ from unittest import skipUnless
 from prometheus_client import CollectorRegistry, Counter, generate_latest
 
 try:
+    from warnings import filterwarnings
+
     from twisted.internet import reactor
     from twisted.trial.unittest import TestCase
     from twisted.web.client import Agent, readBody
@@ -40,6 +42,7 @@ class MetricsResourceTest(TestCase):
         url = f"http://localhost:{port}/metrics"
         d = agent.request(b"GET", url.encode("ascii"))
 
+        filterwarnings('ignore', category=DeprecationWarning)
         d.addCallback(readBody)
         d.addCallback(self.assertEqual, generate_latest(self.registry))
 


### PR DESCRIPTION
#670

Using readBody with a transport that does not haven an abortConnection method will trigger the deprecation warning.

Can refer to [#twisted-issue-7762](https://github.com/twisted/twisted/issues/7762).

So I use `_read_response_body` method instead of `readBody` method and now everything works fine with the use case.

## Before

### cmd

```shell
python3.9 -m pytest tests/test_twisted.py
```

### result

```
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.9.17, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/chenyiqiang/WorkSpace/prometheus/client_python
collected 1 item

tests/test_twisted.py .                                                                                                                                [100%]

====================================================================== warnings summary ======================================================================
tests/test_twisted.py::MetricsResourceTest::test_reports_metrics
  /Users/chenyiqiang/.pyenv/versions/3.9.17/lib/python3.9/site-packages/twisted/internet/defer.py:892: DeprecationWarning: Using readBody with a transport that does not have an abortConnection method
    current.result = callback(  # type: ignore[misc]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 1 passed, 1 warning in 0.80s ================================================================
```

## After

### cmd
```shell
python3.9 -m pytest tests/test_twisted.py
```

### result

```shell
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.9.17, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/chenyiqiang/WorkSpace/prometheus/client_python
collected 1 item

tests/test_twisted.py .                                                                                                                                [100%]

===================================================================== 1 passed in 0.48s ======================================================================
```