### PR TITLE
docs: update multiprocess collector code example

### DIFF
--- a/docs/content/multiprocess/_index.md
+++ b/docs/content/multiprocess/_index.md
@@ -49,8 +49,7 @@ MY_COUNTER = Counter('my_counter', 'Description of my counter')
 # Expose metrics.
 def app(environ, start_response):
     registry = CollectorRegistry()
-    multiprocess.MultiProcessCollector(registry)
-    data = generate_latest(registry)
+    data = generate_latest(multiprocess.MultiProcessCollector(registry))
     status = '200 OK'
     response_headers = [
         ('Content-type', CONTENT_TYPE_LATEST),


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**
As far as I could test locally @csmarchbanks, the documented example does not work in practice, and different web workers will show different sets of metrics. This PR will update the documentation to the manner which seems to have worked for serving the collected data from all processes.

**References:**
https://prometheus.github.io/client_python/multiprocess/

**Reproduction and example:**
https://github.com/moret/prometheus-multiprocess-example