### PR TITLE
Add Django exporter (#1088)

### DIFF
--- a/docs/content/exporting/http/django.md
+++ b/docs/content/exporting/http/django.md
@@ -1,0 +1,47 @@
+---
+title: Django
+weight: 5
+---
+
+To use Prometheus with [Django](https://www.djangoproject.com/) you can use the provided view class 
+to add a metrics endpoint to your app.
+
+```python
+# urls.py
+
+from django.urls import path
+from prometheus_client.django import PrometheusDjangoView
+
+urlpatterns = [
+    # ... any other urls that you want
+    path("metrics/", PrometheusDjangoView.as_view(), name="prometheus-metrics"),
+    # ... still more urls
+]
+```
+
+By default, Multiprocessing support is activated if environment variable `PROMETHEUS_MULTIPROC_DIR` is set.
+You can override this through the view arguments:
+
+```python
+from django.conf import settings
+
+urlpatterns = [
+    path(
+        "metrics/",
+        PrometheusDjangoView.as_view(
+            multiprocess_mode=settings.YOUR_SETTING  # or any boolean value
+        ),
+        name="prometheus-metrics",
+    ),
+]
+```
+
+Full multiprocessing instructions are provided [here]({{< ref "/multiprocess" >}}).
+
+# django-prometheus
+
+The included `PrometheusDjangoView` is useful if you want to define your own metrics from scratch.
+
+An external package called [django-prometheus](https://github.com/django-commons/django-prometheus/) 
+can be used instead if you want to get a bunch of ready-made monitoring metrics for your Django application
+and easily benefit from utilities such as models monitoring.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = prometheus_client/decorator.py|prometheus_client/twisted|tests/test_twisted.py
+exclude = prometheus_client/decorator.py|prometheus_client/twisted|tests/test_twisted.py|prometheus_client/django|tests/test_django.py
 implicit_reexport = False
 disallow_incomplete_defs = True
 

--- a/prometheus_client/django/__init__.py
+++ b/prometheus_client/django/__init__.py
@@ -1,0 +1,5 @@
+from .exposition import PrometheusDjangoView
+
+__all__ = [
+    "PrometheusDjangoView",
+]

--- a/prometheus_client/django/exposition.py
+++ b/prometheus_client/django/exposition.py
@@ -1,0 +1,44 @@
+import os
+
+from django.http import HttpResponse
+from django.views import View
+
+import prometheus_client
+from prometheus_client import multiprocess
+from prometheus_client.exposition import _bake_output
+from prometheus_client.registry import registry
+
+
+class PrometheusDjangoView(View):
+    multiprocess_mode: bool = "PROMETHEUS_MULTIPROC_DIR" in os.environ or "prometheus_multiproc_dir" in os.environ
+    registry: prometheus_client.CollectorRegistry = None
+
+    def get(self, request, *args, **kwargs):
+        if self.registry is None:
+            if self.multiprocess_mode:
+                self.registry = prometheus_client.CollectorRegistry()
+                multiprocess.MultiProcessCollector(registry)
+            else:
+                self.registry = prometheus_client.REGISTRY
+        accept_header = request.headers.get("Accept")
+        accept_encoding_header = request.headers.get("Accept-Encoding")
+        # Bake output
+        status, headers, output = _bake_output(
+            registry=self.registry,
+            accept_header=accept_header,
+            accept_encoding_header=accept_encoding_header,
+            params=request.GET,
+            disable_compression=False,
+        )
+        status = int(status.split(" ")[0])
+        return HttpResponse(
+            output,
+            status=status,
+            headers=headers,
+        )
+
+    def options(self, request, *args, **kwargs):
+        return HttpResponse(
+            status=200,
+            headers={"Allow": "OPTIONS,GET"},
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ twisted = [
 aiohttp = [
 	"aiohttp",
 ]
+django = [
+	"django",
+]
 
 [project.urls]
 Homepage = "https://github.com/prometheus/client_python"

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,0 +1,48 @@
+from unittest import skipUnless
+
+from prometheus_client import CollectorRegistry, Counter, generate_latest
+from prometheus_client.openmetrics.exposition import ALLOWUTF8
+
+try:
+    import django
+    from django.test import RequestFactory, TestCase
+
+    from prometheus_client.django import PrometheusDjangoView
+
+    HAVE_DJANGO = True
+except ImportError:
+    from unittest import TestCase
+
+    HAVE_DJANGO = False
+
+else:
+    from django.conf import settings
+
+    if not settings.configured:
+        settings.configure(
+            DATABASES={
+                "default": {
+                    "ENGINE": "django.db.backends.sqlite3",
+                    'NAME': ':memory:'
+                }
+            },
+            INSTALLED_APPS=[],
+        )
+        django.setup()
+
+
+class MetricsResourceTest(TestCase):
+    @skipUnless(HAVE_DJANGO, "Don't have django installed.")
+    def setUp(self):
+        self.registry = CollectorRegistry()
+        self.factory = RequestFactory()
+
+    def test_reports_metrics(self):
+        c = Counter('cc', 'A counter', registry=self.registry)
+        c.inc()
+
+        request = self.factory.get("/metrics")
+
+        response = PrometheusDjangoView.as_view(registry=self.registry)(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, generate_latest(self.registry, ALLOWUTF8))

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     attrs
     {py3.9,pypy3.9}: twisted
     {py3.9,pypy3.9}: aiohttp
+    {py3.9,pypy3.9}: django
     {py3.9}: python-snappy
 commands = coverage run --parallel -m pytest {posargs}
 


### PR DESCRIPTION
Fixes #1088 

Finally got the time to propose what I had in mind :)

I added a utility view for easy inclusion of a metrics endpoint inside a Django project.

I also added some explanation about django-prometheus and the difference between what it provides and the new view.
I hope the difference is clear that way.