### PR TITLE
Fix bug which caused metric publishing to not accept query string parameters in ASGI app

### DIFF
--- a/prometheus_client/asgi.py
+++ b/prometheus_client/asgi.py
@@ -11,7 +11,7 @@ def make_asgi_app(registry: CollectorRegistry = REGISTRY, disable_compression: b
     async def prometheus_app(scope, receive, send):
         assert scope.get("type") == "http"
         # Prepare parameters
-        params = parse_qs(scope.get('query_string', b''))
+        params = parse_qs(scope.get('query_string', b'').decode("utf8"))
         accept_header = ",".join([
             value.decode("utf8") for (name, value) in scope.get('headers')
             if name.decode("utf8").lower() == 'accept'


### PR DESCRIPTION
The `_bake_output` function in `exposition.py` expects the `params` argument to be a `dict[str, Any]` but the ASGI interface does not handle encoding, thus the parameters are passed in as `dict[bytes, Any]`.