### PR TITLE
Bump flake8 libraries

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,9 @@ commands =
 
 [testenv:flake8]
 deps =
-    flake8==6.0.0
-    flake8-docstrings==1.6.0
-    flake8-import-order==0.18.2
+    flake8~=7.3
+    flake8-docstrings~=1.7
+    flake8-import-order~=0.19
 skip_install = true
 commands =
     flake8 prometheus_client/ tests/ setup.py


### PR DESCRIPTION
... to the latest version available now. Also, do not pin bugfix version because any bugfix update is supposed to bring no breaking fix.