### PR TITLE
OM text exposition for NH

### DIFF
--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -26,61 +26,22 @@ def generate_latest(registry):
     for metric in registry.collect():
         try:
             mname = metric.name
-            # (Vesari): TODO: this is wrong. TYPE should come before HELP!!!!
             output.append('# HELP {} {}\n'.format(
                 escape_metric_name(mname), _escape(metric.documentation)))
             output.append(f'# TYPE {escape_metric_name(mname)} {metric.type}\n')
             if metric.unit:
-                output.append(f'# UNIT {escape_metric_name(mname)} {metric.unit}\n')
+                output.append(f'# UNIT {escape_metric_name(mname)} {metric.unit}\n')    
             for s in metric.samples:
-                if not _is_valid_legacy_metric_name(s.name):
-                    labelstr = escape_metric_name(s.name)
-                    if s.labels:
-                        labelstr += ', '
-                else:
-                    labelstr = ''
+                labelstr, exemplarstr, timestamp = _expose_classic_metrics_sample(metric, s)
                 
-                if s.labels:
-                    items = s.labels.items()
-                    labelstr += ','.join(
-                        ['{}="{}"'.format(
-                            escape_label_name(k), _escape(v))
-                            for k, v in items])
-                if labelstr:
-                    labelstr = "{" + labelstr + "}"
-                    
-                if s.exemplar:
-                    if not _is_valid_exemplar_metric(metric, s):
-                        raise ValueError(f"Metric {metric.name} has exemplars, but is not a histogram bucket or counter")
-                    labels = '{{{0}}}'.format(','.join(
-                        ['{}="{}"'.format(
-                            k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))
-                            for k, v in sorted(s.exemplar.labels.items())]))
-                    if s.exemplar.timestamp is not None:
-                        exemplarstr = ' # {} {} {}'.format(
-                            labels,
-                            floatToGoString(s.exemplar.value),
-                            s.exemplar.timestamp,
-                        )
-                    else:
-                        exemplarstr = ' # {} {}'.format(
-                            labels,
-                            floatToGoString(s.exemplar.value),
-                        )
-                else:
-                    exemplarstr = ''   
-                
-                timestamp = ''
-                if s.timestamp is not None:
-                    timestamp = f' {s.timestamp}'
-
                 native_histogram = ''
                 positive_spans = ''
                 positive_deltas = ''
                 negative_spans = ''
                 negative_deltas = ''
                 pos = False
-                neg = False      
+                neg = False
+                     
                 if s.native_histogram:                
                     # Initialize basic nh template
                     nh_sample_template = '{{count:{},sum:{},schema:{},zero_threshold:{},zero_count:{}'
@@ -127,13 +88,11 @@ def generate_latest(registry):
                     nh_sample_template += '}}'
 
                     # Format the template with the args
-                    native_histogram = nh_sample_template.format(*args)
+                    native_histogram = nh_sample_template.format(*args)    
 
-                print("These are the pos deltas", positive_deltas) #DEBUGGING LINE       
-                print("The is the nh", native_histogram) #DEBUGGING LINE
                 value = ''    
                 if s.value is not None or not s.native_histogram:
-                    value = floatToGoString(s.value)       
+                    value = floatToGoString(s.value)
                 if _is_valid_legacy_metric_name(s.name):
                     output.append('{}{} {}{}{}{}\n'.format(
                         s.name,
@@ -143,7 +102,6 @@ def generate_latest(registry):
                         exemplarstr,
                         native_histogram
                     ))
