### PR TITLE
Use License Expressions in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,11 @@ name = "prometheus_client"
 version = "0.22.0"
 description = "Python client for the Prometheus monitoring system."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "Apache-2.0 AND BSD-2-Clause"
+license-files = [
+	"LICENSE",
+	"NOTICE",
+]
 requires-python = ">=3.9"
 authors = [
     { name = "The Prometheus Authors", email = "prometheus-developers@googlegroups.com" },
@@ -33,7 +37,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: System :: Monitoring",
-    "License :: OSI Approved :: Apache Software License",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
With the release of [PEP-639](https://peps.python.org/pep-0639/) the best practice for specifying the license is now to use a license expression in the license field and specify any license files in license-files rather than the table-based approach from [PEP-621](https://peps.python.org/pep-0621/#license). Including the license in the classifiers is also no longer allowed when using PEP-639 and has been removed.