### PR TITLE
Update documentation and added code warning for remove and clear in multi-process mode

### DIFF
--- a/docs/content/multiprocess/_index.md
+++ b/docs/content/multiprocess/_index.md
@@ -18,6 +18,7 @@ This comes with a number of limitations:
 - The pushgateway cannot be used
 - Gauges cannot use the `pid` label
 - Exemplars are not supported
+- Remove and Clear of labels are currently not supported in multiprocess mode.
 
 There's several steps to getting this working:
 

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -6,6 +6,7 @@ from typing import (
     Any, Callable, Dict, Iterable, List, Literal, Optional, Sequence, Tuple,
     Type, TypeVar, Union,
 )
+import warnings
 
 from . import values  # retain this import style for testability
 from .context_managers import ExceptionCounter, InprogressTracker, Timer
@@ -210,6 +211,11 @@ class MetricWrapperBase(Collector):
             return self._metrics[labelvalues]
 
     def remove(self, *labelvalues: Any) -> None:
+        if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+            warnings.warn(
+                "Removal of labels has not been implemented in  multi-process mode yet.",
+                UserWarning)
+
         if not self._labelnames:
             raise ValueError('No label names were set when constructing %s' % self)
 
@@ -222,6 +228,10 @@ class MetricWrapperBase(Collector):
 
     def clear(self) -> None:
         """Remove all labelsets from the metric"""
+        if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+            warnings.warn(
+                "Clearing labels has not been implemented in multi-process mode yet",
+                UserWarning)
         with self._lock:
             self._metrics = {}
 

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -381,6 +381,22 @@ class TestMultiProcess(unittest.TestCase):
             os.path.join(self.tempdir, 'gauge_livesum_9999999.db'),
         ]))
 
+    def test_remove_clear_warning(self):
+        os.environ['PROMETHEUS_MULTIPROC_DIR'] = self.tempdir
+        with warnings.catch_warnings(record=True) as w:
+            values.ValueClass = get_value_class()
+            registry = CollectorRegistry()
+            collector = MultiProcessCollector(registry)
+            counter = Counter('c', 'help', labelnames=['label'], registry=None)
+            counter.labels('label').inc()
+            counter.remove('label')
+            counter.clear()
+            assert os.environ['PROMETHEUS_MULTIPROC_DIR'] == self.tempdir
+            assert issubclass(w[0].category, UserWarning)
+            assert "Removal of labels has not been implemented" in str(w[0].message)
+            assert issubclass(w[-1].category, UserWarning)
+            assert "Clearing labels has not been implemented" in str(w[-1].message)
+
 
 class TestMmapedDict(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Update documentation and added code warning for remove() and clear() in multi-process mode, its not to close #916 but to provide extra information for users.