### PR TITLE
Fixed asgiref version for Python 3.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ deps =
     pytest
     attrs
     {py3.8,pypy3.8}: twisted
-    py3.8: asgiref
-    # See https://github.com/django/asgiref/issues/393 for why we need to pin asgiref for pypy
+    # See https://github.com/django/asgiref/issues/393 for why we need to pin asgiref
+    py3.8: asgiref==3.6.0
     pypy3.8: asgiref==3.6.0
 commands = coverage run --parallel -m pytest {posargs}
 


### PR DESCRIPTION
Details:

* Needed to pin asgiref to ==3.6.0 also for py3.8 to circumvent the same error as for pypy3.8.

Note: This was previously in PR #1019 and was moved into its own PR.

Since the other PRs currently all succeed on Python 3.8, I'm not sure this change is needed anymore.