### PR TITLE
Reject invalid HTTP methods and resources

### DIFF
--- a/docs/content/exporting/http/_index.md
+++ b/docs/content/exporting/http/_index.md
@@ -53,3 +53,22 @@ from prometheus_client import start_http_server
 
 start_http_server(8000, certfile="server.crt", keyfile="server.key")
 ```
+
+# Supported HTTP methods
+
+The prometheus client will handle the following HTTP methods and resources:
+
+* `OPTIONS (any)` - returns HTTP status 200 and an 'Allow' header indicating the
+  allowed methods (OPTIONS, GET)
+* `GET (any)` - returns HTTP status 200 and the metrics data
+* `GET /favicon.ico` - returns HTTP status 200 and an empty response body. Some
+  browsers support this to display the returned icon in the browser tab.
+
+Other HTTP methods than these are rejected with HTTP status 405 "Method Not Allowed"
+and an 'Allow' header indicating the allowed methods (OPTIONS, GET).
+
+Any returned HTTP errors are also displayed in the response body after a hash
+sign and with a brief hint. Example:
+```
+# HTTP 405 Method Not Allowed: XXX; use OPTIONS or GET
+```


### PR DESCRIPTION
This change addresses issue #1018 (currently, any HTTP method is handled by returning success and metrics data, which causes network scanners to report issues).

Note, this needs careful review w.r.t.:
* Does Prometheus issue any HTTP requests that are now rejected.
* Does HEAD need to be supported.
* Does the `/metrics` resource for which metrics are returned, need to be configurable by the users of this package.
* Does the strict handling need to be enabled/disabled by the users of this package.
* Are unit tests needed.

Note, the pinning of asgiref==3.6.0 removes a test error in the py3.8 tox environment (same fix that already existed for the pypy3.8 tox environment). I don't know why the error on py3.8 comes up in the first place. I guess someone more experienced than me needs to look at that.

For details, see the commit message.