### PR TITLE
Use re-entrant lock.

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -1,5 +1,4 @@
 import os
-from threading import RLock
 import time
 import types
 from typing import (
@@ -16,7 +15,7 @@ from .metrics_core import (
 )
 from .registry import Collector, CollectorRegistry, REGISTRY
 from .samples import Exemplar, Sample
-from .utils import floatToGoString, INF
+from .utils import floatToGoString, INF, Lock
 
 T = TypeVar('T', bound='MetricWrapperBase')
 F = TypeVar("F", bound=Callable[..., Any])
@@ -144,7 +143,7 @@ class MetricWrapperBase(Collector):
 
         if self._is_parent():
             # Prepare the fields needed for child metrics.
-            self._lock = RLock()
+            self._lock = Lock()
             self._metrics: Dict[Sequence[str], T] = {}
 
         if self._is_observable():
@@ -697,7 +696,7 @@ class Info(MetricWrapperBase):
 
     def _metric_init(self):
         self._labelname_set = set(self._labelnames)
-        self._lock = RLock()
+        self._lock = Lock()
         self._value = {}
 
     def info(self, val: Dict[str, str]) -> None:
@@ -759,7 +758,7 @@ class Enum(MetricWrapperBase):
 
     def _metric_init(self) -> None:
         self._value = 0
-        self._lock = RLock()
+        self._lock = Lock()
 
     def state(self, state: str) -> None:
         """Set enum metric state."""

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -1,4 +1,5 @@
 import os
+from threading import RLock
 import time
 import types
 from typing import (
@@ -15,7 +16,7 @@ from .metrics_core import (
 )
 from .registry import Collector, CollectorRegistry, REGISTRY
 from .samples import Exemplar, Sample
-from .utils import floatToGoString, INF, Lock
+from .utils import floatToGoString, INF
 
 T = TypeVar('T', bound='MetricWrapperBase')
 F = TypeVar("F", bound=Callable[..., Any])
@@ -143,7 +144,7 @@ class MetricWrapperBase(Collector):
 
         if self._is_parent():
             # Prepare the fields needed for child metrics.
-            self._lock = Lock()
+            self._lock = RLock()
             self._metrics: Dict[Sequence[str], T] = {}
 
         if self._is_observable():
@@ -696,7 +697,7 @@ class Info(MetricWrapperBase):
 
     def _metric_init(self):
         self._labelname_set = set(self._labelnames)
-        self._lock = Lock()
+        self._lock = RLock()
         self._value = {}
 
     def info(self, val: Dict[str, str]) -> None:
@@ -758,7 +759,7 @@ class Enum(MetricWrapperBase):
 
     def _metric_init(self) -> None:
         self._value = 0
-        self._lock = Lock()
+        self._lock = RLock()
 
     def state(self, state: str) -> None:
         """Set enum metric state."""

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -1,5 +1,5 @@
 import os
-from threading import Lock
+from threading import RLock
 import time
 import types
 from typing import (
@@ -144,7 +144,7 @@ class MetricWrapperBase(Collector):
 
         if self._is_parent():
             # Prepare the fields needed for child metrics.
-            self._lock = Lock()
+            self._lock = RLock()
             self._metrics: Dict[Sequence[str], T] = {}
 
         if self._is_observable():
@@ -697,7 +697,7 @@ class Info(MetricWrapperBase):
 
     def _metric_init(self):
         self._labelname_set = set(self._labelnames)
-        self._lock = Lock()
+        self._lock = RLock()
         self._value = {}
 
     def info(self, val: Dict[str, str]) -> None:
@@ -759,7 +759,7 @@ class Enum(MetricWrapperBase):
 
     def _metric_init(self) -> None:
         self._value = 0
-        self._lock = Lock()
+        self._lock = RLock()
 
     def state(self, state: str) -> None:
         """Set enum metric state."""

--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import copy
-from threading import Lock
+from threading import RLock
 from typing import Dict, Iterable, List, Optional
 
 from .metrics_core import Metric
@@ -30,7 +30,7 @@ class CollectorRegistry(Collector):
         self._collector_to_names: Dict[Collector, List[str]] = {}
         self._names_to_collectors: Dict[str, Collector] = {}
         self._auto_describe = auto_describe
-        self._lock = Lock()
+        self._lock = RLock()
         self._target_info: Optional[Dict[str, str]] = {}
         self.set_target_info(target_info)
 

--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 import copy
+from threading import RLock
 from typing import Dict, Iterable, List, Optional
 
 from .metrics_core import Metric
-from .utils import Lock
 
 
 # Ideally this would be a Protocol, but Protocols are only available in Python >= 3.8.
@@ -30,7 +30,7 @@ class CollectorRegistry(Collector):
         self._collector_to_names: Dict[Collector, List[str]] = {}
         self._names_to_collectors: Dict[str, Collector] = {}
         self._auto_describe = auto_describe
-        self._lock = Lock()
+        self._lock = RLock()
         self._target_info: Optional[Dict[str, str]] = {}
         self.set_target_info(target_info)
 

--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 import copy
-from threading import RLock
 from typing import Dict, Iterable, List, Optional
 
 from .metrics_core import Metric
+from .utils import Lock
 
 
 # Ideally this would be a Protocol, but Protocols are only available in Python >= 3.8.
@@ -30,7 +30,7 @@ class CollectorRegistry(Collector):
         self._collector_to_names: Dict[Collector, List[str]] = {}
         self._names_to_collectors: Dict[str, Collector] = {}
         self._auto_describe = auto_describe
-        self._lock = RLock()
+        self._lock = Lock()
         self._target_info: Optional[Dict[str, str]] = {}
         self.set_target_info(target_info)
 

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -1,4 +1,5 @@
 import math
+# type: ignore[attr-defined]
 from threading import _PyRLock
 
 INF = float("inf")

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -1,4 +1,5 @@
 import math
+from threading import _PyRLock
 
 INF = float("inf")
 MINUS_INF = float("-inf")
@@ -22,3 +23,8 @@ def floatToGoString(d):
             mantissa = f'{s[0]}.{s[1:dot]}{s[dot + 1:]}'.rstrip('0.')
             return f'{mantissa}e+0{dot - 1}'
         return s
+
+
+class Lock(_PyRLock):
+    def locked(self):
+        return bool(self._count)

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -1,6 +1,5 @@
 import math
-# type: ignore[attr-defined]
-from threading import _PyRLock
+from threading import _PyRLock  # type: ignore[attr-defined]
 
 INF = float("inf")
 MINUS_INF = float("-inf")

--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -1,5 +1,4 @@
 import math
-from threading import _PyRLock  # type: ignore[attr-defined]
 
 INF = float("inf")
 MINUS_INF = float("-inf")
@@ -23,8 +22,3 @@ def floatToGoString(d):
             mantissa = f'{s[0]}.{s[1:dot]}{s[dot + 1:]}'.rstrip('0.')
             return f'{mantissa}e+0{dot - 1}'
         return s
-
-
-class Lock(_PyRLock):
-    def locked(self):
-        return bool(self._count)

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -1,5 +1,5 @@
 import os
-from threading import Lock
+from threading import RLock
 import warnings
 
 from .mmap_dict import mmap_key, MmapedDict

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -1,8 +1,8 @@
 import os
+from threading import RLock
 import warnings
 
 from .mmap_dict import mmap_key, MmapedDict
-from .utils import Lock
 
 
 class MutexValue:
@@ -13,7 +13,7 @@ class MutexValue:
     def __init__(self, typ, metric_name, name, labelnames, labelvalues, help_text, **kwargs):
         self._value = 0.0
         self._exemplar = None
-        self._lock = Lock()
+        self._lock = RLock()
 
     def inc(self, amount):
         with self._lock:
@@ -50,7 +50,7 @@ def MultiProcessValue(process_identifier=os.getpid):
     # Use a single global lock when in multi-processing mode
     # as we presume this means there is no threading going on.
     # This avoids the need to also have mutexes in __MmapDict.
-    lock = Lock()
+    lock = RLock()
 
     class MmapedValue:
         """A float protected by a mutex backed by a per-process mmaped file."""

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -13,7 +13,7 @@ class MutexValue:
     def __init__(self, typ, metric_name, name, labelnames, labelvalues, help_text, **kwargs):
         self._value = 0.0
         self._exemplar = None
-        self._lock = Lock()
+        self._lock = RLock()
 
     def inc(self, amount):
         with self._lock:
@@ -50,7 +50,7 @@ def MultiProcessValue(process_identifier=os.getpid):
     # Use a single global lock when in multi-processing mode
     # as we presume this means there is no threading going on.
     # This avoids the need to also have mutexes in __MmapDict.
-    lock = Lock()
+    lock = RLock()
 
     class MmapedValue:
         """A float protected by a mutex backed by a per-process mmaped file."""

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -1,8 +1,8 @@
 import os
-from threading import RLock
 import warnings
 
 from .mmap_dict import mmap_key, MmapedDict
+from .utils import Lock
 
 
 class MutexValue:
@@ -13,7 +13,7 @@ class MutexValue:
     def __init__(self, typ, metric_name, name, labelnames, labelvalues, help_text, **kwargs):
         self._value = 0.0
         self._exemplar = None
-        self._lock = RLock()
+        self._lock = Lock()
 
     def inc(self, amount):
         with self._lock:
@@ -50,7 +50,7 @@ def MultiProcessValue(process_identifier=os.getpid):
     # Use a single global lock when in multi-processing mode
     # as we presume this means there is no threading going on.
     # This avoids the need to also have mutexes in __MmapDict.
-    lock = RLock()
+    lock = Lock()
 
     class MmapedValue:
         """A float protected by a mutex backed by a per-process mmaped file."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,14 @@ from prometheus_client.decorator import getargspec
 from prometheus_client.metrics import _get_use_created
 
 
+def is_locked(lock):
+    "Tries to obtain a lock, returns True on success, False on failure."
+    locked = lock.acquire(blocking=False)
+    if locked:
+        lock.release()
+    return not locked
+
+
 def assert_not_observable(fn, *args, **kwargs):
     """
     Assert that a function call falls with a ValueError exception containing
@@ -963,7 +971,7 @@ class TestCollectorRegistry(unittest.TestCase):
         m = Metric('target', 'Target metadata', 'info')
         m.samples = [Sample('target_info', {'foo': 'bar'}, 1)]
         for _ in registry.restricted_registry(['target_info', 's_sum']).collect():
-            self.assertFalse(registry._lock.locked())
+            self.assertFalse(is_locked(registry._lock))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While using `django-prometheus` I found a situation where adding a metric to the registry caused a read from cache. I had cache metrics enabled, which attempted to add cache metrics to the registry. This resulting in a deadlock as the second registry call attempted to obtain the lock already held lower on the call stack.

I changed usage to an RLock, which allows the lock to be obtained in a nested fashion within a call stack. This still provides thread safety.