### PR TITLE
Support UTF-8 in metric creation, parsing, and exposition

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -10,19 +10,21 @@ import warnings
 
 from . import values  # retain this import style for testability
 from .context_managers import ExceptionCounter, InprogressTracker, Timer
-from .metrics_core import (
-    Metric, METRIC_LABEL_NAME_RE, METRIC_NAME_RE,
-    RESERVED_METRIC_LABEL_NAME_RE,
-)
+from .metrics_core import Metric
 from .registry import Collector, CollectorRegistry, REGISTRY
 from .samples import Exemplar, Sample
 from .utils import floatToGoString, INF
+from .validation import (
+    _validate_exemplar, _validate_labelnames, _validate_metric_name,
+)
 
 T = TypeVar('T', bound='MetricWrapperBase')
 F = TypeVar("F", bound=Callable[..., Any])
 
 
 def _build_full_name(metric_type, name, namespace, subsystem, unit):
+    if not name:
+        raise ValueError('Metric name should not be empty')
     full_name = ''
     if namespace:
         full_name += namespace + '_'
@@ -37,31 +39,6 @@ def _build_full_name(metric_type, name, namespace, subsystem, unit):
         raise ValueError('Metric name is of a type that cannot have a unit: ' + full_name)
     return full_name
 
-
-def _validate_labelname(l):
-    if not METRIC_LABEL_NAME_RE.match(l):
-        raise ValueError('Invalid label metric name: ' + l)
-    if RESERVED_METRIC_LABEL_NAME_RE.match(l):
-        raise ValueError('Reserved label metric name: ' + l)
-
-
-def _validate_labelnames(cls, labelnames):
-    labelnames = tuple(labelnames)
-    for l in labelnames:
-        _validate_labelname(l)
-        if l in cls._reserved_labelnames:
-            raise ValueError('Reserved label metric name: ' + l)
-    return labelnames
-
-
-def _validate_exemplar(exemplar):
-    runes = 0
-    for k, v in exemplar.items():
-        _validate_labelname(k)
-        runes += len(k)
-        runes += len(v)
-    if runes > 128:
-        raise ValueError('Exemplar labels have %d UTF-8 characters, exceeding the limit of 128')
 
 
 def _get_use_created() -> bool:
@@ -139,8 +116,7 @@ class MetricWrapperBase(Collector):
         self._documentation = documentation
         self._unit = unit
 
-        if not METRIC_NAME_RE.match(self._name):
-            raise ValueError('Invalid metric name: ' + self._name)
+        _validate_metric_name(self._name)
 
         if self._is_parent():
             # Prepare the fields needed for child metrics.

--- a/prometheus_client/metrics_core.py
+++ b/prometheus_client/metrics_core.py
@@ -1,15 +1,12 @@
-import re
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from .samples import Exemplar, NativeHistogram, Sample, Timestamp
+from .validation import _validate_metric_name
 
 METRIC_TYPES = (
     'counter', 'gauge', 'summary', 'histogram',
     'gaugehistogram', 'unknown', 'info', 'stateset',
 )
-METRIC_NAME_RE = re.compile(r'^[a-zA-Z_:][a-zA-Z0-9_:]*$')
-METRIC_LABEL_NAME_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
-RESERVED_METRIC_LABEL_NAME_RE = re.compile(r'^__.*$')
 
 
 class Metric:
@@ -24,8 +21,7 @@ class Metric:
     def __init__(self, name: str, documentation: str, typ: str, unit: str = ''):
         if unit and not name.endswith("_" + unit):
             name += "_" + unit
-        if not METRIC_NAME_RE.match(name):
-            raise ValueError('Invalid metric name: ' + name)
+        _validate_metric_name(name)
         self.name: str = name
         self.documentation: str = documentation
         self.unit: str = unit

--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -2,6 +2,9 @@
 
 
 from ..utils import floatToGoString
+from ..validation import (
+    _is_valid_legacy_labelname, _is_valid_legacy_metric_name,
+)
 
 CONTENT_TYPE_LATEST = 'application/openmetrics-text; version=1.0.0; charset=utf-8'
 """Content type of the latest OpenMetrics text format"""
@@ -24,18 +27,27 @@ def generate_latest(registry):
         try:
             mname = metric.name
             output.append('# HELP {} {}\n'.format(
-                mname, metric.documentation.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"')))
-            output.append(f'# TYPE {mname} {metric.type}\n')
+                escape_metric_name(mname), _escape(metric.documentation)))
+            output.append(f'# TYPE {escape_metric_name(mname)} {metric.type}\n')
             if metric.unit:
