### PR TITLE
fix: replace bare except with except BaseException in decorator

### DIFF
--- a/prometheus_client/decorator.py
+++ b/prometheus_client/decorator.py
@@ -193,7 +193,7 @@ class FunctionMaker(object):
         try:
             code = compile(src, filename, 'single')
             exec(code, evaldict)
-        except:
+        except BaseException:
             print('Error in generated code:', file=sys.stderr)
             print(src, file=sys.stderr)
             raise


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except BaseException:` in `prometheus_client/decorator.py` (PEP 8 E722).

The bare `except` clause catches everything including `SystemExit` and `KeyboardInterrupt`. Since this block re-raises the exception, using `except BaseException:` preserves the exact same behavior while being explicit about the intent.

**Change:**
```python
# Before
except:
    print('Error in generated code:', file=sys.stderr)
    print(src, file=sys.stderr)
    raise

# After
except BaseException:
    print('Error in generated code:', file=sys.stderr)
    print(src, file=sys.stderr)
    raise
```

## Testing
No behavior change — the `raise` re-raises the caught exception regardless. `BaseException` catches everything just like bare `except`, but satisfies PEP 8 E722.