### PR TITLE
Fix incorrect use of reentrant locks

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -1,5 +1,5 @@
 import os
-from threading import RLock
+from threading import Lock
 import time
 import types
 from typing import (
@@ -144,7 +144,7 @@ class MetricWrapperBase(Collector):
 
         if self._is_parent():
             # Prepare the fields needed for child metrics.
-            self._lock = RLock()
+            self._lock = Lock()
             self._metrics: Dict[Sequence[str], T] = {}
 
         if self._is_observable():
@@ -697,7 +697,7 @@ class Info(MetricWrapperBase):
 
     def _metric_init(self):
         self._labelname_set = set(self._labelnames)
-        self._lock = RLock()
+        self._lock = Lock()
         self._value = {}
 
     def info(self, val: Dict[str, str]) -> None:
@@ -759,7 +759,7 @@ class Enum(MetricWrapperBase):
 
     def _metric_init(self) -> None:
         self._value = 0
-        self._lock = RLock()
+        self._lock = Lock()
 
     def state(self, state: str) -> None:
         """Set enum metric state."""

--- a/prometheus_client/registry.py
+++ b/prometheus_client/registry.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import copy
-from threading import RLock
+from threading import Lock
 from typing import Dict, Iterable, List, Optional
 
 from .metrics_core import Metric
@@ -30,7 +30,7 @@ class CollectorRegistry(Collector):
         self._collector_to_names: Dict[Collector, List[str]] = {}
         self._names_to_collectors: Dict[str, Collector] = {}
         self._auto_describe = auto_describe
-        self._lock = RLock()
+        self._lock = Lock()
         self._target_info: Optional[Dict[str, str]] = {}
         self.set_target_info(target_info)
 

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -1,5 +1,5 @@
 import os
-from threading import RLock
+from threading import Lock
 import warnings
 
 from .mmap_dict import mmap_key, MmapedDict
@@ -13,7 +13,7 @@ class MutexValue:
     def __init__(self, typ, metric_name, name, labelnames, labelvalues, help_text, **kwargs):
         self._value = 0.0
         self._exemplar = None
-        self._lock = RLock()
+        self._lock = Lock()
 
     def inc(self, amount):
         with self._lock:
@@ -50,7 +50,7 @@ def MultiProcessValue(process_identifier=os.getpid):
     # Use a single global lock when in multi-processing mode
     # as we presume this means there is no threading going on.
     # This avoids the need to also have mutexes in __MmapDict.
-    lock = RLock()
+    lock = Lock()
 
     class MmapedValue:
         """A float protected by a mutex backed by a per-process mmaped file."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,14 +16,6 @@ from prometheus_client.decorator import getargspec
 from prometheus_client.metrics import _get_use_created
 
 
-def is_locked(lock):
-    "Tries to obtain a lock, returns True on success, False on failure."
-    locked = lock.acquire(blocking=False)
-    if locked:
-        lock.release()
-    return not locked
-
-
 def assert_not_observable(fn, *args, **kwargs):
     """
     Assert that a function call falls with a ValueError exception containing
@@ -986,7 +978,7 @@ class TestCollectorRegistry(unittest.TestCase):
         m = Metric('target', 'Target metadata', 'info')
         m.samples = [Sample('target_info', {'foo': 'bar'}, 1)]
         for _ in registry.restricted_registry(['target_info', 's_sum']).collect():
-            self.assertFalse(is_locked(registry._lock))
+            self.assertFalse(registry._lock.locked())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The first commit fixes a correctness bug introduced in
0014e9776350a252930671ed170edee464f9b428 resulting in eg. lost updates during some scenarios.

The code being locked is not reentrant safe. It's preferable to deadlock in these situations instead of silently loosing updates for example or allowing data corruption (mmap_dict).

Consider this example

```python
from prometheus_client import Counter

my_counter = Counter('my_counter', 'my_counter description', labelnames=["bug"])


class Tracked(float):
    def __radd__(self, other):
        # Executes within the locked section of ValueClass.inc() if used as
        # amount arg to Counter.inc().
        my_counter.labels(bug="isit").inc(1)
        my_counter.labels(bug="race").inc(10)
        return self + other

    def __str__(self):
        return f"Tracked({float(self)})"


def main():
    my_counter.labels(bug="race").inc(Tracked(100))

    for sample in my_counter.collect()[0].samples:
        print(sample)


if __name__ == '__main__':
    main()
```

Executing this with reentrant locks in place results in (both multiprocess and single process mode):
```
$ python3 example.py 
Sample(name='my_counter_total', labels={'bug': 'race'}, value=100.0, timestamp=None, exemplar=None, native_histogram=None)
Sample(name='my_counter_created', labels={'bug': 'race'}, value=1733062486.7625494, timestamp=None, exemplar=None, native_histogram=None)
Sample(name='my_counter_total', labels={'bug': 'isit'}, value=1.0, timestamp=None, exemplar=None, native_histogram=None)
Sample(name='my_counter_created', labels={'bug': 'isit'}, value=1733062486.7625587, timestamp=None, exemplar=None, native_histogram=None)
```

We would expect the value of the bug=race counter to be 110 however.

With this fix, this code will:

- With the changes from the first commit only: deadlock, signalling to the user that they have a bug.
- With both commits: raise a RuntimeError.

It's also likely to happen if someone tries to write metrics during signal handling. Again, it's preferable to deadlock instead of being incorrect IMHO.

I'm open to dropping the second commit (it does add some complexity and maybe not everyone will like the overhead of an extra lock), but it may be a useful quality of life improvement (crashing is usually better than a deadlock).

Let me know what you think!