### PR TITLE
Add sanity check for label value

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -705,6 +705,8 @@ class Info(MetricWrapperBase):
         if self._labelname_set.intersection(val.keys()):
             raise ValueError('Overlapping labels for Info metric, metric: {} child: {}'.format(
                 self._labelnames, val))
+        if any(i is None for i in val.values()):
+            raise ValueError('Label value cannot be None')
         with self._lock:
             self._value = dict(val)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -534,6 +534,7 @@ class TestInfo(unittest.TestCase):
 
     def test_labels(self):
         self.assertRaises(ValueError, self.labels.labels('a').info, {'l': ''})
+        self.assertRaises(ValueError, self.labels.labels('a').info, {'il': None})
 
         self.labels.labels('a').info({'foo': 'bar'})
         self.assertEqual(1, self.registry.get_sample_value('il_info', {'l': 'a', 'foo': 'bar'}))


### PR DESCRIPTION
Add a sanity check when set info's label. value can't be null.
@csmarchbanks ptal.
fix #1011
