### PR TITLE
Fix including test data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft tests/certs
+graft tests/proc


### PR DESCRIPTION
Readd parts of `MANIFEST.in` responsible for including the test data in the source distribution.  Without that, setuptools includes only `.py` files from the test tree, leading to test failures.

Fixes #1112