### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ workflows:
           matrix:
             parameters:
                python:
-                 - "3.8.18"
                  - "3.9.18"
                  - "3.10"
                  - "3.11"
@@ -89,4 +88,4 @@ workflows:
           matrix:
             parameters:
                python:
-                 - "3.8"
+                 - "3.9"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'twisted': ['twisted'],
     },
     test_suite="tests",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -38,7 +38,6 @@ setup(
         "Intended Audience :: System Administrators",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-envlist = coverage-clean,py{3.8,3.9,3.10,3.11,3.12,py3.8,3.9-nooptionals},coverage-report,flake8,isort,mypy
+envlist = coverage-clean,py{3.9,3.10,3.11,3.12,py3.9,3.9-nooptionals},coverage-report,flake8,isort,mypy
 
 [testenv]
 deps =
     coverage
     pytest
     attrs
-    {py3.8,pypy3.8}: twisted
-    py3.8: asgiref
-    # See https://github.com/django/asgiref/issues/393 for why we need to pin asgiref for pypy
-    pypy3.8: asgiref==3.6.0
+    {py3.9,pypy3.9}: twisted
+    # NOTE: Pinned due to https://github.com/prometheus/client_python/issues/1020
+    py3.9: asgiref==3.7
+    pypy3.9: asgiref==3.7
 commands = coverage run --parallel -m pytest {posargs}
 
 [testenv:py3.9-nooptionals]


### PR DESCRIPTION
Python 3.8 already reached its EOL last month. Remove support and testing of Python 3.8 .