### PR TITLE
Allow enabling/disabling _created metrics from code

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -11,7 +11,10 @@ from .exposition import (
     write_to_textfile,
 )
 from .gc_collector import GC_COLLECTOR, GCCollector
-from .metrics import Counter, Enum, Gauge, Histogram, Info, Summary
+from .metrics import (
+    Counter, disable_created_metrics, enable_created_metrics, Enum, Gauge,
+    Histogram, Info, Summary,
+)
 from .metrics_core import Metric
 from .platform_collector import PLATFORM_COLLECTOR, PlatformCollector
 from .process_collector import PROCESS_COLLECTOR, ProcessCollector
@@ -27,6 +30,8 @@ __all__ = (
     'Histogram',
     'Info',
     'Enum',
+    'enable_created_metrics',
+    'disable_created_metrics',
     'CONTENT_TYPE_LATEST',
     'generate_latest',
     'MetricsHandler',

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -70,6 +70,18 @@ def _get_use_created() -> bool:
 _use_created = _get_use_created()
 
 
+def disable_created_metrics():
+    """Disable exporting _created metrics on counters, histograms, and summaries."""
+    global _use_created
+    _use_created = False
+
+
+def enable_created_metrics():
+    """Enable exporting _created metrics on counters, histograms, and summaries."""
+    global _use_created
+    _use_created = True
+
+
 class MetricWrapperBase(Collector):
     _type: Optional[str] = None
     _reserved_labelnames: Sequence[str] = ()


### PR DESCRIPTION
Fixes #933

This takes the approach of globally enabling/disabling _created metrics still. Another option would be to enable/disable `_created` metrics on each registry, but that would be a larger change as we would have to keep persist the registry on each metric (or filter them out which seems more prone to errors/conflicts?). My thought is to start with the global option, but we could add the registry option for more fine use cases if required in the future?

@SuperQ WDYT?