### PR TITLE
Update OpenMetrics Content Type to 1.0.0

### DIFF
--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -3,7 +3,7 @@
 
 from ..utils import floatToGoString
 
-CONTENT_TYPE_LATEST = 'application/openmetrics-text; version=0.0.1; charset=utf-8'
+CONTENT_TYPE_LATEST = 'application/openmetrics-text; version=1.0.0; charset=utf-8'
 """Content type of the latest OpenMetrics text format"""
 
 


### PR DESCRIPTION
OpenMetrics has been released (for a long time now) and we support 1.0.0 not 0.0.1. See https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#overall-structure for more detail.