### PR TITLE
Check if labelvalues is in _metrics before deletion in MetricWrapperBase.remove()

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -200,7 +200,8 @@ class MetricWrapperBase(Collector):
             raise ValueError('Incorrect label count (expected %d, got %s)' % (len(self._labelnames), labelvalues))
         labelvalues = tuple(str(l) for l in labelvalues)
         with self._lock:
-            del self._metrics[labelvalues]
+            if labelvalues in self._metrics:
+                del self._metrics[labelvalues]
 
     def clear(self) -> None:
         """Remove all labelsets from the metric"""


### PR DESCRIPTION
Currently raises an error if labelvalues is not in _metrics. Since the labelvalues get removed anyways, there isn't really any point of this error, since we would want to assume that after running this function call labelvalues will not exist regardless of it existed beforehand or not.