### PR TITLE
fix(multiprocess): avoid double-building child metric names (#1035)

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -109,6 +109,10 @@ class MetricWrapperBase(Collector):
                  registry: Optional[CollectorRegistry] = REGISTRY,
                  _labelvalues: Optional[Sequence[str]] = None,
                  ) -> None:
+
+        self._original_name = name
+        self._namespace = namespace
+        self._subsystem = subsystem
         self._name = _build_full_name(self._type, name, namespace, subsystem, unit)
         self._labelnames = _validate_labelnames(self, labelnames)
         self._labelvalues = tuple(_labelvalues or ())
@@ -177,18 +181,22 @@ class MetricWrapperBase(Collector):
         with self._lock:
             if labelvalues not in self._metrics:
 
-                child_kwargs = dict(self._kwargs) if self._kwargs else {}
+                original_name = getattr(self, '_original_name', self._name)
+                namespace = getattr(self, '_namespace', '')
+                subsystem = getattr(self, '_subsystem', '')
+                unit = getattr(self, '_unit', '')
 
+                child_kwargs = dict(self._kwargs) if self._kwargs else {}
                 for k in ('namespace', 'subsystem', 'unit'):
                     child_kwargs.pop(k, None)
 
                 self._metrics[labelvalues] = self.__class__(
-                    self._name,
+                    original_name,
                     documentation=self._documentation,
                     labelnames=self._labelnames,
-                    namespace="",
-                    subsystem="",  
-                    unit="",
+                    namespace=namespace,
+                    subsystem=subsystem,
+                    unit=unit,
                     _labelvalues=labelvalues,
                     **child_kwargs
                 )


### PR DESCRIPTION
## Description

Fixes **#1035**

Child metrics created via `labels()` could rebuild their full names when using metric subclasses with default `namespace`/`subsystem`/`unit`, especially in multiprocess mode, producing double-prefixed names.

## Problem

With a subclass like:

```python
class CustomCounter(Counter):
    def __init__(self, name, documentation, labelnames=(),
                 namespace='mydefaultnamespace',
                 subsystem='mydefaultsubsystem',
                 unit='defaultunit',
                 **kwargs):
        super().__init__(name, documentation, labelnames=labelnames,
                         namespace=namespace, subsystem=subsystem,
                         unit=unit, **kwargs)
```

and an instance:

```python
c = CustomCounter(
    name='m',
    documentation='help',
    labelnames=('status', 'method'),
    namespace='mynamespace',
    subsystem='mysubsystem',
    unit='seconds',
)
```

multiprocess mode could export child metrics with double-prefixed names like:

```
mydefaultnamespace_mydefaultsubsystem_mynamespace_mysubsystem_m_seconds_total
```

instead of the correct:

```
mynamespace_mysubsystem_m_seconds_total
```

This happened because the already-built full name was passed to the child metric constructor, which then applied namespace/subsystem/unit transformations a second time.

## Solution

* In `MetricWrapperBase.__init__`, store original constructor arguments:
  ```python
  self._original_name = name
  self._namespace = namespace
  self._subsystem = subsystem
  self._unit = unit
  ```

* In `MetricWrapperBase.labels()`, use stored values when creating child metrics:
  ```python
  original_name = getattr(self, '_original_name', self._name)
  namespace = getattr(self, '_namespace', '')
  subsystem = getattr(self, '_subsystem', '')
  unit = getattr(self, '_unit', '')
  
  self._metrics[labelvalues] = self.__class__(
      original_name,
      namespace=namespace,
      subsystem=subsystem,
      unit=unit,
      ...
  )
  ```

This ensures the full name is built exactly once, making single-process and multiprocess exports consistent.

## Testing

- [x] All existing tests pass
- [x] Verified correct name construction in multiprocess mode
- [x] Verified subclass compatibility (child metrics preserve parent context)
- [x] Backward compatible via `getattr()` fallbacks

## Breaking Changes

None (internal-only change to `MetricWrapperBase`)