-                output.append(f'# UNIT {mname} {metric.unit}\n')
+                output.append(f'# UNIT {escape_metric_name(mname)} {metric.unit}\n')
             for s in metric.samples:
-                if s.labels:
-                    labelstr = '{{{0}}}'.format(','.join(
-                        ['{}="{}"'.format(
-                            k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))
-                            for k, v in sorted(s.labels.items())]))
+                if not _is_valid_legacy_metric_name(s.name):
+                    labelstr = escape_metric_name(s.name)
+                    if s.labels:
+                        labelstr += ', '
                 else:
                     labelstr = ''
+                
+                if s.labels:
+                    items = sorted(s.labels.items())
+                    labelstr += ','.join(
+                        ['{}="{}"'.format(
+                            escape_label_name(k), _escape(v))
+                            for k, v in items])
+                if labelstr:
+                    labelstr = "{" + labelstr + "}"
+                    
                 if s.exemplar:
                     if not _is_valid_exemplar_metric(metric, s):
                         raise ValueError(f"Metric {metric.name} has exemplars, but is not a histogram bucket or counter")
@@ -59,16 +71,47 @@ def generate_latest(registry):
                 timestamp = ''
                 if s.timestamp is not None:
                     timestamp = f' {s.timestamp}'
-                output.append('{}{} {}{}{}\n'.format(
-                    s.name,
-                    labelstr,
-                    floatToGoString(s.value),
-                    timestamp,
-                    exemplarstr,
-                ))
+                if _is_valid_legacy_metric_name(s.name):
+                    output.append('{}{} {}{}{}\n'.format(
+                        s.name,
+                        labelstr,
+                        floatToGoString(s.value),
+                        timestamp,
+                        exemplarstr,
+                    ))
+                else:
+                    output.append('{} {}{}{}\n'.format(
+                        labelstr,
+                        floatToGoString(s.value),
+                        timestamp,
+                        exemplarstr,
+                    ))
         except Exception as exception:
             exception.args = (exception.args or ('',)) + (metric,)
             raise
 
     output.append('# EOF\n')
     return ''.join(output).encode('utf-8')
+
+
+def escape_metric_name(s: str) -> str:
+    """Escapes the metric name and puts it in quotes iff the name does not
+    conform to the legacy Prometheus character set.
+    """
+    if _is_valid_legacy_metric_name(s):
+        return s
+    return '"{}"'.format(_escape(s))
+
+
+def escape_label_name(s: str) -> str:
+    """Escapes the label name and puts it in quotes iff the name does not
+    conform to the legacy Prometheus character set.
+    """
+    if _is_valid_legacy_labelname(s):
+        return s
+    return '"{}"'.format(_escape(s))
+
+
+def _escape(s: str) -> str:
+    """Performs backslash escaping on backslash, newline, and double-quote characters."""
+    return s.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"')

