### PR TITLE
Don't send an empty HTTP header for /favicon.ico

### DIFF
--- a/prometheus_client/exposition.py
+++ b/prometheus_client/exposition.py
@@ -132,7 +132,7 @@ def make_wsgi_app(registry: CollectorRegistry = REGISTRY, disable_compression: b
         elif environ['PATH_INFO'] == '/favicon.ico':
             # Serve empty response for browsers
             status = '200 OK'
-            headers = [('', '')]
+            headers = []
             output = b''
         else:
             # Note: For backwards compatibility, the URI path for GET is not


### PR DESCRIPTION
Requesting /favicon.ico sends an empty HTTP header:

```
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /favicon.ico HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
>
* HTTP 1.0, assume close after body
< HTTP/1.0 200 OK
< Date: Mon, 07 Apr 2025 14:24:35 GMT
< Server: WSGIServer/0.2 CPython/3.12.9
< :
< Content-Length: 0
<
* Closing connection 0
```

The empty header right before `Content-Length` breaks strict proxies/middleware.
