### PR TITLE
fix: error in determining timestamp  "less than"

### DIFF
--- a/prometheus_client/samples.py
+++ b/prometheus_client/samples.py
@@ -30,6 +30,9 @@ class Timestamp:
     def __gt__(self, other: "Timestamp") -> bool:
         return self.sec > other.sec or self.nsec > other.nsec
 
+    def __lt__(self, other: "Timestamp") -> bool:
+        return self.sec < other.sec or self.nsec < other.nsec
+
 
 # Timestamp and exemplar are optional.
 # Value can be an int or a float.

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,0 +1,26 @@
+import unittest
+from prometheus_client import samples
+
+
+class TestSamples(unittest.TestCase):
+    def test_gt(self):
+        self.assertEqual(samples.Timestamp(1, 1) > samples.Timestamp(1, 1), False)
+        self.assertEqual(samples.Timestamp(1, 1) > samples.Timestamp(1, 2), False)
+        self.assertEqual(samples.Timestamp(1, 1) > samples.Timestamp(2, 1), False)
+        self.assertEqual(samples.Timestamp(1, 1) > samples.Timestamp(2, 2), False)
+        self.assertEqual(samples.Timestamp(1, 2) > samples.Timestamp(1, 1), True)
+        self.assertEqual(samples.Timestamp(2, 1) > samples.Timestamp(1, 1), True)
+        self.assertEqual(samples.Timestamp(2, 2) > samples.Timestamp(1, 1), True)
+
+    def test_lt(self):
+        self.assertEqual(samples.Timestamp(1, 1) < samples.Timestamp(1, 1), False)
+        self.assertEqual(samples.Timestamp(1, 1) < samples.Timestamp(1, 2), True)
+        self.assertEqual(samples.Timestamp(1, 1) < samples.Timestamp(2, 1), True)
+        self.assertEqual(samples.Timestamp(1, 1) < samples.Timestamp(2, 2), True)
+        self.assertEqual(samples.Timestamp(1, 2) < samples.Timestamp(1, 1), False)
+        self.assertEqual(samples.Timestamp(2, 1) < samples.Timestamp(1, 1), False)
+        self.assertEqual(samples.Timestamp(2, 2) < samples.Timestamp(1, 1), False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
```
__lt__ is the negation of __gt__ by default.
so samples.Timestamp(1, 1) > samples.Timestamp(1, 1) is false
and samples.Timestamp(1, 1) < samples.Timestamp(1, 1) is true. but  samples.Timestamp(1, 1) < samples.Timestamp(1, 1) should be false too.
add __lt__ func to fix the bug

```