--- a/prometheus_client/validation.py
+++ b/prometheus_client/validation.py
@@ -1,0 +1,123 @@
+import os
+import re
+
+METRIC_NAME_RE = re.compile(r'^[a-zA-Z_:][a-zA-Z0-9_:]*$')
+METRIC_LABEL_NAME_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+RESERVED_METRIC_LABEL_NAME_RE = re.compile(r'^__.*$')
+
+
+def _init_legacy_validation() -> bool:
+    """Retrieve name validation setting from environment."""
+    return os.environ.get("PROMETHEUS_LEGACY_NAME_VALIDATION", 'False').lower() in ('true', '1', 't')
+
+
+_legacy_validation = _init_legacy_validation()
+
+
+def get_legacy_validation() -> bool:
+    """Return the current status of the legacy validation setting."""
+    global _legacy_validation
+    return _legacy_validation
+
+
+def disable_legacy_validation():
+    """Disable legacy name validation, instead allowing all UTF8 characters."""
+    global _legacy_validation
+    _legacy_validation = False
+
+
+def enable_legacy_validation():
+    """Enable legacy name validation instead of allowing all UTF8 characters."""
+    global _legacy_validation
+    _legacy_validation = True
+
+
+def _validate_metric_name(name: str) -> None:
+    """Raises ValueError if the provided name is not a valid metric name.
+    
+    This check uses the global legacy validation setting to determine the validation scheme.
+    """
+    if not name:
+        raise ValueError("metric name cannot be empty")
+    global _legacy_validation
+    if _legacy_validation:
+        if not METRIC_NAME_RE.match(name):
+            raise ValueError("invalid metric name " + name)
+    try:
+        name.encode('utf-8')
+    except UnicodeDecodeError:
+        raise ValueError("invalid metric name " + name)
+
+
+def _is_valid_legacy_metric_name(name: str) -> bool:
+    """Returns true if the provided metric name conforms to the legacy validation scheme."""
+    return METRIC_NAME_RE.match(name) is not None
+
+
+def _validate_metric_label_name_token(tok: str) -> None:
+    """Raises ValueError if a parsed label name token is invalid. 
+    
+    UTF-8 names must be quoted.
+    """
+    if not tok:
+        raise ValueError("invalid label name token " + tok)
+    global _legacy_validation
+    quoted = tok[0] == '"' and tok[-1] == '"'
+    if not quoted or _legacy_validation:
+        if not METRIC_LABEL_NAME_RE.match(tok):
+            raise ValueError("invalid label name token " + tok)
+        return
+    try:
+        tok.encode('utf-8')
+    except UnicodeDecodeError:
+        raise ValueError("invalid label name token " + tok)
+
+
+def _validate_labelname(l):
+    """Raises ValueError if the provided name is not a valid label name.
+    
+    This check uses the global legacy validation setting to determine the validation scheme.
+    """
+    if get_legacy_validation():
+        if not METRIC_LABEL_NAME_RE.match(l):
+            raise ValueError('Invalid label metric name: ' + l)
+        if RESERVED_METRIC_LABEL_NAME_RE.match(l):
+            raise ValueError('Reserved label metric name: ' + l)
+    else:
+        try:
+            l.encode('utf-8')
+        except UnicodeDecodeError:
+            raise ValueError('Invalid label metric name: ' + l)
+        if RESERVED_METRIC_LABEL_NAME_RE.match(l):
+            raise ValueError('Reserved label metric name: ' + l)
+        
+
+def _is_valid_legacy_labelname(l: str) -> bool:
+    """Returns true if the provided label name conforms to the legacy validation scheme."""
+    if METRIC_LABEL_NAME_RE.match(l) is None:
+        return False
+    return RESERVED_METRIC_LABEL_NAME_RE.match(l) is None
+
+
+def _validate_labelnames(cls, labelnames):
+    """Raises ValueError if any of the provided names is not a valid label name.
+    
+    This check uses the global legacy validation setting to determine the validation scheme.
+    """
+    labelnames = tuple(labelnames)
+    for l in labelnames:
+        _validate_labelname(l)
+        if l in cls._reserved_labelnames:
+            raise ValueError('Reserved label methe fric name: ' + l)
+    return labelnames
+
+
+def _validate_exemplar(exemplar):
+    """Raises ValueError if the exemplar is invalid."""
+    runes = 0
+    for k, v in exemplar.items():
+        _validate_labelname(k)
+        runes += len(k)
+        runes += len(v)
+    if runes > 128:
+        raise ValueError('Exemplar labels have %d UTF-8 characters, exceeding the limit of 128')

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -33,6 +33,12 @@ class TestGenerateText(unittest.TestCase):
         c.inc()
         self.assertEqual(b'# HELP cc A counter\n# TYPE cc counter\ncc_total 1.0\ncc_created 123.456\n# EOF\n',
                          generate_latest(self.registry))
+        
+    def test_counter_utf8(self):
+        c = Counter('cc.with.dots', 'A counter', registry=self.registry)
+        c.inc()
+        self.assertEqual(b'# HELP "cc.with.dots" A counter\n# TYPE "cc.with.dots" counter\n{"cc.with.dots_total"} 1.0\n{"cc.with.dots_created"} 123.456\n# EOF\n',
+                         generate_latest(self.registry))
 
     def test_counter_total(self):
         c = Counter('cc_total', 'A counter', registry=self.registry)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,9 @@ from prometheus_client.core import (
 )
 from prometheus_client.decorator import getargspec
 from prometheus_client.metrics import _get_use_created
+from prometheus_client.validation import (
+    disable_legacy_validation, enable_legacy_validation,
+)
 
 
 def is_locked(lock):
@@ -114,8 +117,12 @@ class TestCounter(unittest.TestCase):
         assert_not_observable(counter.inc)
 
     def test_exemplar_invalid_label_name(self):
