### PR TITLE
Mark collector parameter as optional in ProcessCollector and PlatformCollector

### DIFF
--- a/prometheus_client/platform_collector.py
+++ b/prometheus_client/platform_collector.py
@@ -9,7 +9,7 @@ class PlatformCollector(Collector):
     """Collector for python platform information"""
 
     def __init__(self,
-                 registry: CollectorRegistry = REGISTRY,
+                 registry: Optional[CollectorRegistry] = REGISTRY,
                  platform: Optional[Any] = None,
                  ):
         self._platform = pf if platform is None else platform

--- a/prometheus_client/process_collector.py
+++ b/prometheus_client/process_collector.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, Iterable, Union
+from typing import Callable, Iterable, Optional, Union
 
 from .metrics_core import CounterMetricFamily, GaugeMetricFamily, Metric
 from .registry import Collector, CollectorRegistry, REGISTRY
@@ -20,7 +20,7 @@ class ProcessCollector(Collector):
                  namespace: str = '',
                  pid: Callable[[], Union[int, str]] = lambda: 'self',
                  proc: str = '/proc',
-                 registry: CollectorRegistry = REGISTRY):
+                 registry: Optional[CollectorRegistry] = REGISTRY):
         self._namespace = namespace
         self._pid = pid
         self._proc = proc


### PR DESCRIPTION
The `registry` parameter can be passed as `None`, but this wasn't reflected in the typing.