-
                 else:
                     output.append('{} {}{}{}{}\n'.format(
                         labelstr,
@@ -181,3 +139,47 @@ def escape_label_name(s: str) -> str:
 def _escape(s: str) -> str:
     """Performs backslash escaping on backslash, newline, and double-quote characters."""
     return s.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"')
+
+
+def _expose_classic_metrics_sample(metric, sample) -> tuple[str, str, str]:
+    if not _is_valid_legacy_metric_name(sample.name):
+        labelstr = escape_metric_name(sample.name)
+        if sample.labels:
+            labelstr += ', '
+    else:
+        labelstr = ''
+            
+    if sample.labels:
+        items = sample.labels.items()
+        labelstr += ','.join(
+            ['{}="{}"'.format(
+                escape_label_name(k), _escape(v))
+                for k, v in items])        
+    if labelstr:
+        labelstr = "{" + labelstr + "}"
+                
+    if sample.exemplar:
+        if not _is_valid_exemplar_metric(metric, sample):
+            raise ValueError(f"Metric {metric.name} has exemplars, but is not a histogram bucket or counter")
+        labels = '{{{0}}}'.format(','.join(
+            ['{}="{}"'.format(
+                k, v.replace('\\', r'\\').replace('\n', r'\n').replace('"', r'\"'))
+                for k, v in sorted(sample.exemplar.labels.items())]))
+        if sample.exemplar.timestamp is not None:
+            exemplarstr = ' # {} {} {}'.format(
+                labels,
+                floatToGoString(sample.exemplar.value),
+                sample.exemplar.timestamp,
+            )
+        else:
+            exemplarstr = ' # {} {}'.format(
+                labels,
+                floatToGoString(sample.exemplar.value),
+            )
+    else:
+        exemplarstr = ''   
+            
+    timestamp = ''
+    if sample.timestamp is not None:
+        timestamp = f' {sample.timestamp}'
+    return labelstr, exemplarstr, timestamp 

--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -89,18 +89,20 @@ def generate_latest(registry):
                         negative_spans = ','.join([f'{ns[0]}:{ns[1]}' for ns in s.native_histogram.neg_spans])                  
                         negative_deltas = ','.join(str(nd) for nd in s.native_histogram.neg_deltas)
                     
-                    nh_sample_template = '{{count:{},sum:{},schema:{},zero_threshold:{},zero_count:{}}}'
+                    nh_sample_template = '{{' + 'count:{},sum:{},schema:{},zero_threshold:{},zero_count:{}'
                     if positive_spans != '':
-                        nh_sample_template += ',positive_spans:[{{{}}}]'
+                        nh_sample_template += ',positive_spans:[{}]'
                     if negative_spans != '':
-                       nh_sample_template += ',negative_spans:[{{{}}}]'
+                        nh_sample_template += ',negative_spans:[{}]'
                     if positive_deltas != '':
-                       nh_sample_template += ',positive_deltas:[{{{}}}]'
-                       if negative_deltas == '':
-                           nh_sample_template += '}}'
+                        nh_sample_template += ',positive_deltas:[{}]'
+                        if negative_deltas == '':
+                            nh_sample_template += '}}'
                     if negative_deltas != '':
-                       nh_sample_template += ',negative_deltas:[{{{}}}]'
-                       nh_sample_template += '}}'
+                        nh_sample_template += ',negative_deltas:[{}]'
+                        nh_sample_template += '}}'
+                    else:
+                        nh_sample_template += '}}'    
                       
                     native_histogram = nh_sample_template.format(
                         s.native_histogram.count_value,

--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -41,7 +41,7 @@ def generate_latest(registry):
                     labelstr = ''
                 
                 if s.labels:
-                    items = sorted(s.labels.items())
+                    items = s.labels.items()
                     labelstr += ','.join(
                         ['{}="{}"'.format(
                             escape_label_name(k), _escape(v))
@@ -81,9 +81,7 @@ def generate_latest(registry):
                 negative_deltas = ''
                 pos = False
                 neg = False      
-                if s.native_histogram:
-                    if s.name is not metric.name:
-                        raise ValueError(f"Metric {metric.name} is native histogram, but sample name is not valid")                 
+                if s.native_histogram:                
                     # Initialize basic nh template
                     nh_sample_template = '{{count:{},sum:{},schema:{},zero_threshold:{},zero_count:{}'
 

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -98,14 +98,13 @@ hh_created 123.456
     def test_native_histogram(self):
         hfm = HistogramMetricFamily("nh", "nh")
         hfm.add_sample("nh", None, None, None, None, NativeHistogram(24, 100, 0, 0.001, 4, (BucketSpan(0, 2), BucketSpan(1, 2)), (BucketSpan(0, 2), BucketSpan(1, 2)), (2, 1, -3, 3), (2, 1, -2, 3)))
-       # print(hfm)
         self.custom_collector(hfm)
-        print("this is the GOT", generate_latest(self.registry)) # DEBUGGING LINE
         self.assertEqual(b"""# HELP nh nh
 # TYPE nh histogram
 nh {count:24,sum:100,schema:0,zero_threshold:0.001,zero_count:4,positive_spans:[0:2,1:2],negative_spans:[0:2,1:2],positive_deltas:[2,1,-3,3],negative_deltas:[2,1,-2,3]}
 # EOF
 """, generate_latest(self.registry))
+
 
     def test_nh_no_observation(self):
         hfm = HistogramMetricFamily("nhnoobs", "nhnoobs")
@@ -117,6 +116,19 @@ nhnoobs {count:0,sum:0,schema:3,zero_threshold:2.938735877055719e-39,zero_count:
 # EOF
 """, generate_latest(self.registry))
 
+
+    def test_nh_longer_spans(self):
+        hfm = HistogramMetricFamily("nhsp", "Is a basic example of a native histogram with three spans")
+        hfm.add_sample("nhsp", None, None, None, None, NativeHistogram(4, 6, 3, 2.938735877055719e-39, 1, (BucketSpan(0, 1), BucketSpan(7, 1), BucketSpan(4, 1)), None, (1, 0, 0), None))
+        self.custom_collector(hfm)
+        print("this is the GOT", generate_latest(self.registry)) # DEBUGGING LINE
+        self.assertEqual(b"""# HELP nhsp Is a basic example of a native histogram with three spans
+# TYPE nhsp histogram
+nhsp {count:4,sum:6,schema:3,zero_threshold:2.938735877055719e-39,zero_count:1,positive_spans:[0:1,7:1,4:1],positive_deltas:[1,0,0]}
+# EOF
+""", generate_latest(self.registry))
+
+    
 
     def test_histogram_negative_buckets(self):
         s = Histogram('hh', 'A histogram', buckets=[-1, -0.5, 0, 0.5, 1], registry=self.registry)

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -95,17 +95,17 @@ hh_created 123.456
 """, generate_latest(self.registry))
 
 
-    '''def test_native_histogram(self):
-        hfm = HistogramMetricFamily("nativehistogram", "Is a basic example of a native histogram")
-        hfm.add_sample("nativehistogram", None, None, None, None, NativeHistogram(24, 100, 0, 0.001, 4, (BucketSpan(0, 2), BucketSpan(1, 2)), (BucketSpan(0, 2), BucketSpan(1, 2)), (2, 1, -3, 3), (2, 1, -2, 3)))
+    def test_native_histogram(self):
+        hfm = HistogramMetricFamily("nh", "nh")
+        hfm.add_sample("nh", None, None, None, None, NativeHistogram(24, 100, 0, 0.001, 4, (BucketSpan(0, 2), BucketSpan(1, 2)), (BucketSpan(0, 2), BucketSpan(1, 2)), (2, 1, -3, 3), (2, 1, -2, 3)))
        # print(hfm)
         self.custom_collector(hfm)
         print("this is the GOT", generate_latest(self.registry)) # DEBUGGING LINE
-        self.assertEqual(b"""# HELP nativehistogram Is a basic example of a native histogram
-# TYPE nativehistogram histogram        
-nativehistogram {count:24,sum:100,schema:0,zero_threshold:0.001,zero_count:4,positive_spans:[0:2,1:2],negative_spans:[0:2,1:2],positive_deltas:[2,1,-3,3],negative_deltas:[2,1,-2,3]}
+        self.assertEqual(b"""# HELP nh nh
+# TYPE nh histogram
+nh {count:24,sum:100,schema:0,zero_threshold:0.001,zero_count:4,positive_spans:[0:2,1:2],negative_spans:[0:2,1:2],positive_deltas:[2,1,-3,3],negative_deltas:[2,1,-2,3]}
 # EOF
-""", generate_latest(self.registry))'''
+""", generate_latest(self.registry))
 
     def test_nh_no_observation(self):
         hfm = HistogramMetricFamily("nhnoobs", "nhnoobs")

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -121,14 +121,52 @@ nhnoobs {count:0,sum:0,schema:3,zero_threshold:2.938735877055719e-39,zero_count:
         hfm = HistogramMetricFamily("nhsp", "Is a basic example of a native histogram with three spans")
         hfm.add_sample("nhsp", None, None, None, None, NativeHistogram(4, 6, 3, 2.938735877055719e-39, 1, (BucketSpan(0, 1), BucketSpan(7, 1), BucketSpan(4, 1)), None, (1, 0, 0), None))
         self.custom_collector(hfm)
-        print("this is the GOT", generate_latest(self.registry)) # DEBUGGING LINE
         self.assertEqual(b"""# HELP nhsp Is a basic example of a native histogram with three spans
 # TYPE nhsp histogram
 nhsp {count:4,sum:6,schema:3,zero_threshold:2.938735877055719e-39,zero_count:1,positive_spans:[0:1,7:1,4:1],positive_deltas:[1,0,0]}
 # EOF
 """, generate_latest(self.registry))
-
+   
+    def test_native_histogram_utf8(self):
+        hfm = HistogramMetricFamily("native{histogram", "Is a basic example of a native histogram")
+        hfm.add_sample("native{histogram", None, None, None, None, NativeHistogram(24, 100, 0, 0.001, 4, (BucketSpan(0, 2), BucketSpan(1, 2)), (BucketSpan(0, 2), BucketSpan(1, 2)), (2, 1, -3, 3), (2, 1, -2, 3)))
+        self.custom_collector(hfm)
+        self.assertEqual(b"""# HELP "native{histogram" Is a basic example of a native histogram
+# TYPE "native{histogram" histogram
+{"native{histogram"} {count:24,sum:100,schema:0,zero_threshold:0.001,zero_count:4,positive_spans:[0:2,1:2],negative_spans:[0:2,1:2],positive_deltas:[2,1,-3,3],negative_deltas:[2,1,-2,3]}
+# EOF
+""", generate_latest(self.registry))
     
+    def test_native_histogram_utf8_stress(self):
+        hfm = HistogramMetricFamily("native{histogram", "Is a basic example of a native histogram")
+        hfm.add_sample("native{histogram", {'xx{} # {}': ' EOF # {}}}'}, None, None, None, NativeHistogram(24, 100, 0, 0.001, 4, (BucketSpan(0, 2), BucketSpan(1, 2)), (BucketSpan(0, 2), BucketSpan(1, 2)), (2, 1, -3, 3), (2, 1, -2, 3)))
+        self.custom_collector(hfm)
+        self.assertEqual(b"""# HELP "native{histogram" Is a basic example of a native histogram
+# TYPE "native{histogram" histogram
+{"native{histogram", "xx{} # {}"=" EOF # {}}}"} {count:24,sum:100,schema:0,zero_threshold:0.001,zero_count:4,positive_spans:[0:2,1:2],negative_spans:[0:2,1:2],positive_deltas:[2,1,-3,3],negative_deltas:[2,1,-2,3]}
+# EOF
+""", generate_latest(self.registry))
+
+    def test_native_histogram_with_labels(self):
+        hfm = HistogramMetricFamily("hist_w_labels", "Is a basic example of a native histogram with labels")
+        hfm.add_sample("hist_w_labels", {"foo": "bar", "baz": "qux"}, None, None, None, NativeHistogram(24, 100, 0, 0.001, 4, (BucketSpan(0, 2), BucketSpan(1, 2)), (BucketSpan(0, 2), BucketSpan(1, 2)), (2, 1, -3, 3), (2, 1, -2, 3)))
+        self.custom_collector(hfm)
+        self.assertEqual(b"""# HELP hist_w_labels Is a basic example of a native histogram with labels
+# TYPE hist_w_labels histogram
+hist_w_labels{foo="bar",baz="qux"} {count:24,sum:100,schema:0,zero_threshold:0.001,zero_count:4,positive_spans:[0:2,1:2],negative_spans:[0:2,1:2],positive_deltas:[2,1,-3,3],negative_deltas:[2,1,-2,3]}
+# EOF
+""", generate_latest(self.registry))
+    
+    def test_native_histogram_with_labels_utf8(self):
+        hfm = HistogramMetricFamily("hist.w.labels", "Is a basic example of a native histogram with labels")
+        hfm.add_sample("hist.w.labels", {"foo": "bar", "baz": "qux"}, None, None, None, NativeHistogram(24, 100, 0, 0.001, 4, (BucketSpan(0, 2), BucketSpan(1, 2)), (BucketSpan(0, 2), BucketSpan(1, 2)), (2, 1, -3, 3), (2, 1, -2, 3)))
+        self.custom_collector(hfm)
+        print("this is the GOT", generate_latest(self.registry)) # DEBUGGING LINE
+        self.assertEqual(b"""# HELP "hist.w.labels" Is a basic example of a native histogram with labels
+# TYPE "hist.w.labels" histogram
+{"hist.w.labels", foo="bar",baz="qux"} {count:24,sum:100,schema:0,zero_threshold:0.001,zero_count:4,positive_spans:[0:2,1:2],negative_spans:[0:2,1:2],positive_deltas:[2,1,-3,3],negative_deltas:[2,1,-2,3]}
+# EOF
+""", generate_latest(self.registry))
 
     def test_histogram_negative_buckets(self):
         s = Histogram('hh', 'A histogram', buckets=[-1, -0.5, 0, 0.5, 1], registry=self.registry)

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -5,7 +5,7 @@ from prometheus_client import (
     CollectorRegistry, Counter, Enum, Gauge, Histogram, Info, Metric, Summary,
 )
 from prometheus_client.core import (
-    Exemplar, GaugeHistogramMetricFamily, Timestamp,
+    BucketSpan, Exemplar, GaugeHistogramMetricFamily, NativeHistogram, HistogramMetricFamily, Sample, Timestamp,
 )
 from prometheus_client.openmetrics.exposition import generate_latest
 
@@ -93,6 +93,30 @@ hh_sum 0.05
 hh_created 123.456
 # EOF
 """, generate_latest(self.registry))
+
+
+    '''def test_native_histogram(self):
+        hfm = HistogramMetricFamily("nativehistogram", "Is a basic example of a native histogram")
+        hfm.add_sample("nativehistogram", None, None, None, None, NativeHistogram(24, 100, 0, 0.001, 4, (BucketSpan(0, 2), BucketSpan(1, 2)), (BucketSpan(0, 2), BucketSpan(1, 2)), (2, 1, -3, 3), (2, 1, -2, 3)))
+       # print(hfm)
+        self.custom_collector(hfm)
+        print("this is the GOT", generate_latest(self.registry)) # DEBUGGING LINE
+        self.assertEqual(b"""# HELP nativehistogram Is a basic example of a native histogram
+# TYPE nativehistogram histogram        
+nativehistogram {count:24,sum:100,schema:0,zero_threshold:0.001,zero_count:4,positive_spans:[0:2,1:2],negative_spans:[0:2,1:2],positive_deltas:[2,1,-3,3],negative_deltas:[2,1,-2,3]}
+# EOF
+""", generate_latest(self.registry))'''
+
+    def test_nh_no_observation(self):
+        hfm = HistogramMetricFamily("nhnoobs", "nhnoobs")
+        hfm.add_sample("nhnoobs", None, None, None, None, NativeHistogram(0, 0, 3, 2.938735877055719e-39, 0))
+        self.custom_collector(hfm)
+        self.assertEqual(b"""# HELP nhnoobs nhnoobs
+# TYPE nhnoobs histogram
+nhnoobs {count:0,sum:0,schema:3,zero_threshold:2.938735877055719e-39,zero_count:0}
+# EOF
+""", generate_latest(self.registry))
+
 
     def test_histogram_negative_buckets(self):
         s = Histogram('hh', 'A histogram', buckets=[-1, -0.5, 0, 0.5, 1], registry=self.registry)


### PR DESCRIPTION
For the sake of separation of concerns, this PR focuses only on the OM exposition format for native histograms and it does so by mocking native histograms in tests i.e. it uses the helper function `custom_collector` (as it is already done for gauge histograms) instead of the `observe` function. I will carry out the implementation of the "complete" support for native histograms in client_python in another iteration (I'm already on it). 
Incidentally, in the exposition logic, the `#HELP` line gets appended before the `#TYPE` line, whereas in the parser logic is the other way around; also, in the exposition logic the value is always a float in the OM format, whereas in the parser it doesn't seem to be the norm. In this PR I follow the behaviour already existing in the exposition logic. Let me know if I should change anything in this regard.