+        enable_legacy_validation()
         self.assertRaises(ValueError, self.counter.inc, exemplar={':o)': 'smile'})
         self.assertRaises(ValueError, self.counter.inc, exemplar={'1': 'number'})
+        disable_legacy_validation()
+        self.counter.inc(exemplar={':o)': 'smile'})
+        self.counter.inc(exemplar={'1': 'number'})
 
     def test_exemplar_unicode(self):
         # 128 characters should not raise, even using characters larger than 1 byte.
@@ -510,9 +517,15 @@ class TestHistogram(unittest.TestCase):
         self.assertEqual(1, value('hl_count', {'l': 'a'}))
         self.assertEqual(1, value('hl_bucket', {'le': '+Inf', 'l': 'a'}))
 
-    def test_exemplar_invalid_label_name(self):
+    def test_exemplar_invalid_legacy_label_name(self):
+        enable_legacy_validation()
         self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={':o)': 'smile'})
         self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={'1': 'number'})
+
+    def test_exemplar_invalid_label_name(self):
+        disable_legacy_validation()
+        self.histogram.observe(3.0, exemplar={':o)': 'smile'})
+        self.histogram.observe(3.0, exemplar={'1': 'number'})
 
     def test_exemplar_too_long(self):
         # 129 characters in total should fail.
@@ -654,13 +667,22 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertRaises(ValueError, self.two_labels.labels)
         self.assertRaises(ValueError, self.two_labels.labels, {'a': 'x'}, b='y')
 
-    def test_invalid_names_raise(self):
+    def test_invalid_legacy_names_raise(self):
+        enable_legacy_validation()
         self.assertRaises(ValueError, Counter, '', 'help')
         self.assertRaises(ValueError, Counter, '^', 'help')
         self.assertRaises(ValueError, Counter, '', 'help', namespace='&')
         self.assertRaises(ValueError, Counter, '', 'help', subsystem='(')
         self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['^'])
         self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['a:b'])
+        self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['__reserved'])
+        self.assertRaises(ValueError, Summary, 'c_total', '', labelnames=['quantile'])
+
+    def test_invalid_names_raise(self):
+        disable_legacy_validation()
+        self.assertRaises(ValueError, Counter, '', 'help')
+        self.assertRaises(ValueError, Counter, '', 'help', namespace='&')
+        self.assertRaises(ValueError, Counter, '', 'help', subsystem='(')
         self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['__reserved'])
         self.assertRaises(ValueError, Summary, 'c_total', '', labelnames=['quantile'])
 
@@ -713,6 +735,10 @@ class TestMetricFamilies(unittest.TestCase):
     def test_counter(self):
         self.custom_collector(CounterMetricFamily('c_total', 'help', value=1))
         self.assertEqual(1, self.registry.get_sample_value('c_total', {}))
+
+    def test_counter_utf8(self):
+        self.custom_collector(CounterMetricFamily('my.metric', 'help', value=1))
+        self.assertEqual(1, self.registry.get_sample_value('my.metric_total', {}))
 
     def test_counter_total(self):
         self.custom_collector(CounterMetricFamily('c_total', 'help', value=1))

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -47,6 +47,17 @@ cc_total 1.0
 # TYPE cc_created gauge
 cc_created 123.456
 """, generate_latest(self.registry))
+        
+    def test_counter_utf8(self):
+        c = Counter('utf8.cc', 'A counter', registry=self.registry)
+        c.inc()
+        self.assertEqual(b"""# HELP "utf8.cc_total" A counter
+# TYPE "utf8.cc_total" counter
+{"utf8.cc_total"} 1.0
+# HELP "utf8.cc_created" A counter
+# TYPE "utf8.cc_created" gauge
+{"utf8.cc_created"} 123.456
+""", generate_latest(self.registry))
 
     def test_counter_name_unit_append(self):
         c = Counter('requests', 'Request counter', unit="total", registry=self.registry)


### PR DESCRIPTION
Adding support for UTF-8 required substantial reworking of the parsing code because the previous code relied on regexes and .index calls that would incorrectly find characters inside quote marks. Note that this means the previous code was already broken for parsing exposition text where characters like braces and hashes were in label values. I have added tests to exercise the edge cases I can think of.

Does not address content negotiation, which will be a followon.

part of https://github.com/prometheus/client_python/issues/1013