### PR TITLE
Enable graceful shutdown for start_{http,wsgi}_server

### DIFF
--- a/docs/content/exporting/http/_index.md
+++ b/docs/content/exporting/http/_index.md
@@ -18,6 +18,15 @@ start_http_server(8000)
 
 Visit [http://localhost:8000/](http://localhost:8000/) to view the metrics.
 
+The function will return the HTTP server and thread objects, which can be used
+to shutdown the server gracefully:
+
+```python
+server, t = start_http_server(8000)
+server.shutdown()
+t.join()
+```
+
 To add Prometheus exposition to an existing HTTP server, see the `MetricsHandler` class
 which provides a `BaseHTTPRequestHandler`. It also serves as a simple example of how
 to write a custom endpoint.

--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -210,7 +210,7 @@ def start_wsgi_server(
         client_capath: Optional[str] = None,
         protocol: int = ssl.PROTOCOL_TLS_SERVER,
         client_auth_required: bool = False,
-) -> None:
+) -> Tuple[WSGIServer, threading.Thread]:
     """Starts a WSGI server for prometheus metrics as a daemon thread."""
 
     class TmpServer(ThreadingWSGIServer):
@@ -225,6 +225,8 @@ def start_wsgi_server(
     t = threading.Thread(target=httpd.serve_forever)
     t.daemon = True
     t.start()
+
+    return httpd, t
 
 
 start_http_server = start_wsgi_server


### PR DESCRIPTION
Hello @csmarchbanks, I made the `start_http_server` function a bit easier to cancel gracefully.