### PR TITLE
Fix order-dependent flaky tests related to UTF-8 support

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -513,9 +513,9 @@ class TestHistogram(unittest.TestCase):
         enable_legacy_validation()
         self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={':o)': 'smile'})
         self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={'1': 'number'})
+        disable_legacy_validation()
 
     def test_exemplar_invalid_label_name(self):
-        disable_legacy_validation()
         self.histogram.observe(3.0, exemplar={':o)': 'smile'})
         self.histogram.observe(3.0, exemplar={'1': 'number'})
 
@@ -669,9 +669,9 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['a:b'])
         self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['__reserved'])
         self.assertRaises(ValueError, Summary, 'c_total', '', labelnames=['quantile'])
+        disable_legacy_validation()
 
     def test_invalid_names_raise(self):
-        disable_legacy_validation()
         self.assertRaises(ValueError, Counter, '', 'help')
         self.assertRaises(ValueError, Counter, '', 'help', namespace='&')
         self.assertRaises(ValueError, Counter, '', 'help', subsystem='(')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -109,10 +109,9 @@ class TestCounter(unittest.TestCase):
         assert_not_observable(counter.inc)
 
     def test_exemplar_invalid_label_name(self):
-        enable_legacy_validation()
-        self.assertRaises(ValueError, self.counter.inc, exemplar={':o)': 'smile'})
-        self.assertRaises(ValueError, self.counter.inc, exemplar={'1': 'number'})
-        disable_legacy_validation()
+        with LegacyValidationContextManager():
+            self.assertRaises(ValueError, self.counter.inc, exemplar={':o)': 'smile'})
+            self.assertRaises(ValueError, self.counter.inc, exemplar={'1': 'number'})
         self.counter.inc(exemplar={':o)': 'smile'})
         self.counter.inc(exemplar={'1': 'number'})
 
@@ -510,11 +509,10 @@ class TestHistogram(unittest.TestCase):
         self.assertEqual(1, value('hl_bucket', {'le': '+Inf', 'l': 'a'}))
 
     def test_exemplar_invalid_legacy_label_name(self):
-        enable_legacy_validation()
-        self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={':o)': 'smile'})
-        self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={'1': 'number'})
-        disable_legacy_validation()
-
+        with LegacyValidationContextManager():
+            self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={':o)': 'smile'})
+            self.assertRaises(ValueError, self.histogram.observe, 3.0, exemplar={'1': 'number'})
+        
     def test_exemplar_invalid_label_name(self):
         self.histogram.observe(3.0, exemplar={':o)': 'smile'})
         self.histogram.observe(3.0, exemplar={'1': 'number'})
@@ -660,16 +658,15 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertRaises(ValueError, self.two_labels.labels, {'a': 'x'}, b='y')
 
     def test_invalid_legacy_names_raise(self):
-        enable_legacy_validation()
-        self.assertRaises(ValueError, Counter, '', 'help')
-        self.assertRaises(ValueError, Counter, '^', 'help')
-        self.assertRaises(ValueError, Counter, '', 'help', namespace='&')
-        self.assertRaises(ValueError, Counter, '', 'help', subsystem='(')
-        self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['^'])
-        self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['a:b'])
-        self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['__reserved'])
-        self.assertRaises(ValueError, Summary, 'c_total', '', labelnames=['quantile'])
-        disable_legacy_validation()
+        with LegacyValidationContextManager():
+            self.assertRaises(ValueError, Counter, '', 'help')
+            self.assertRaises(ValueError, Counter, '^', 'help')
+            self.assertRaises(ValueError, Counter, '', 'help', namespace='&')
+            self.assertRaises(ValueError, Counter, '', 'help', subsystem='(')
+            self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['^'])
+            self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['a:b'])
+            self.assertRaises(ValueError, Counter, 'c_total', '', labelnames=['__reserved'])
+            self.assertRaises(ValueError, Summary, 'c_total', '', labelnames=['quantile'])
 
     def test_invalid_names_raise(self):
         self.assertRaises(ValueError, Counter, '', 'help')
@@ -1005,6 +1002,14 @@ class TestCollectorRegistry(unittest.TestCase):
         m.samples = [Sample('target_info', {'foo': 'bar'}, 1)]
         for _ in registry.restricted_registry(['target_info', 's_sum']).collect():
             self.assertFalse(registry._lock.locked())
+
+
+class LegacyValidationContextManager:
+    def __enter__(self):
+        enable_legacy_validation()
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        disable_legacy_validation()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For a university course, I tested this project for flaky tests, which are tests that can both pass or fail without changes to their code. I noticed that the tests changed in #1070 fail when their execution order is changed because the legacy validation is enabled in some tests but disabled in the test that follows. Since the execution order is not ensured, it's safer to disable them in the same test.
With these changes applied, the whole test suit passes every time even when executed in random order.