### PR TITLE
Expose measured duration on Timer context manager

### DIFF
--- a/docs/content/instrumenting/gauge.md
+++ b/docs/content/instrumenting/gauge.md
@@ -108,6 +108,10 @@ def process():
 
 with g.time():
     pass
+
+with g.time() as t:
+    pass
+# t.duration holds the observed seconds
 ```
 
 ### `set_function(f)`

--- a/docs/content/instrumenting/gauge.md
+++ b/docs/content/instrumenting/gauge.md
@@ -111,7 +111,7 @@ with g.time():
 
 with g.time() as t:
     pass
-# t.duration holds the observed seconds
+print(t.duration) # observed time in seconds.
 ```
 
 ### `set_function(f)`

--- a/docs/content/instrumenting/histogram.md
+++ b/docs/content/instrumenting/histogram.md
@@ -86,6 +86,10 @@ def process():
 
 with h.time():
     pass
+
+with h.time() as t:
+    pass
+# t.duration holds the observed seconds
 ```
 
 ## Labels

--- a/docs/content/instrumenting/histogram.md
+++ b/docs/content/instrumenting/histogram.md
@@ -89,7 +89,7 @@ with h.time():
 
 with h.time() as t:
     pass
-# t.duration holds the observed seconds
+print(t.duration) # observed time in seconds.
 ```
 
 ## Labels

--- a/docs/content/instrumenting/summary.md
+++ b/docs/content/instrumenting/summary.md
@@ -68,6 +68,10 @@ def process():
 
 with s.time():
     pass
+
+with s.time() as t:
+    pass
+# t.duration holds the observed seconds
 ```
 
 ## Labels

--- a/docs/content/instrumenting/summary.md
+++ b/docs/content/instrumenting/summary.md
@@ -71,7 +71,7 @@ with s.time():
 
 with s.time() as t:
     pass
-# t.duration holds the observed seconds
+print(t.duration) # observed time in seconds.
 ```
 
 ## Labels

--- a/prometheus_client/context_managers.py
+++ b/prometheus_client/context_managers.py
@@ -55,6 +55,7 @@ class Timer:
     def __init__(self, metric, callback_name):
         self._metric = metric
         self._callback_name = callback_name
+        self.duration = None
 
     def _new_timer(self):
         return self.__class__(self._metric, self._callback_name)
@@ -65,9 +66,9 @@ class Timer:
 
     def __exit__(self, typ, value, traceback):
         # Time can go backwards.
-        duration = max(default_timer() - self._start, 0)
+        self.duration = max(default_timer() - self._start, 0)
         callback = getattr(self._metric, self._callback_name)
-        callback(duration)
+        callback(self.duration)
 
     def labels(self, *args, **kw):
         self._metric = self._metric.labels(*args, **kw)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -378,6 +378,14 @@ class TestSummary(unittest.TestCase):
             metric.labels('foo')
         self.assertEqual(1, value('s_with_labels_count', {'label1': 'foo'}))
 
+    def test_timer_duration_exposed(self):
+        with self.summary.time() as t:
+            time.sleep(0.01)
+        self.assertIsNotNone(t.duration)
+        self.assertGreater(t.duration, 0)
+        recorded_sum = self.registry.get_sample_value('s_sum')
+        self.assertEqual(t.duration, recorded_sum)
+
     def test_timer_not_observable(self):
         s = Summary('test', 'help', labelnames=('label',), registry=self.registry)
 


### PR DESCRIPTION
 ### Motivation

  When you use `.time()` as a context manager, the duration is already computed internally but thrown away — if you want to log or reuse it, you end up measuring twice:

  ```python
  start = time.monotonic()
  with REQUEST_LATENCY.time():
      response = handle_request()
  logger.info("request took %.3fs", time.monotonic() - start)
  ```

  That's redundant and slightly off (the two measurements don't cover the same interval). This change stores the observed value on the `Timer` so it can be read back after the block exits.

  ### Usage

  ```python
  with REQUEST_LATENCY.time() as t:
      response = handle_request()

  logger.info("request took %.3fs", t.duration)
  ```

  `t.duration` is `None` before the block runs and holds the observed seconds (the same value passed to `observe()` / `set()`) afterwards.

  ### Compatibility

  Purely additive. Existing `with metric.time():` usage is unchanged — the attribute is only visible if you bind the context manager with `as`.