### PR TITLE
Fix issue parsing double spaces after # HELP/# TYPE

### DIFF
--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -186,6 +186,12 @@ def _split_quoted(text, separator, maxsplit=0):
             tokens[-1] = text[x:]
             x = len(text)
             continue
+        # If the first character is the separator keep going. This happens when
+        # there are double whitespace characters separating symbols.
+        if split_pos == x:
+            x += 1
+            continue
+
         if maxsplit > 0 and len(tokens) > maxsplit:
             tokens[-1] = text[x:]
             break

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -121,7 +121,6 @@ a 1
 """)
         self.assertEqualMetrics([CounterMetricFamily("a", "help", value=1)], list(families))
 
-
     def test_comments_parts_are_not_validated_against_legacy_metric_name(self):
         # https://github.com/prometheus/client_python/issues/1108
         families = text_string_to_metric_families("""
@@ -130,7 +129,12 @@ a 1
 """)
         self.assertEqualMetrics([], list(families))
 
-
+    def test_extra_whitespace(self):
+        families = text_string_to_metric_families("""# TYPE  a  counter
+# HELP  a  help
+a  1
+""")
+        self.assertEqualMetrics([CounterMetricFamily("a", "help", value=1)], list(families))
 
     def test_tabs(self):
         families = text_string_to_metric_families("""#\tTYPE\ta\tcounter


### PR DESCRIPTION
A regression was reported for 0.22.x where if there are two spaces after HELP or TEXT we would raise a value error. This was caused by having an extra entry in our array of splits due to how we process the splits.

Fixes #1131 