### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ workflows:
                  - "3.9"
                  - "3.10"
                  - "3.11"
+                 - "3.12"
       - test_nooptionals:
           matrix:
             parameters:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Monitoring",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py3.8,py3.9,py3.10,py3.11,pypy3.8,py3.9-nooptionals,coverage-report,flake8,isort,mypy
+envlist = coverage-clean,py{3.8,3.9,3.10,3.11,3.12,py3.8,3.9-nooptionals},coverage-report,flake8,isort,mypy
 
 [testenv]
 deps =


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

---

Tested locally via tox:

```console
❯ tox -e py312
py312: install_deps> python -I -m pip install attrs coverage pytest
.pkg: install_requires> python -I -m pip install 'setuptools>=40.8.0' wheel
.pkg: _optional_hooks> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: install_requires_for_build_wheel> python -I -m pip install wheel
.pkg: prepare_metadata_for_build_wheel> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py312: install_package> python -I -m pip install --force-reinstall --no-deps /private/tmp/client_python/.tox/.tmp/package/1/prometheus_client-0.17.1.tar.gz
py312: commands[0]> coverage run --parallel -m pytest
======================================================================================= test session starts ========================================================================================
platform darwin -- Python 3.12.0rc2, pytest-7.4.2, pluggy-1.3.0
cachedir: .tox/py312/.pytest_cache
rootdir: /private/tmp/client_python
collected 303 items

tests/test_asgi.py ssssssss                                                                                                                                                                  [  2%]
tests/test_core.py ...................................................................................................                                                                       [ 35%]
tests/test_exposition.py ..........................................................                                                                                                          [ 54%]
tests/test_gc_collector.py ..                                                                                                                                                                [ 55%]
tests/test_graphite_bridge.py .......                                                                                                                                                        [ 57%]
tests/test_multiprocess.py ..........................                                                                                                                                        [ 66%]
tests/test_parser.py ........................                                                                                                                                                [ 73%]
tests/test_platform_collector.py ..                                                                                                                                                          [ 74%]
tests/test_process_collector.py ....                                                                                                                                                         [ 75%]
tests/test_twisted.py s                                                                                                                                                                      [ 76%]
tests/test_wsgi.py .......                                                                                                                                                                   [ 78%]
tests/openmetrics/test_exposition.py ....................                                                                                                                                    [ 85%]
tests/openmetrics/test_parser.py .............................................                                                                                                               [100%]

================================================================================== 294 passed, 9 skipped in 5.26s ==================================================================================
.pkg: _exit> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py312: OK (11.09=setup[4.66]+cmd[6.43] seconds)
  congratulations :) (11.17 seconds)
```
