### PR TITLE
add restricted registry documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,7 +740,7 @@ for family in text_string_to_metric_families(u"my_gauge 1.0\n"):
 ## Restricted registry
 
 Registry support restriction to only return specific metrics.
-If you’re using the built-in HTTP server, you can use the GET parameter "name []", since it’s an array it can be used multiple times.
+If you’re using the built-in HTTP server, you can use the GET parameter "name[]", since it’s an array it can be used multiple times.
 If you’re directly using generate_latest, you can use the function restricted_registry().
 
 ```python

--- a/README.md
+++ b/README.md
@@ -743,22 +743,7 @@ Registry support querying a specific metric with the GET parameter "name[]".
 Since it's an array it can be use multiple times.
 
 ```python
-curl -v --get --data-urlencode "name[]=python_gc_objects_collected_total" --data-urlencode "name[]=python_info" http://127.0.0.1:9200/metrics
-* About to connect() to 127.0.0.1 port 9200 (#0)
-*   Trying 127.0.0.1...
-* Connected to 127.0.0.1 (127.0.0.1) port 9200 (#0)
-> GET /metrics?name[]=python_gc_objects_collected_total&name[]=python_info HTTP/1.1
-> User-Agent: curl/7.29.0
-> Host: 127.0.0.1:9200
-> Accept: */*
->
-* HTTP 1.0, assume close after body
-< HTTP/1.0 200 OK
-< Date: Thu, 19 Oct 2023 10:00:38 GMT
-< Server: WSGIServer/0.2 CPython/3.9.3
-< Content-Type: text/plain; version=0.0.4; charset=utf-8
-< Content-Length: 454
-<
+curl --get --data-urlencode "name[]=python_gc_objects_collected_total" --data-urlencode "name[]=python_info" http://127.0.0.1:9200/metrics
 # HELP python_info Python platform information
 # TYPE python_info gauge
 python_info{implementation="CPython",major="3",minor="9",patchlevel="3",version="3.9.3"} 1.0
@@ -767,7 +752,6 @@ python_info{implementation="CPython",major="3",minor="9",patchlevel="3",version=
 python_gc_objects_collected_total{generation="0"} 73129.0
 python_gc_objects_collected_total{generation="1"} 8594.0
 python_gc_objects_collected_total{generation="2"} 296.0
-* Closing connection 0
 ```
 
 ## Links

--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ for family in text_string_to_metric_families(u"my_gauge 1.0\n"):
 
 ## Restricted registry
 
-Registry support restriction to only return specific metrics.
+Registries support restriction to only return specific metrics.
 If you’re using the built-in HTTP server, you can use the GET parameter "name[]", since it’s an array it can be used multiple times.
 If you’re directly using generate_latest, you can use the function restricted_registry().
 

--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ for family in text_string_to_metric_families(u"my_gauge 1.0\n"):
 
 Registries support restriction to only return specific metrics.
 If you’re using the built-in HTTP server, you can use the GET parameter "name[]", since it’s an array it can be used multiple times.
-If you’re directly using generate_latest, you can use the function restricted_registry().
+If you’re directly using `generate_latest`, you can use the function `restricted_registry()`.
 
 ```python
 curl --get --data-urlencode "name[]=python_gc_objects_collected_total" --data-urlencode "name[]=python_info" http://127.0.0.1:9200/metrics

--- a/README.md
+++ b/README.md
@@ -737,6 +737,39 @@ for family in text_string_to_metric_families(u"my_gauge 1.0\n"):
     print("Name: {0} Labels: {1} Value: {2}".format(*sample))
 ```
 
+## Restricted registry
+
+Registry support querying a specific metric with the GET parameter "name[]".
+Since it's an array it can be use multiple times.
+
+```python
+curl -v --get --data-urlencode "name[]=python_gc_objects_collected_total" --data-urlencode "name[]=python_info" http://127.0.0.1:9200/metrics
+* About to connect() to 127.0.0.1 port 9200 (#0)
+*   Trying 127.0.0.1...
+* Connected to 127.0.0.1 (127.0.0.1) port 9200 (#0)
+> GET /metrics?name[]=python_gc_objects_collected_total&name[]=python_info HTTP/1.1
+> User-Agent: curl/7.29.0
+> Host: 127.0.0.1:9200
+> Accept: */*
+>
+* HTTP 1.0, assume close after body
+< HTTP/1.0 200 OK
+< Date: Thu, 19 Oct 2023 10:00:38 GMT
+< Server: WSGIServer/0.2 CPython/3.9.3
+< Content-Type: text/plain; version=0.0.4; charset=utf-8
+< Content-Length: 454
+<
+# HELP python_info Python platform information
+# TYPE python_info gauge
+python_info{implementation="CPython",major="3",minor="9",patchlevel="3",version="3.9.3"} 1.0
+# HELP python_gc_objects_collected_total Objects collected during gc
+# TYPE python_gc_objects_collected_total counter
+python_gc_objects_collected_total{generation="0"} 73129.0
+python_gc_objects_collected_total{generation="1"} 8594.0
+python_gc_objects_collected_total{generation="2"} 296.0
+* Closing connection 0
+```
+
 ## Links
 
 * [Releases](https://github.com/prometheus/client_python/releases): The releases page shows the history of the project and acts as a changelog.

--- a/README.md
+++ b/README.md
@@ -739,11 +739,21 @@ for family in text_string_to_metric_families(u"my_gauge 1.0\n"):
 
 ## Restricted registry
 
-Registry support querying a specific metric with the GET parameter "name[]".
-Since it's an array it can be use multiple times.
+Registry support restriction to only return specific metrics.
+If you’re using the built-in HTTP server, you can use the GET parameter "name []", since it’s an array it can be used multiple times.
+If you’re directly using generate_latest, you can use the function restricted_registry().
 
 ```python
 curl --get --data-urlencode "name[]=python_gc_objects_collected_total" --data-urlencode "name[]=python_info" http://127.0.0.1:9200/metrics
+```
+
+```python
+from prometheus_client import generate_latest
+
+generate_latest(REGISTRY.restricted_registry(['python_gc_objects_collected_total', 'python_info']))
+```
+
+```python
 # HELP python_info Python platform information
 # TYPE python_info gauge
 python_info{implementation="CPython",major="3",minor="9",patchlevel="3",version="3.9.3"} 1.0
@@ -753,6 +763,7 @@ python_gc_objects_collected_total{generation="0"} 73129.0
 python_gc_objects_collected_total{generation="1"} 8594.0
 python_gc_objects_collected_total{generation="2"} 296.0
 ```
+
 
 ## Links
 


### PR DESCRIPTION
i found this undocumented feature in the code, it's pretty useful to debug an exporter that return thousand of metrics.
i don't know if having this feature undocumented was intentional or  not
(@csmarchbanks)