### PR TITLE
Fix AttributeError: Remove unnecessary 'decode' for Python 3 compatibility

### DIFF
--- a/prometheus_client/asgi.py
+++ b/prometheus_client/asgi.py
@@ -13,12 +13,12 @@ def make_asgi_app(registry: CollectorRegistry = REGISTRY, disable_compression: b
         # Prepare parameters
         params = parse_qs(scope.get('query_string', b''))
         accept_header = ",".join([
-            value.decode("utf8") for (name, value) in scope.get('headers')
-            if name.decode("utf8").lower() == 'accept'
+            value for (name, value) in scope.get('headers')
+            if name.lower() == 'accept'
         ])
         accept_encoding_header = ",".join([
-            value.decode("utf8") for (name, value) in scope.get('headers')
-            if name.decode("utf8").lower() == 'accept-encoding'
+            value for (name, value) in scope.get('headers')
+            if name.lower() == 'accept-encoding'
         ])
         # Bake output
         status, headers, output = _bake_output(registry, accept_header, accept_encoding_header, params, disable_compression)


### PR DESCRIPTION
Fix AttributeError: Remove unnecessary 'decode' for Python 3 compatibility


