### PR TITLE
wsgi server: address family discovery is not quite right

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -154,7 +154,7 @@ def _get_best_family(address, port):
     # binding an ipv6 address is requested.
     # This function is based on what upstream python did for http.server
     # in https://github.com/python/cpython/pull/11767
-    infos = socket.getaddrinfo(address, port)
+    infos = socket.getaddrinfo(address, port, type=socket.SOCK_STREAM, flags=socket.AI_PASSIVE)
     family, _, _, _, sockaddr = next(iter(infos))
     return family, sockaddr[0]
 


### PR DESCRIPTION
The code introduced to improve binding to an IPv6 address is based on similar code in Python itself, but is missing some critical arguments to the **socket.getaddrinfo()** call: in particular, the socket type must be set to **SOCK_STREAM**, because we want a TCP connection; the **AI_PASSIVE** flag should also be passed because we intend to use the result for binding a listen socket rather than making an outbound connection.