### PR TITLE
A redis-backed storage backend

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -207,6 +207,10 @@ class MetricWrapperBase(Collector):
             warnings.warn(
                 "Removal of labels has not been implemented in  multi-process mode yet.",
                 UserWarning)
+        if 'PROMETHEUS_REDIS_URL' in os.environ:
+            warnings.warn(
+                "Removal of labels has not been implemented in redis mode yet.",
+                UserWarning)
 
         if not self._labelnames:
             raise ValueError('No label names were set when constructing %s' % self)
@@ -226,6 +230,10 @@ class MetricWrapperBase(Collector):
                 "Removal of labels has not been implemented in  multi-process mode yet.",
                 UserWarning
             )
+        if 'PROMETHEUS_REDIS_URL' in os.environ:
+            warnings.warn(
+                "Removal of labels has not been implemented in redis mode yet.",
+                UserWarning)
 
         if not self._labelnames:
             raise ValueError('No label names were set when constructing %s' % self)
@@ -257,6 +265,10 @@ class MetricWrapperBase(Collector):
         if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
             warnings.warn(
                 "Clearing labels has not been implemented in multi-process mode yet",
+                UserWarning)
+        if 'PROMETHEUS_REDIS_URL' in os.environ:
+            warnings.warn(
+                "Clearing of labels has not been implemented in redis mode yet.",
                 UserWarning)
         with self._lock:
             self._metrics = {}

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -207,6 +207,10 @@ class MetricWrapperBase(Collector):
             warnings.warn(
                 "Removal of labels has not been implemented in  multi-process mode yet.",
                 UserWarning)
+        if 'PROMETHEUS_REDIS_URL' in os.environ:
+            warnings.warn(
+                "Removal of labels has not been implemented in redis mode yet.",
+                UserWarning)
 
         if not self._labelnames:
             raise ValueError('No label names were set when constructing %s' % self)
@@ -226,6 +230,10 @@ class MetricWrapperBase(Collector):
                 "Removal of labels has not been implemented in  multi-process mode yet.",
                 UserWarning
             )
+        if 'PROMETHEUS_REDIS_URL' in os.environ:
+            warnings.warn(
+                "Removal of labels has not been implemented in redis mode yet.",
+                UserWarning)
 
         if not self._labelnames:
             raise ValueError('No label names were set when constructing %s' % self)
@@ -259,6 +267,10 @@ class MetricWrapperBase(Collector):
         if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
             warnings.warn(
                 "Clearing labels has not been implemented in multi-process mode yet",
+                UserWarning)
+        if 'PROMETHEUS_REDIS_URL' in os.environ:
+            warnings.warn(
+                "Clearing of labels has not been implemented in redis mode yet.",
                 UserWarning)
         with self._lock:
             self._metrics = {}

--- a/prometheus_client/redis.py
+++ b/prometheus_client/redis.py
@@ -1,0 +1,98 @@
+import os
+from datetime import timedelta
+from threading import Event, Thread
+from typing import Any
+from urllib.parse import urlsplit
+
+from redis import Redis
+
+# For testing, a pool of otherwise anonymous FakeRedis instances are made
+# available by ID
+_fake_redis_pool: dict[int, Redis] = {}
+
+
+def redis_client() -> Redis:
+    """
+    Create a redis client for PROMETHEUS_REDIS_URL.
+
+    Configure the redis database via a URL in PROMETHEUS_REDIS_URL of the form
+    redis://localhost:6379/0
+    """
+    parsed_url = urlsplit(os.environ["PROMETHEUS_REDIS_URL"])
+    assert parsed_url.path.startswith("/")
+    assert parsed_url.path[1:].isdigit()
+    port = parsed_url.port or 6379
+    db = int(parsed_url.path[1:])
+
+    if parsed_url.scheme == "fakeredis":
+        from fakeredis import FakeRedis
+
+        if db not in _fake_redis_pool:
+            _fake_redis_pool[db] = FakeRedis()
+        return _fake_redis_pool[db]
+
+    assert parsed_url.scheme == "redis"
+    assert parsed_url.hostname
+    return Redis(host=parsed_url.hostname, port=port, db=db)
+
+
+# For each process identifier, a list of keys that should be kept from expiring
+_live_metrics: dict[str, set[str]] = {}
+
+
+def _key_expiry() -> timedelta:
+    """Return the configured expiry for multiprocess keys."""
+    return timedelta(seconds=int(os.environ.get("PROMETHEUS_REDIS_REFRESH_TTL", 20)))
+
+
+class KeepMetricsAliveThread(Thread):
+    """A daemon thread that keeps metrics from expiring as long as we live."""
+
+    stop: Event
+    identifier: str
+    client: Redis
+
+    def __init__(
+        self, identifier: str, client: Redis, *args: Any, **kwargs: Any
+    ) -> None:
+        self.stop = Event()
+        self.identifier = identifier
+        self.client = client
+        super().__init__(*args, **kwargs)
+
+    def loop_wait(self, delay: float) -> bool:
+        return self.stop.wait(delay)
+
+    def run(self) -> None:
+        delay = float(os.environ.get("PROMETHEUS_REDIS_REFRESH_FREQUENCY", 10))
+        expiry = _key_expiry()
+        while not self.loop_wait(delay):
+            for key in _live_metrics[self.identifier]:
+                self.client.expire(key, expiry)
+
+
+_daemon_threads: dict[str, KeepMetricsAliveThread] = {}
+
+
+def _keep_key_from_expiring(identifier: str, key: str) -> None:
+    """Stop key for process identifier from expiring as long as we are alive."""
+    _live_metrics.setdefault(identifier, set()).add(key)
+    if identifier not in _daemon_threads:
+        thread = KeepMetricsAliveThread(
+            identifier=identifier, client=redis_client(), daemon=True
+        )
+        thread.start()
+        _daemon_threads[identifier] = thread
+
+
+def mark_process_dead(identifier: str | int) -> None:
+    """Immediately expire all live* metrics for process identifier."""
+    thread = _daemon_threads.pop(str(identifier), None)
+    if thread is not None:
+        thread.stop.set()
+        thread.join()
+
+    keys = _live_metrics.pop(str(identifier), None)
+    if not keys:
+        return
+    redis_client().delete(*keys)

--- a/prometheus_client/redis.py
+++ b/prometheus_client/redis.py
@@ -1,0 +1,98 @@
+from datetime import timedelta
+import os
+from threading import Event, Thread
+from typing import Any
+from urllib.parse import urlsplit
+
+from redis import Redis
+
+# For testing, a pool of otherwise anonymous FakeRedis instances are made
+# available by ID
+_fake_redis_pool: dict[int, Redis] = {}
+
+
+def redis_client() -> Redis:
+    """
+    Create a redis client for PROMETHEUS_REDIS_URL.
+
+    Configure the redis database via a URL in PROMETHEUS_REDIS_URL of the form
+    redis://localhost:6379/0
+    """
+    parsed_url = urlsplit(os.environ["PROMETHEUS_REDIS_URL"])
+    assert parsed_url.path.startswith("/")
+    assert parsed_url.path[1:].isdigit()
+    port = parsed_url.port or 6379
+    db = int(parsed_url.path[1:])
+
+    if parsed_url.scheme == "fakeredis":
+        from fakeredis import FakeRedis
+
+        if db not in _fake_redis_pool:
+            _fake_redis_pool[db] = FakeRedis()
+        return _fake_redis_pool[db]
+
+    assert parsed_url.scheme == "redis"
+    assert parsed_url.hostname
+    return Redis(host=parsed_url.hostname, port=port, db=db)
+
+
+# For each process identifier, a list of keys that should be kept from expiring
+_live_metrics: dict[str, set[str]] = {}
+
+
+def _key_expiry() -> timedelta:
+    """Return the configured expiry for multiprocess keys."""
+    return timedelta(seconds=int(os.environ.get("PROMETHEUS_REDIS_REFRESH_TTL", 20)))
+
+
+class KeepMetricsAliveThread(Thread):
+    """A daemon thread that keeps metrics from expiring as long as we live."""
+
+    stop: Event
+    identifier: str
+    client: Redis
+
+    def __init__(
+        self, identifier: str, client: Redis, *args: Any, **kwargs: Any
+    ) -> None:
+        self.stop = Event()
+        self.identifier = identifier
+        self.client = client
+        super().__init__(*args, **kwargs)
+
+    def loop_wait(self, delay: float) -> bool:
+        return self.stop.wait(delay)
+
+    def run(self) -> None:
+        delay = float(os.environ.get("PROMETHEUS_REDIS_REFRESH_FREQUENCY", 10))
+        expiry = _key_expiry()
+        while not self.loop_wait(delay):
+            for key in _live_metrics[self.identifier]:
+                self.client.expire(key, expiry)
+
+
+_daemon_threads: dict[str, KeepMetricsAliveThread] = {}
+
+
+def _keep_key_from_expiring(identifier: str, key: str) -> None:
+    """Stop key for process identifier from expiring as long as we are alive."""
+    _live_metrics.setdefault(identifier, set()).add(key)
+    if identifier not in _daemon_threads:
+        thread = KeepMetricsAliveThread(
+            identifier=identifier, client=redis_client(), daemon=True
+        )
+        thread.start()
+        _daemon_threads[identifier] = thread
+
+
+def mark_process_dead(identifier: str | int) -> None:
+    """Immediately expire all live* metrics for process identifier."""
+    thread = _daemon_threads.pop(str(identifier), None)
+    if thread is not None:
+        thread.stop.set()
+        thread.join()
+
+    keys = _live_metrics.pop(str(identifier), None)
+    if not keys:
+        return
+    redis_client().delete(*keys)

--- a/prometheus_client/redis_collector.py
+++ b/prometheus_client/redis_collector.py
@@ -1,0 +1,123 @@
+from collections.abc import Iterable
+import json
+import os
+from urllib.parse import urlsplit
+
+from .metrics_core import Metric
+from .registry import Collector, CollectorRegistry
+from .samples import Sample
+
+fake_redis_pool = {}
+
+
+def redis_client():
+    """
+    Create a redis client for PROMETHEUS_REDIS_URL.
+
+    Configure the redis database via a URL in PROMETHEUS_REDIS_URL of the form
+    redis://localhost:6379/0
+    """
+    from redis import Redis
+
+    parsed_url = urlsplit(os.environ["PROMETHEUS_REDIS_URL"])
+    assert parsed_url.path.startswith("/")
+    assert parsed_url.path[1:].isdigit()
+    port = parsed_url.port or 6379
+    db = int(parsed_url.path[1:])
+
+    if parsed_url.scheme == "fakeredis":
+        from fakeredis import FakeRedis
+
+        if db not in fake_redis_pool:
+            fake_redis_pool[db] = FakeRedis()
+        return fake_redis_pool[db]
+
+    assert parsed_url.scheme == "redis"
+    return Redis(host=parsed_url.hostname, port=port, db=db)
+
+
+class RedisCollector(Collector):
+    """Collector for redis mode."""
+
+    def __init__(self, registry: CollectorRegistry | None) -> None:
+        self._client = redis_client()
+        if registry:
+            registry.register(self)
+
+    def _iter_values(self) -> Iterable[tuple[bytes, str]]:
+        cursor = 0
+        while True:
+            cursor, keys = self._client.scan(cursor=cursor, match="value:*")
+            values = self._client.mget(keys)
+            yield from zip(keys, values)
+            if cursor == 0:
+                break
+
+    def collect(self) -> Iterable[Metric]:
+        metrics: dict[str, Metric] = {}
+        histograms: set[str] = set()
+
+        for key, value_s in self._iter_values():
+            # FIXME: Catch ValueError here, just in case?
+            prefix_b, typ_b, mmap_key = key.split(b":", 2)
+            assert prefix_b == b"value"
+            typ = typ_b.decode()
+            value = float(value_s)
+
+            metric_name, name, labels, help_text = json.loads(mmap_key)
+
+            metric = metrics.get(metric_name)
+            if metric is None:
+                metric = Metric(metric_name, help_text, typ)
+                metrics[metric_name] = metric
+                if typ in ("histogram", "gaugehistogram"):
+                    histograms.add(metric_name)
+
+            metric.add_sample(name, labels, value)
+
+        for name in histograms:
+            self._fix_histogram(metrics[name])
+
+        return metrics.values()
+
+    def _fix_histogram(self, metric: Metric) -> None:
+        """
+        Fix-up histogram samples.
+
+        Sort the buckets as expected by a client, and accumulate the values.
+        The Histogram class is optimized to only increment the bucket that a
+        value first appears in, not larger ones that would also contain it.
+        """
+        by_label: dict[tuple[tuple[str, ...], str], list[Sample]] = {}
+
+        # Organize into lists of samples by label
+        for sample in metric.samples:
+            if "le" in sample.labels:
+                labels_without_le = sample.labels.copy()
+                labels_without_le.pop("le")
+                key = (tuple(labels_without_le.values()), sample.name)
+            else:
+                key = (tuple(sample.labels.values()), sample.name)
+            by_label.setdefault(key, []).append(sample)
+
+        metric.samples = []
+
+        for (labels, name), samples in sorted(by_label.items()):
+            if name.endswith("_bucket"):
+                # Sort buckets within each label
+                samples.sort(key=lambda sample: float(sample.labels["le"]))
+
+                # Accumulate values into larger buckets
+                value = 0.0
+                for sample in samples:
+                    value += sample.value
+                    metric.samples.append(Sample(sample.name, sample.labels, value))
+
+                labels_without_le = sample.labels.copy()
+                labels_without_le.pop("le")
+                metric.samples.append(
+                    Sample(f"{metric.name}_count", labels_without_le, value)
+                )
+
+            else:
+                metric.samples.extend(samples)

--- a/prometheus_client/redis_collector.py
+++ b/prometheus_client/redis_collector.py
@@ -1,39 +1,12 @@
-from collections.abc import Iterable
 import json
-import os
-from urllib.parse import urlsplit
+from collections.abc import Iterable
+from typing import cast
 
 from .metrics_core import Metric
+from .redis import redis_client
 from .registry import Collector, CollectorRegistry
 from .samples import Sample
-
-fake_redis_pool = {}
-
-
-def redis_client():
-    """
-    Create a redis client for PROMETHEUS_REDIS_URL.
-
-    Configure the redis database via a URL in PROMETHEUS_REDIS_URL of the form
-    redis://localhost:6379/0
-    """
-    from redis import Redis
-
-    parsed_url = urlsplit(os.environ["PROMETHEUS_REDIS_URL"])
-    assert parsed_url.path.startswith("/")
-    assert parsed_url.path[1:].isdigit()
-    port = parsed_url.port or 6379
-    db = int(parsed_url.path[1:])
-
-    if parsed_url.scheme == "fakeredis":
-        from fakeredis import FakeRedis
-
-        if db not in fake_redis_pool:
-            fake_redis_pool[db] = FakeRedis()
-        return fake_redis_pool[db]
-
-    assert parsed_url.scheme == "redis"
-    return Redis(host=parsed_url.hostname, port=port, db=db)
+from .values import MULTIPROCESS_MODE_T
 
 
 class RedisCollector(Collector):
@@ -56,29 +29,75 @@ class RedisCollector(Collector):
     def collect(self) -> Iterable[Metric]:
         metrics: dict[str, Metric] = {}
         histograms: set[str] = set()
+        multiprocess: dict[str, MULTIPROCESS_MODE_T] = {}
 
         for key, value_s in self._iter_values():
             # FIXME: Catch ValueError here, just in case?
-            prefix_b, typ_b, mmap_key = key.split(b":", 2)
+            prefix_b, typ_b, multiprocess_mode_b, mmap_key = key.split(b":", 3)
             assert prefix_b == b"value"
-            typ = typ_b.decode()
             value = float(value_s)
 
             metric_name, name, labels, help_text = json.loads(mmap_key)
 
             metric = metrics.get(metric_name)
             if metric is None:
+                typ = typ_b.decode()
                 metric = Metric(metric_name, help_text, typ)
                 metrics[metric_name] = metric
+
                 if typ in ("histogram", "gaugehistogram"):
                     histograms.add(metric_name)
 
+                multiprocess_mode = cast(
+                    MULTIPROCESS_MODE_T, multiprocess_mode_b.decode()
+                )
+                if typ in ("gauge", "gaugehistogram") and multiprocess_mode:
+                    multiprocess[metric_name] = multiprocess_mode
+
             metric.add_sample(name, labels, value)
+
+        for name, multiprocess_mode in multiprocess.items():
+            self._accumulate_multiprocess(metrics[name], multiprocess_mode)
 
         for name in histograms:
             self._fix_histogram(metrics[name])
 
         return metrics.values()
+
+    def _accumulate_multiprocess(
+        self, metric: Metric, multiprocess_mode: MULTIPROCESS_MODE_T
+    ) -> None:
+        """Merge metrics from multiple processes using multiprocess_mode."""
+        # We deal with live/dead with Redis expiry
+        if multiprocess_mode.startswith("live"):
+            multiprocess_mode = cast(
+                MULTIPROCESS_MODE_T, multiprocess_mode[len("live") :]
+            )
+        if multiprocess_mode == "all":
+            return
+
+        by_label: dict[tuple[tuple[str, ...], str], Sample] = {}
+
+        for sample in metric.samples:
+            labels = sample.labels.copy()
+            labels.pop("pid")
+            key = (tuple(labels.values()), sample.name)
+            value = sample.value
+            if key in by_label:
+                current_value = by_label[key].value
+                if multiprocess_mode == "min" and value > current_value:
+                    continue
+                if multiprocess_mode == "max" and value < current_value:
+                    continue
+                if multiprocess_mode == "sum":
+                    value += current_value
+                if multiprocess_mode == "mostrecent":
+                    raise NotImplementedError(
+                        "The 'mostrecent' modes are not supported in RedisCollector"
+                    )
+            by_label[key] = Sample(sample.name, labels, value)
+
+        metric.samples = list(by_label.values())
 
     def _fix_histogram(self, metric: Metric) -> None:
         """

--- a/prometheus_client/redis_collector.py
+++ b/prometheus_client/redis_collector.py
@@ -1,39 +1,12 @@
 from collections.abc import Iterable
 import json
-import os
-from urllib.parse import urlsplit
+from typing import cast
 
 from .metrics_core import Metric
+from .redis import redis_client
 from .registry import Collector, CollectorRegistry
 from .samples import Sample
-
-fake_redis_pool = {}
-
-
-def redis_client():
-    """
-    Create a redis client for PROMETHEUS_REDIS_URL.
-
-    Configure the redis database via a URL in PROMETHEUS_REDIS_URL of the form
-    redis://localhost:6379/0
-    """
-    from redis import Redis
-
-    parsed_url = urlsplit(os.environ["PROMETHEUS_REDIS_URL"])
-    assert parsed_url.path.startswith("/")
-    assert parsed_url.path[1:].isdigit()
-    port = parsed_url.port or 6379
-    db = int(parsed_url.path[1:])
-
-    if parsed_url.scheme == "fakeredis":
-        from fakeredis import FakeRedis
-
-        if db not in fake_redis_pool:
-            fake_redis_pool[db] = FakeRedis()
-        return fake_redis_pool[db]
-
-    assert parsed_url.scheme == "redis"
-    return Redis(host=parsed_url.hostname, port=port, db=db)
+from .values import MULTIPROCESS_MODE_T
 
 
 class RedisCollector(Collector):
@@ -56,29 +29,75 @@ class RedisCollector(Collector):
     def collect(self) -> Iterable[Metric]:
         metrics: dict[str, Metric] = {}
         histograms: set[str] = set()
+        multiprocess: dict[str, MULTIPROCESS_MODE_T] = {}
 
         for key, value_s in self._iter_values():
             # FIXME: Catch ValueError here, just in case?
-            prefix_b, typ_b, mmap_key = key.split(b":", 2)
+            prefix_b, typ_b, multiprocess_mode_b, mmap_key = key.split(b":", 3)
             assert prefix_b == b"value"
-            typ = typ_b.decode()
             value = float(value_s)
 
             metric_name, name, labels, help_text = json.loads(mmap_key)
 
             metric = metrics.get(metric_name)
             if metric is None:
+                typ = typ_b.decode()
                 metric = Metric(metric_name, help_text, typ)
                 metrics[metric_name] = metric
+
                 if typ in ("histogram", "gaugehistogram"):
                     histograms.add(metric_name)
 
+                multiprocess_mode = cast(
+                    MULTIPROCESS_MODE_T, multiprocess_mode_b.decode()
+                )
+                if typ in ("gauge", "gaugehistogram") and multiprocess_mode:
+                    multiprocess[metric_name] = multiprocess_mode
+
             metric.add_sample(name, labels, value)
+
+        for name, multiprocess_mode in multiprocess.items():
+            self._accumulate_multiprocess(metrics[name], multiprocess_mode)
 
         for name in histograms:
             self._fix_histogram(metrics[name])
 
         return metrics.values()
+
+    def _accumulate_multiprocess(
+        self, metric: Metric, multiprocess_mode: MULTIPROCESS_MODE_T
+    ) -> None:
+        """Merge metrics from multiple processes using multiprocess_mode."""
+        # We deal with live/dead with Redis expiry
+        if multiprocess_mode.startswith("live"):
+            multiprocess_mode = cast(
+                MULTIPROCESS_MODE_T, multiprocess_mode[len("live"):]
+            )
+        if multiprocess_mode == "all":
+            return
+
+        by_label: dict[tuple[tuple[str, ...], str], Sample] = {}
+
+        for sample in metric.samples:
+            labels = sample.labels.copy()
+            labels.pop("pid")
+            key = (tuple(labels.values()), sample.name)
+            value = sample.value
+            if key in by_label:
+                current_value = by_label[key].value
+                if multiprocess_mode == "min" and value > current_value:
+                    continue
+                if multiprocess_mode == "max" and value < current_value:
+                    continue
+                if multiprocess_mode == "sum":
+                    value += current_value
+                if multiprocess_mode == "mostrecent":
+                    raise NotImplementedError(
+                        "The 'mostrecent' modes are not supported in RedisCollector"
+                    )
+            by_label[key] = Sample(sample.name, labels, value)
+
+        metric.samples = list(by_label.values())
 
     def _fix_histogram(self, metric: Metric) -> None:
         """

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -1,11 +1,27 @@
 import os
-from threading import Lock
-from typing import Any, Protocol
 import warnings
+from collections.abc import Callable, Sequence
+from datetime import timedelta
+from threading import Lock
+from typing import Any, Protocol, Literal
 
 from .mmap_dict import mmap_key, MmapedDict
-from .redis_collector import redis_client
+from .redis import redis_client, _keep_key_from_expiring, _key_expiry
 from .samples import Exemplar
+
+MULTIPROCESS_MODE_T = Literal[
+    "all",
+    "liveall",
+    "min",
+    "livemin",
+    "max",
+    "livemax",
+    "sum",
+    "livesum",
+    "mostrecent",
+    "livemostrecent",
+    "",
+]
 
 
 class Value(Protocol):
@@ -18,8 +34,8 @@ class Value(Protocol):
         typ: str,
         metric_name: str,
         name: str,
-        labelnames: list[str],
-        labelvalues: list[str],
+        labelnames: Sequence[str],
+        labelvalues: Sequence[str],
         help_text: str,
         **kwargs: Any,
     ) -> None:
@@ -162,50 +178,115 @@ def MultiProcessValue(process_identifier=os.getpid):
     return MmapedValue
 
 
-class RedisValue(Value):
-    """
-    A value implementation that stores data in a redis/valkey database.
+def RedisValue(process_identifier: Callable[[], str | int] = os.getpid) -> type[Value]:
 
-    Key scheme:
-    * value:typ:MMAP_KEY
-    """
+    class RedisValueImpl(Value):
+        """
+        A value implementation that stores data in a redis/valkey database.
 
-    _multiprocess = False
+        Key scheme:
+        * value:typ:MMAP_KEY
 
-    def __init__(
-        self,
-        typ: str,
-        metric_name: str,
-        name: str,
-        labelnames: list[str],
-        labelvalues: list[str],
-        help_text: str,
-        **kwargs: Any,
-    ) -> None:
-        key = mmap_key(metric_name, name, labelnames, labelvalues, help_text)
-        self._key = f"value:{typ}:{key}"
-        redis_client().setnx(self._key, 0.0)
+        When a live multiprocess_mode is used, we set the key to expire after
+        PROMETHEUS_REDIS_REFRESH_TTL seconds. We launch a daemon thread that
+        extends the expiry of all our process' keys every
+        PROMETHEUS_REDIS_REFRESH_FREQUENCY.
+        """
 
-    def inc(self, amount: float) -> None:
-        redis_client().incrbyfloat(self._key, amount)
+        _multiprocess: bool = True
 
-    def set(self, value: float, timestamp: float | None = None) -> None:
-        # TODO: Implement timestamps
-        redis_client().set(self._key, value)
+        _typ: str
+        _metric_name: str
+        _name: str
+        _labelnames: list[str]
+        _labelvalues: list[str]
+        _help_text: str
+        _multiprocess_mode: MULTIPROCESS_MODE_T
+        _expiry: timedelta | None
 
-    def get(self) -> float:
-        value = redis_client().get(self._key)
-        if value is None:
-            return 0.0
-        return float(value)
+        _key: str
 
-    def set_exemplar(self, exemplar: Exemplar) -> None:
-        # TODO: Implement exemplars for redis.
-        raise NotImplementedError("Exemplars are not implemented for Redis.")
+        def __init__(
+            self,
+            typ: str,
+            metric_name: str,
+            name: str,
+            labelnames: Sequence[str],
+            labelvalues: Sequence[str],
+            help_text: str,
+            multiprocess_mode: MULTIPROCESS_MODE_T = "",
+            **kwargs: Any,
+        ) -> None:
+            self._typ = typ
+            self._metric_name = metric_name
+            self._name = name
+            self._labelnames = list(labelnames)
+            self._labelvalues = list(labelvalues)
+            self._help_text = help_text
+            self._multiprocess_mode = multiprocess_mode
+            self._expiry = None
+            if multiprocess_mode:
+                if multiprocess_mode in ("mostrecent", "livemostrecent"):
+                    raise NotImplementedError(
+                        "The 'mostrecent' modes are not supported in RedisValue"
+                    )
+                assert typ in ("gauge", "gaugehistogram")
+                self._labelnames.append("pid")
+                self._labelvalues.append("")
+                if multiprocess_mode.startswith("live"):
+                    self._expiry = _key_expiry()
+            self._update_key(True)
+            redis_client().set(self._key, 0.0, ex=self._expiry, nx=True)
 
-    def get_exemplar(self) -> Exemplar | None:
-        # TODO: Implement exemplars for redis.
-        return None
+        def _update_key(self, update: bool = False) -> None:
+            if self._multiprocess_mode:
+                assert self._labelnames[-1] == "pid"
+                new_id = str(process_identifier())
+                if new_id != self._labelvalues[-1]:
+                    self._labelvalues[-1] = new_id
+                    update = True
+
+            if update:
+                key = mmap_key(
+                    self._metric_name,
+                    self._name,
+                    self._labelnames,
+                    self._labelvalues,
+                    self._help_text,
+                )
+                self._key = f"value:{self._typ}:{self._multiprocess_mode}:{key}"
+
+            if self._expiry and update:
+                _keep_key_from_expiring(self._labelvalues[-1], self._key)
+
+        def inc(self, amount: float) -> None:
+            self._update_key()
+            client = redis_client()
+            client.incrbyfloat(self._key, amount)
+            if self._expiry:
+                client.expire(self._key, self._expiry)
+
+        def set(self, value: float, timestamp: float | None = None) -> None:
+            self._update_key()
+            # TODO: Implement timestamps
+            redis_client().set(self._key, value, ex=self._expiry)
+
+        def get(self) -> float:
+            self._update_key()
+            value = redis_client().get(self._key)
+            if value is None:
+                return 0.0
+            return float(value)
+
+        def set_exemplar(self, exemplar: Exemplar) -> None:
+            # TODO: Implement exemplars for redis.
+            raise NotImplementedError("Exemplars are not implemented for Redis.")
+
+        def get_exemplar(self) -> Exemplar | None:
+            # TODO: Implement exemplars for redis.
+            return None
+
+    return RedisValueImpl
 
 
 def get_value_class() -> type[Value]:
@@ -214,8 +295,11 @@ def get_value_class() -> type[Value]:
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
     if "PROMETHEUS_REDIS_URL" in os.environ:
-        return RedisValue
-    elif 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+        return RedisValue()
+    elif (
+        "prometheus_multiproc_dir" in os.environ
+        or "PROMETHEUS_MULTIPROC_DIR" in os.environ
+    ):
         return MultiProcessValue()
     else:
         return MutexValue

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -1,11 +1,48 @@
 import os
 from threading import Lock
+from typing import Any, Protocol
 import warnings
 
 from .mmap_dict import mmap_key, MmapedDict
+from .redis_collector import redis_client
+from .samples import Exemplar
 
 
-class MutexValue:
+class Value(Protocol):
+    """Prometheus Client Metric implementation."""
+
+    _multiprocess: bool
+
+    def __init__(
+        self,
+        typ: str,
+        metric_name: str,
+        name: str,
+        labelnames: list[str],
+        labelvalues: list[str],
+        help_text: str,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a metric."""
+
+    def inc(self, amount: float) -> None:
+        """Increment the metric by amount."""
+
+    def set(self, value: float, timestamp: float | None = None) -> None:
+        """Set the metric to value."""
+
+    def get(self) -> float:
+        """Get the current metric value."""
+
+    def set_exemplar(self, exemplar: Exemplar) -> None:
+        """Set an exemplar value."""
+        exemplar  # For vulture
+
+    def get_exemplar(self) -> Exemplar | None:
+        """Get any set exemplar value."""
+
+
+class MutexValue(Value):
     """A float protected by a mutex."""
 
     _multiprocess = False
@@ -52,7 +89,7 @@ def MultiProcessValue(process_identifier=os.getpid):
     # This avoids the need to also have mutexes in __MmapDict.
     lock = Lock()
 
-    class MmapedValue:
+    class MmapedValue(Value):
         """A float protected by a mutex backed by a per-process mmaped file."""
 
         _multiprocess = True
@@ -125,12 +162,60 @@ def MultiProcessValue(process_identifier=os.getpid):
     return MmapedValue
 
 
-def get_value_class():
+class RedisValue(Value):
+    """
+    A value implementation that stores data in a redis/valkey database.
+
+    Key scheme:
+    * value:typ:MMAP_KEY
+    """
+
+    _multiprocess = False
+
+    def __init__(
+        self,
+        typ: str,
+        metric_name: str,
+        name: str,
+        labelnames: list[str],
+        labelvalues: list[str],
+        help_text: str,
+        **kwargs: Any,
+    ) -> None:
+        key = mmap_key(metric_name, name, labelnames, labelvalues, help_text)
+        self._key = f"value:{typ}:{key}"
+        redis_client().setnx(self._key, 0.0)
+
+    def inc(self, amount: float) -> None:
+        redis_client().incrbyfloat(self._key, amount)
+
+    def set(self, value: float, timestamp: float | None = None) -> None:
+        # TODO: Implement timestamps
+        redis_client().set(self._key, value)
+
+    def get(self) -> float:
+        value = redis_client().get(self._key)
+        if value is None:
+            return 0.0
+        return float(value)
+
+    def set_exemplar(self, exemplar: Exemplar) -> None:
+        # TODO: Implement exemplars for redis.
+        raise NotImplementedError("Exemplars are not implemented for Redis.")
+
+    def get_exemplar(self) -> Exemplar | None:
+        # TODO: Implement exemplars for redis.
+        return None
+
+
+def get_value_class() -> type[Value]:
     # Should we enable multi-process mode?
     # This needs to be chosen before the first metric is constructed,
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
-    if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+    if "PROMETHEUS_REDIS_URL" in os.environ:
+        return RedisValue
+    elif 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
         return MultiProcessValue()
     else:
         return MutexValue

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -1,11 +1,27 @@
+from collections.abc import Callable, Sequence
+from datetime import timedelta
 import os
 from threading import Lock
-from typing import Any, Callable, List, Protocol
+from typing import Any, List, Literal, Protocol
 import warnings
 
 from .mmap_dict import mmap_key, MmapedDict
-from .redis_collector import redis_client
+from .redis import _keep_key_from_expiring, _key_expiry, redis_client
 from .samples import Exemplar
+
+MULTIPROCESS_MODE_T = Literal[
+    "all",
+    "liveall",
+    "min",
+    "livemin",
+    "max",
+    "livemax",
+    "sum",
+    "livesum",
+    "mostrecent",
+    "livemostrecent",
+    "",
+]
 
 _multi_process_cleanups: List[Callable[[], None]] = []
 
@@ -26,8 +42,8 @@ class Value(Protocol):
         typ: str,
         metric_name: str,
         name: str,
-        labelnames: list[str],
-        labelvalues: list[str],
+        labelnames: Sequence[str],
+        labelvalues: Sequence[str],
         help_text: str,
         **kwargs: Any,
     ) -> None:
@@ -185,50 +201,115 @@ def MultiProcessValue(process_identifier=os.getpid):
     return MmapedValue
 
 
-class RedisValue(Value):
-    """
-    A value implementation that stores data in a redis/valkey database.
+def RedisValue(process_identifier: Callable[[], str | int] = os.getpid) -> type[Value]:
 
-    Key scheme:
-    * value:typ:MMAP_KEY
-    """
+    class RedisValueImpl(Value):
+        """
+        A value implementation that stores data in a redis/valkey database.
 
-    _multiprocess = False
+        Key scheme:
+        * value:typ:MMAP_KEY
 
-    def __init__(
-        self,
-        typ: str,
-        metric_name: str,
-        name: str,
-        labelnames: list[str],
-        labelvalues: list[str],
-        help_text: str,
-        **kwargs: Any,
-    ) -> None:
-        key = mmap_key(metric_name, name, labelnames, labelvalues, help_text)
-        self._key = f"value:{typ}:{key}"
-        redis_client().setnx(self._key, 0.0)
+        When a live multiprocess_mode is used, we set the key to expire after
+        PROMETHEUS_REDIS_REFRESH_TTL seconds. We launch a daemon thread that
+        extends the expiry of all our process' keys every
+        PROMETHEUS_REDIS_REFRESH_FREQUENCY.
+        """
 
-    def inc(self, amount: float) -> None:
-        redis_client().incrbyfloat(self._key, amount)
+        _multiprocess: bool = True
 
-    def set(self, value: float, timestamp: float | None = None) -> None:
-        # TODO: Implement timestamps
-        redis_client().set(self._key, value)
+        _typ: str
+        _metric_name: str
+        _name: str
+        _labelnames: list[str]
+        _labelvalues: list[str]
+        _help_text: str
+        _multiprocess_mode: MULTIPROCESS_MODE_T
+        _expiry: timedelta | None
 
-    def get(self) -> float:
-        value = redis_client().get(self._key)
-        if value is None:
-            return 0.0
-        return float(value)
+        _key: str
 
-    def set_exemplar(self, exemplar: Exemplar) -> None:
-        # TODO: Implement exemplars for redis.
-        raise NotImplementedError("Exemplars are not implemented for Redis.")
+        def __init__(
+            self,
+            typ: str,
+            metric_name: str,
+            name: str,
+            labelnames: Sequence[str],
+            labelvalues: Sequence[str],
+            help_text: str,
+            multiprocess_mode: MULTIPROCESS_MODE_T = "",
+            **kwargs: Any,
+        ) -> None:
+            self._typ = typ
+            self._metric_name = metric_name
+            self._name = name
+            self._labelnames = list(labelnames)
+            self._labelvalues = list(labelvalues)
+            self._help_text = help_text
+            self._multiprocess_mode = multiprocess_mode
+            self._expiry = None
+            if multiprocess_mode:
+                if multiprocess_mode in ("mostrecent", "livemostrecent"):
+                    raise NotImplementedError(
+                        "The 'mostrecent' modes are not supported in RedisValue"
+                    )
+                assert typ in ("gauge", "gaugehistogram")
+                self._labelnames.append("pid")
+                self._labelvalues.append("")
+                if multiprocess_mode.startswith("live"):
+                    self._expiry = _key_expiry()
+            self._update_key(True)
+            redis_client().set(self._key, 0.0, ex=self._expiry, nx=True)
 
-    def get_exemplar(self) -> Exemplar | None:
-        # TODO: Implement exemplars for redis.
-        return None
+        def _update_key(self, update: bool = False) -> None:
+            if self._multiprocess_mode:
+                assert self._labelnames[-1] == "pid"
+                new_id = str(process_identifier())
+                if new_id != self._labelvalues[-1]:
+                    self._labelvalues[-1] = new_id
+                    update = True
+
+            if update:
+                key = mmap_key(
+                    self._metric_name,
+                    self._name,
+                    self._labelnames,
+                    self._labelvalues,
+                    self._help_text,
+                )
+                self._key = f"value:{self._typ}:{self._multiprocess_mode}:{key}"
+
+            if self._expiry and update:
+                _keep_key_from_expiring(self._labelvalues[-1], self._key)
+
+        def inc(self, amount: float) -> None:
+            self._update_key()
+            client = redis_client()
+            client.incrbyfloat(self._key, amount)
+            if self._expiry:
+                client.expire(self._key, self._expiry)
+
+        def set(self, value: float, timestamp: float | None = None) -> None:
+            self._update_key()
+            # TODO: Implement timestamps
+            redis_client().set(self._key, value, ex=self._expiry)
+
+        def get(self) -> float:
+            self._update_key()
+            value = redis_client().get(self._key)
+            if value is None:
+                return 0.0
+            return float(value)
+
+        def set_exemplar(self, exemplar: Exemplar) -> None:
+            # TODO: Implement exemplars for redis.
+            raise NotImplementedError("Exemplars are not implemented for Redis.")
+
+        def get_exemplar(self) -> Exemplar | None:
+            # TODO: Implement exemplars for redis.
+            return None
+
+    return RedisValueImpl
 
 
 def get_value_class() -> type[Value]:
@@ -237,8 +318,11 @@ def get_value_class() -> type[Value]:
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
     if "PROMETHEUS_REDIS_URL" in os.environ:
-        return RedisValue
-    elif 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+        return RedisValue()
+    elif (
+        "prometheus_multiproc_dir" in os.environ
+        or "PROMETHEUS_MULTIPROC_DIR" in os.environ
+    ):
         return MultiProcessValue()
     else:
         return MutexValue

--- a/prometheus_client/values.py
+++ b/prometheus_client/values.py
@@ -1,9 +1,11 @@
 import os
 from threading import Lock
-from typing import Callable, List
+from typing import Any, Callable, List, Protocol
 import warnings
 
 from .mmap_dict import mmap_key, MmapedDict
+from .redis_collector import redis_client
+from .samples import Exemplar
 
 _multi_process_cleanups: List[Callable[[], None]] = []
 
@@ -14,7 +16,41 @@ def close_all_multiprocess_files():
     _multi_process_cleanups.clear()
 
 
-class MutexValue:
+class Value(Protocol):
+    """Prometheus Client Metric implementation."""
+
+    _multiprocess: bool
+
+    def __init__(
+        self,
+        typ: str,
+        metric_name: str,
+        name: str,
+        labelnames: list[str],
+        labelvalues: list[str],
+        help_text: str,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a metric."""
+
+    def inc(self, amount: float) -> None:
+        """Increment the metric by amount."""
+
+    def set(self, value: float, timestamp: float | None = None) -> None:
+        """Set the metric to value."""
+
+    def get(self) -> float:
+        """Get the current metric value."""
+
+    def set_exemplar(self, exemplar: Exemplar) -> None:
+        """Set an exemplar value."""
+        exemplar  # For vulture
+
+    def get_exemplar(self) -> Exemplar | None:
+        """Get any set exemplar value."""
+
+
+class MutexValue(Value):
     """A float protected by a mutex."""
 
     _multiprocess = False
@@ -68,7 +104,7 @@ def MultiProcessValue(process_identifier=os.getpid):
         values.clear()
     _multi_process_cleanups.append(cleanup)
 
-    class MmapedValue:
+    class MmapedValue(Value):
         """A float protected by a mutex backed by a per-process mmaped file."""
 
         _multiprocess = True
@@ -149,12 +185,60 @@ def MultiProcessValue(process_identifier=os.getpid):
     return MmapedValue
 
 
-def get_value_class():
+class RedisValue(Value):
+    """
+    A value implementation that stores data in a redis/valkey database.
+
+    Key scheme:
+    * value:typ:MMAP_KEY
+    """
+
+    _multiprocess = False
+
+    def __init__(
+        self,
+        typ: str,
+        metric_name: str,
+        name: str,
+        labelnames: list[str],
+        labelvalues: list[str],
+        help_text: str,
+        **kwargs: Any,
+    ) -> None:
+        key = mmap_key(metric_name, name, labelnames, labelvalues, help_text)
+        self._key = f"value:{typ}:{key}"
+        redis_client().setnx(self._key, 0.0)
+
+    def inc(self, amount: float) -> None:
+        redis_client().incrbyfloat(self._key, amount)
+
+    def set(self, value: float, timestamp: float | None = None) -> None:
+        # TODO: Implement timestamps
+        redis_client().set(self._key, value)
+
+    def get(self) -> float:
+        value = redis_client().get(self._key)
+        if value is None:
+            return 0.0
+        return float(value)
+
+    def set_exemplar(self, exemplar: Exemplar) -> None:
+        # TODO: Implement exemplars for redis.
+        raise NotImplementedError("Exemplars are not implemented for Redis.")
+
+    def get_exemplar(self) -> Exemplar | None:
+        # TODO: Implement exemplars for redis.
+        return None
+
+
+def get_value_class() -> type[Value]:
     # Should we enable multi-process mode?
     # This needs to be chosen before the first metric is constructed,
     # and as that may be in some arbitrary library the user/admin has
     # no control over we use an environment variable.
-    if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+    if "PROMETHEUS_REDIS_URL" in os.environ:
+        return RedisValue
+    elif 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
         return MultiProcessValue()
     else:
         return MutexValue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ aiohttp = [
 django = [
 	"django",
 ]
+redis = [
+	"redis",
+]
 
 [project.urls]
 Homepage = "https://github.com/prometheus/client_python"

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,0 +1,391 @@
+import os
+import unittest
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+from prometheus_client import values
+from prometheus_client.core import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    Sample,
+    Summary,
+)
+from prometheus_client.redis_collector import RedisCollector, redis_client
+from prometheus_client.samples import Exemplar
+from prometheus_client.values import MutexValue, RedisValue, Value
+
+pytest.importorskip("redis")
+
+
+class RedisTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["PROMETHEUS_REDIS_URL"] = "fakeredis://localhost/42"
+        values.ValueClass = RedisValue
+
+    def tearDown(self) -> None:
+        redis_client().flushdb()
+        del os.environ["PROMETHEUS_REDIS_URL"]
+        values.ValueClass = MutexValue
+
+
+class ValueTestCase(RedisTestCase):
+    def create_value(
+        self,
+        metric_name: str = "test",
+        name: str | None = None,
+        type_: str = "counter",
+        labelnames: list[str] | None = None,
+        labelvalues: list[str] | None = None,
+    ) -> Value:
+        return values.ValueClass(
+            type_,
+            metric_name,
+            name or metric_name + "_total",
+            labelnames or [],
+            labelvalues or [],
+            "Help Text",
+        )
+
+    def test_initializes_value(self) -> None:
+        value = self.create_value()
+        self.assertEqual(value.get(), 0.0)
+
+    def test_sets_and_gets_value(self) -> None:
+        value = self.create_value()
+        value.set(5)
+        self.assertEqual(value.get(), 5.0)
+
+    def test_inc_value(self) -> None:
+        value = self.create_value()
+        value.inc(3)
+        value.inc(5)
+        self.assertEqual(value.get(), 8.0)
+
+    def test_get_missing_value(self) -> None:
+        value = self.create_value()
+        redis_client().delete(value._key)
+        self.assertEqual(value.get(), 0.0)
+
+    def test_exemplars_not_implemented(self) -> None:
+        value = self.create_value("test4")
+        with self.assertRaises(NotImplementedError):
+            value.set_exemplar(Exemplar(labels={}, value=0.0, timestamp=0.0))
+        self.assertIsNone(value.get_exemplar())
+
+    def test_differentiated_by_name(self) -> None:
+        v1 = self.create_value("value1")
+        v2 = self.create_value("value2")
+        v1.set(1)
+        v2.set(2)
+        self.assertEqual(v1.get(), 1.0)
+        self.assertEqual(v2.get(), 2.0)
+
+    def test_differentiated_by_labels(self) -> None:
+        v1 = self.create_value("value3", labelnames=["a"], labelvalues=["1"])
+        v2 = self.create_value("value3", labelnames=["a"], labelvalues=["2"])
+        v1.set(1)
+        v2.set(2)
+        self.assertEqual(v1.get(), 1.0)
+        self.assertEqual(v2.get(), 2.0)
+
+
+class TestRedis(RedisTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.registry = CollectorRegistry(support_collectors_without_names=True)
+        self.collector = RedisCollector(self.registry)
+
+    def test_counter_adds(self) -> None:
+        c1 = Counter("c", "help", registry=None)
+        c2 = Counter("c", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("c_total"))
+        c1.inc(1)
+        c2.inc(2)
+        self.assertEqual(3, self.registry.get_sample_value("c_total"))
+
+    def test_summary_adds(self) -> None:
+        s1 = Summary("s", "help", registry=None)
+        s2 = Summary("s", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("s_count"))
+        self.assertEqual(0, self.registry.get_sample_value("s_sum"))
+        s1.observe(1)
+        s2.observe(2)
+        self.assertEqual(2, self.registry.get_sample_value("s_count"))
+        self.assertEqual(3, self.registry.get_sample_value("s_sum"))
+
+    def test_histogram_adds(self) -> None:
+        h1 = Histogram("h", "help", registry=None)
+        h2 = Histogram("h", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("h_count"))
+        self.assertEqual(0, self.registry.get_sample_value("h_sum"))
+        self.assertEqual(0, self.registry.get_sample_value("h_bucket", {"le": "5.0"}))
+        h1.observe(1)
+        h2.observe(2)
+        self.assertEqual(2, self.registry.get_sample_value("h_count"))
+        self.assertEqual(3, self.registry.get_sample_value("h_sum"))
+        self.assertEqual(2, self.registry.get_sample_value("h_bucket", {"le": "5.0"}))
+
+    def test_namespace_subsystem(self) -> None:
+        c1 = Counter("c", "help", registry=None, namespace="ns", subsystem="ss")
+        c1.inc(1)
+        self.assertEqual(1, self.registry.get_sample_value("ns_ss_c_total"))
+
+    def test_collect(self) -> None:
+        labels = {i: i for i in "abcd"}
+
+        def add_label(key: str, value: str) -> dict[str, str]:
+            l = labels.copy()
+            l[key] = value
+            return l
+
+        c = Counter("c", "help", labelnames=labels.keys(), registry=None)
+        g = Gauge("g", "help", labelnames=labels.keys(), registry=None)
+        h = Histogram("h", "help", labelnames=labels.keys(), registry=None)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(1)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(5)
+
+        metrics = {m.name: m for m in self.collector.collect()}
+
+        self.assertEqual(metrics["c"].samples, [Sample("c_total", labels, 2.0)])
+
+        expected_histogram = [
+            Sample("h_bucket", add_label("le", "0.005"), 0.0),
+            Sample("h_bucket", add_label("le", "0.01"), 0.0),
+            Sample("h_bucket", add_label("le", "0.025"), 0.0),
+            Sample("h_bucket", add_label("le", "0.05"), 0.0),
+            Sample("h_bucket", add_label("le", "0.075"), 0.0),
+            Sample("h_bucket", add_label("le", "0.1"), 0.0),
+            Sample("h_bucket", add_label("le", "0.25"), 0.0),
+            Sample("h_bucket", add_label("le", "0.5"), 0.0),
+            Sample("h_bucket", add_label("le", "0.75"), 0.0),
+            Sample("h_bucket", add_label("le", "1.0"), 1.0),
+            Sample("h_bucket", add_label("le", "2.5"), 1.0),
+            Sample("h_bucket", add_label("le", "5.0"), 2.0),
+            Sample("h_bucket", add_label("le", "7.5"), 2.0),
+            Sample("h_bucket", add_label("le", "10.0"), 2.0),
+            Sample("h_bucket", add_label("le", "+Inf"), 2.0),
+            Sample("h_count", labels, 2.0),
+            Sample("h_sum", labels, 6.0),
+        ]
+
+        self.assertEqual(metrics["h"].samples, expected_histogram)
+
+    def test_collect_histogram_ordering(self) -> None:
+        h = Histogram("h", "help", labelnames=["view"], registry=None)
+
+        h.labels(view="view1").observe(1)
+
+        h.labels(view="view1").observe(5)
+        h.labels(view="view2").observe(1)
+
+        metrics = {m.name: m for m in self.collector.collect()}
+
+        expected_histogram = [
+            Sample("h_bucket", {"view": "view1", "le": "0.005"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.01"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.025"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.05"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.075"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.1"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.25"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.5"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.75"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "1.0"}, 1.0),
+            Sample("h_bucket", {"view": "view1", "le": "2.5"}, 1.0),
+            Sample("h_bucket", {"view": "view1", "le": "5.0"}, 2.0),
+            Sample("h_bucket", {"view": "view1", "le": "7.5"}, 2.0),
+            Sample("h_bucket", {"view": "view1", "le": "10.0"}, 2.0),
+            Sample("h_bucket", {"view": "view1", "le": "+Inf"}, 2.0),
+            Sample("h_count", {"view": "view1"}, 2.0),
+            Sample("h_sum", {"view": "view1"}, 6.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.005"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.01"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.025"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.05"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.075"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.1"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.25"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.5"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.75"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "1.0"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "2.5"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "5.0"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "7.5"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "10.0"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "+Inf"}, 1.0),
+            Sample("h_count", {"view": "view2"}, 1.0),
+            Sample("h_sum", {"view": "view2"}, 1.0),
+        ]
+
+        self.assertEqual(metrics["h"].samples, expected_histogram)
+
+    def test_restrict(self) -> None:
+        labels = {i: i for i in "abcd"}
+
+        c = Counter("c", "help", labelnames=labels.keys(), registry=None)
+        g = Gauge("g", "help", labelnames=labels.keys(), registry=None)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+
+        metrics = {
+            m.name: m for m in self.registry.restricted_registry(["c_total"]).collect()
+        }
+
+        self.assertEqual(metrics.keys(), {"c"})
+
+        self.assertEqual(metrics["c"].samples, [Sample("c_total", labels, 2.0)])
+
+    def test_collect_preserves_help(self) -> None:
+        labels = {i: i for i in "abcd"}
+
+        c = Counter("c", "c help", labelnames=labels.keys(), registry=None)
+        g = Gauge("g", "g help", labelnames=labels.keys(), registry=None)
+        h = Histogram("h", "h help", labelnames=labels.keys(), registry=None)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(1)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(5)
+
+        metrics = {m.name: m for m in self.collector.collect()}
+
+        self.assertEqual(metrics["c"].documentation, "c help")
+        self.assertEqual(metrics["g"].documentation, "g help")
+        self.assertEqual(metrics["h"].documentation, "h help")
+
+    def test_child_name_is_built_once_with_namespace_subsystem_unit(self) -> None:
+        """
+        Repro for #1035:
+        In multiprocess mode, child metrics must NOT rebuild the full name
+        (namespace/subsystem/unit) a second time. The exported family name should
+        be built once, and Counter samples should use "<family>_total".
+        """
+        from prometheus_client import Counter
+
+        class CustomCounter(Counter):
+            def __init__(
+                self,
+                name: str,
+                documentation: str,
+                labelnames: Sequence[str] = (),
+                namespace: str = "mydefaultnamespace",
+                subsystem: str = "mydefaultsubsystem",
+                unit: str = "",
+                registry: CollectorRegistry | None = None,
+                _labelvalues: Sequence[str] | None = None,
+            ):
+                # Intentionally provide non-empty defaults to trigger the bug path.
+                super().__init__(
+                    name=name,
+                    documentation=documentation,
+                    labelnames=labelnames,
+                    namespace=namespace,
+                    subsystem=subsystem,
+                    unit=unit,
+                    registry=registry,
+                    _labelvalues=_labelvalues,
+                )
+
+        # Create a Counter with explicit namespace/subsystem/unit
+        c = CustomCounter(
+            name="m",
+            documentation="help",
+            labelnames=("status", "method"),
+            namespace="ns",
+            subsystem="ss",
+            unit="seconds",  # avoid '_total_total' confusion
+            registry=None,  # not registered in local registry in multiprocess mode
+        )
+
+        # Create two labeled children
+        c.labels(status="200", method="GET").inc()
+        c.labels(status="404", method="POST").inc()
+
+        # Collect from the multiprocess collector initialized in setUp()
+        metrics = {m.name: m for m in self.collector.collect()}
+
+        # Family name should be built once (no '_total' in family name)
+        expected_family = "ns_ss_m_seconds"
+        self.assertIn(expected_family, metrics, f"missing family {expected_family}")
+
+        # Counter samples must use '<family>_total'
+        mf = metrics[expected_family]
+        sample_names = {s.name for s in mf.samples}
+        self.assertTrue(
+            all(name == expected_family + "_total" for name in sample_names),
+            f"unexpected sample names: {sample_names}",
+        )
+
+        # Ensure no double-built prefix sneaks in (the original bug)
+        bad_prefix = "mydefaultnamespace_mydefaultsubsystem_"
+        all_names = {mf.name, *sample_names}
+        self.assertTrue(
+            all(not n.startswith(bad_prefix) for n in all_names),
+            f"found double-built name(s): {[n for n in all_names if n.startswith(bad_prefix)]}",
+        )
+
+    def test_child_preserves_parent_context_for_subclasses(self) -> None:
+        """
+        Ensure child metrics preserve parent's namespace/subsystem/unit information
+        so that subclasses can correctly use these parameters in their logic.
+        """
+
+        class ContextAwareCounter(Counter):
+            def __init__(
+                self,
+                name: str,
+                documentation: str,
+                labelnames: Sequence[str] = (),
+                namespace: str = "",
+                subsystem: str = "",
+                unit: str = "",
+                **kwargs: Any,
+            ):
+                self.context = {
+                    "namespace": namespace,
+                    "subsystem": subsystem,
+                    "unit": unit,
+                }
+                super().__init__(
+                    name,
+                    documentation,
+                    labelnames=labelnames,
+                    namespace=namespace,
+                    subsystem=subsystem,
+                    unit=unit,
+                    **kwargs,
+                )
+
+        parent = ContextAwareCounter(
+            "m",
+            "help",
+            labelnames=["status"],
+            namespace="prod",
+            subsystem="api",
+            unit="seconds",
+            registry=None,
+        )
+
+        child = parent.labels(status="200")
+
+        # Verify that child retains parent's context
+        self.assertEqual(child.context["namespace"], "prod")
+        self.assertEqual(child.context["subsystem"], "api")
+        self.assertEqual(child.context["unit"], "seconds")

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,7 +1,12 @@
 import os
 import unittest
+import warnings
 from collections.abc import Sequence
+from datetime import timedelta
+from time import time
+from threading import Event
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -14,9 +19,22 @@ from prometheus_client.core import (
     Sample,
     Summary,
 )
-from prometheus_client.redis_collector import RedisCollector, redis_client
+from prometheus_client.redis import (
+    mark_process_dead,
+    redis_client,
+    _daemon_threads,
+    _keep_key_from_expiring,
+    _live_metrics,
+)
+from prometheus_client.redis_collector import RedisCollector
 from prometheus_client.samples import Exemplar
-from prometheus_client.values import MutexValue, RedisValue, Value
+from prometheus_client.values import (
+    MULTIPROCESS_MODE_T,
+    MutexValue,
+    RedisValue,
+    Value,
+    get_value_class,
+)
 
 pytest.importorskip("redis")
 
@@ -24,9 +42,11 @@ pytest.importorskip("redis")
 class RedisTestCase(unittest.TestCase):
     def setUp(self) -> None:
         os.environ["PROMETHEUS_REDIS_URL"] = "fakeredis://localhost/42"
-        values.ValueClass = RedisValue
+        values.ValueClass = RedisValue(lambda: 123)
 
     def tearDown(self) -> None:
+        for identifier in list(_daemon_threads):
+            mark_process_dead(identifier)
         redis_client().flushdb()
         del os.environ["PROMETHEUS_REDIS_URL"]
         values.ValueClass = MutexValue
@@ -40,6 +60,7 @@ class ValueTestCase(RedisTestCase):
         type_: str = "counter",
         labelnames: list[str] | None = None,
         labelvalues: list[str] | None = None,
+        multiprocess_mode: MULTIPROCESS_MODE_T = "",
     ) -> Value:
         return values.ValueClass(
             type_,
@@ -48,6 +69,7 @@ class ValueTestCase(RedisTestCase):
             labelnames or [],
             labelvalues or [],
             "Help Text",
+            multiprocess_mode=multiprocess_mode,
         )
 
     def test_initializes_value(self) -> None:
@@ -92,8 +114,130 @@ class ValueTestCase(RedisTestCase):
         self.assertEqual(v1.get(), 1.0)
         self.assertEqual(v2.get(), 2.0)
 
+    def test_multiprocess_mode_mostrecent(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            self.create_value(type_="gauge", multiprocess_mode="mostrecent")
 
-class TestRedis(RedisTestCase):
+    def test_multiprocess_mode_counter(self) -> None:
+        with self.assertRaises(AssertionError):
+            self.create_value(type_="counter", multiprocess_mode="liveall")
+
+    def test_multiprocess_mode(self) -> None:
+        value = self.create_value(type_="gauge", multiprocess_mode="all")
+        self.assertEqual(value._labelnames, ["pid"])
+        self.assertEqual(value._labelvalues[-1], "123")
+        self.assertIsNone(value._expiry)
+        self.assertLess(redis_client().expiretime(value._key), 0)
+
+    def test_multiprocess_mode_live(self) -> None:
+        value = self.create_value(type_="gauge", multiprocess_mode="liveall")
+        unixtime = time()
+        self.assertEqual(value._labelnames, ["pid"])
+        self.assertEqual(value._labelvalues[-1], "123")
+        self.assertEqual(value._expiry, timedelta(seconds=20))
+        expiretime = redis_client().expiretime(value._key)
+        self.assertGreater(expiretime, unixtime)
+        self.assertLessEqual(expiretime, unixtime + 20)
+
+        self.assertIn("123", _daemon_threads)
+        self.assertIn("123", _live_metrics)
+        self.assertIn(value._key, _live_metrics["123"])
+
+    def test_live_inc_updates_expiry(self) -> None:
+        value = self.create_value(type_="gauge", multiprocess_mode="liveall")
+        unixtime = time()
+        redis_client().persist(value._key)
+        self.assertLess(redis_client().expiretime(value._key), 0)
+
+        value.inc(1)
+        self.assertGreater(redis_client().expiretime(value._key), unixtime)
+
+    def test_live_set_updates_expiry(self) -> None:
+        value = self.create_value(type_="gauge", multiprocess_mode="liveall")
+        unixtime = time()
+        redis_client().persist(value._key)
+        self.assertLess(redis_client().expiretime(value._key), 0)
+
+        value.set(1)
+        self.assertGreater(redis_client().expiretime(value._key), unixtime)
+
+    def test_multiprocess_pid_change(self) -> None:
+        pid = 1
+        values.ValueClass = RedisValue(lambda: pid)
+
+        value = self.create_value(type_="gauge", multiprocess_mode="all")
+        self.assertEqual(value._labelnames[-1], "pid")
+        self.assertEqual(value._labelvalues[-1], "1")
+        value.inc(1)
+        self.assertEqual(value.get(), 1.0)
+
+        pid = 2
+        value.inc(1)
+        self.assertEqual(value._labelvalues[-1], "2")
+        self.assertEqual(value.get(), 1.0)
+
+
+class KeepMetricsAliveTestCase(RedisTestCase):
+    """Test KeepMetricsAliveThread and friends."""
+
+    def setUp(self):
+        super().setUp()
+        self.stop_event = Event()
+
+    def tearDown(self):
+        super().tearDown()
+        self.stop_event.set()
+
+    def mock_loop(self) -> None:
+        self.loop_event = Event()
+        self.waiting_event = Event()
+        patcher = mock.patch(
+            "prometheus_client.redis.KeepMetricsAliveThread.loop_wait",
+            side_effect=self.loop_wait,
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def loop_wait(self, _timeout: float) -> bool:
+        self.waiting_event.set()
+        self.waiting_event = Event()
+        assert self.loop_event.wait(5) is True
+        return self.stop_event.is_set()
+
+    def run_loop_once(self, stop: bool=False) -> None:
+        if stop:
+            self.stop_event.set()
+        self.loop_event.set()
+        if not stop:
+            self.loop_event = Event()
+            assert self.waiting_event.wait() is True
+
+    def test_mark_unknown_process_dead(self) -> None:
+        mark_process_dead("unknown")
+
+    def test_mark_known_process_dead(self) -> None:
+        client = redis_client()
+        client.set("key", "hello")
+        _keep_key_from_expiring("identifier", "key")
+        self.assertIn("identifier", _daemon_threads)
+        mark_process_dead("identifier")
+        self.assertNotIn("identifier", _daemon_threads)
+
+    def test_live_daemon_updates_expiry(self) -> None:
+        """Exercise the full lifecycle of the daemon thread."""
+        self.mock_loop()
+        client = redis_client()
+        client.set("key", "hello")
+        _keep_key_from_expiring("identifier", "key")
+        self.assertLess(client.expiretime("key"), 0)
+
+        unixtime = time()
+        self.run_loop_once()
+        self.assertGreater(client.expiretime("key"), unixtime)
+        self.run_loop_once(stop=True)
+
+
+class TestRedisCollector(RedisTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.registry = CollectorRegistry(support_collectors_without_names=True)
@@ -109,6 +253,7 @@ class TestRedis(RedisTestCase):
 
     def test_summary_adds(self) -> None:
         s1 = Summary("s", "help", registry=None)
+        values.ValueClass = RedisValue(lambda: 456)
         s2 = Summary("s", "help", registry=None)
         self.assertEqual(0, self.registry.get_sample_value("s_count"))
         self.assertEqual(0, self.registry.get_sample_value("s_sum"))
@@ -119,6 +264,7 @@ class TestRedis(RedisTestCase):
 
     def test_histogram_adds(self) -> None:
         h1 = Histogram("h", "help", registry=None)
+        values.ValueClass = RedisValue(lambda: 456)
         h2 = Histogram("h", "help", registry=None)
         self.assertEqual(0, self.registry.get_sample_value("h_count"))
         self.assertEqual(0, self.registry.get_sample_value("h_sum"))
@@ -129,12 +275,135 @@ class TestRedis(RedisTestCase):
         self.assertEqual(3, self.registry.get_sample_value("h_sum"))
         self.assertEqual(2, self.registry.get_sample_value("h_bucket", {"le": "5.0"}))
 
+    def test_gauge_all(self) -> None:
+        g1 = Gauge("g", "help", registry=None)
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(0, self.registry.get_sample_value("g", {"pid": "456"}))
+        g1.set(1)
+        g2.set(2)
+        mark_process_dead(123)
+        self.assertEqual(1, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(2, self.registry.get_sample_value("g", {"pid": "456"}))
+
+    def test_gauge_liveall(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="liveall")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="liveall")
+        self.assertEqual(0, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(0, self.registry.get_sample_value("g", {"pid": "456"}))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(2, self.registry.get_sample_value("g", {"pid": "456"}))
+        mark_process_dead(123)
+        self.assertEqual(None, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(2, self.registry.get_sample_value("g", {"pid": "456"}))
+
+    def test_gauge_min(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="min")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="min")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+
+    def test_gauge_livemin(self):
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="livemin")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="livemin")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+
+    def test_gauge_max(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="max")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="max")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+
+    def test_gauge_livemax(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="livemax")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="livemax")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(2)
+        g2.set(1)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+
+    def test_gauge_sum(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="sum")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="sum")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(3, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(3, self.registry.get_sample_value("g"))
+
+    def test_gauge_livesum(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="livesum")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="livesum")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(3, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+
+    def xxx_test_gauge_mostrecent(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="mostrecent")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="mostrecent")
+        g2.set(2)
+        g1.set(1)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+
+    def xxx_test_gauge_livemostrecent(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="livemostrecent")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="livemostrecent")
+        g2.set(2)
+        g1.set(1)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+
     def test_namespace_subsystem(self) -> None:
         c1 = Counter("c", "help", registry=None, namespace="ns", subsystem="ss")
         c1.inc(1)
         self.assertEqual(1, self.registry.get_sample_value("ns_ss_c_total"))
 
+    def test_counter_across_forks(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
+        c1 = Counter("c", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("c_total"))
+        c1.inc(1)
+        c1.inc(1)
+        pid = 1
+        c1.inc(1)
+        self.assertEqual(3, self.registry.get_sample_value("c_total"))
+        # Unlike MultiProcessValue, we don't store any local state
+        self.assertEqual(3, c1._value.get())
+
     def test_collect(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
         labels = {i: i for i in "abcd"}
 
         def add_label(key: str, value: str) -> dict[str, str]:
@@ -150,6 +419,8 @@ class TestRedis(RedisTestCase):
         g.labels(**labels).set(1)
         h.labels(**labels).observe(1)
 
+        pid = 1
+
         c.labels(**labels).inc(1)
         g.labels(**labels).set(1)
         h.labels(**labels).observe(5)
@@ -157,6 +428,14 @@ class TestRedis(RedisTestCase):
         metrics = {m.name: m for m in self.collector.collect()}
 
         self.assertEqual(metrics["c"].samples, [Sample("c_total", labels, 2.0)])
+        metrics["g"].samples.sort(key=lambda x: x[1]["pid"])
+        self.assertEqual(
+            metrics["g"].samples,
+            [
+                Sample("g", add_label("pid", "0"), 1.0),
+                Sample("g", add_label("pid", "1"), 1.0),
+            ],
+        )
 
         expected_histogram = [
             Sample("h_bucket", add_label("le", "0.005"), 0.0),
@@ -181,9 +460,14 @@ class TestRedis(RedisTestCase):
         self.assertEqual(metrics["h"].samples, expected_histogram)
 
     def test_collect_histogram_ordering(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
+
         h = Histogram("h", "help", labelnames=["view"], registry=None)
 
         h.labels(view="view1").observe(1)
+
+        pid = 1
 
         h.labels(view="view1").observe(5)
         h.labels(view="view2").observe(1)
@@ -230,6 +514,8 @@ class TestRedis(RedisTestCase):
         self.assertEqual(metrics["h"].samples, expected_histogram)
 
     def test_restrict(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
         labels = {i: i for i in "abcd"}
 
         c = Counter("c", "help", labelnames=labels.keys(), registry=None)
@@ -237,6 +523,8 @@ class TestRedis(RedisTestCase):
 
         c.labels(**labels).inc(1)
         g.labels(**labels).set(1)
+
+        pid = 1
 
         c.labels(**labels).inc(1)
         g.labels(**labels).set(1)
@@ -250,6 +538,8 @@ class TestRedis(RedisTestCase):
         self.assertEqual(metrics["c"].samples, [Sample("c_total", labels, 2.0)])
 
     def test_collect_preserves_help(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
         labels = {i: i for i in "abcd"}
 
         c = Counter("c", "c help", labelnames=labels.keys(), registry=None)
@@ -260,6 +550,8 @@ class TestRedis(RedisTestCase):
         g.labels(**labels).set(1)
         h.labels(**labels).observe(1)
 
+        pid = 1
+
         c.labels(**labels).inc(1)
         g.labels(**labels).set(1)
         h.labels(**labels).observe(5)
@@ -269,6 +561,20 @@ class TestRedis(RedisTestCase):
         self.assertEqual(metrics["c"].documentation, "c help")
         self.assertEqual(metrics["g"].documentation, "g help")
         self.assertEqual(metrics["h"].documentation, "h help")
+
+    def test_remove_clear_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as w:
+            values.ValueClass = get_value_class()
+            registry = CollectorRegistry()
+            collector = RedisCollector(registry)
+            counter = Counter("c", "help", labelnames=["label"], registry=None)
+            counter.labels("label").inc()
+            counter.remove("label")
+            counter.clear()
+            assert issubclass(w[0].category, UserWarning)
+            assert "Removal of labels has not been implemented" in str(w[0].message)
+            assert issubclass(w[-1].category, UserWarning)
+            assert "Clearing of labels has not been implemented" in str(w[-1].message)
 
     def test_child_name_is_built_once_with_namespace_subsystem_unit(self) -> None:
         """

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,7 +1,12 @@
-import os
-import unittest
 from collections.abc import Sequence
+from datetime import timedelta
+import os
+from threading import Event
+from time import time
 from typing import Any
+import unittest
+from unittest import mock
+import warnings
 
 import pytest
 
@@ -9,9 +14,15 @@ from prometheus_client import values
 from prometheus_client.core import (
     CollectorRegistry, Counter, Gauge, Histogram, Sample, Summary,
 )
-from prometheus_client.redis_collector import RedisCollector, redis_client
+from prometheus_client.redis import (
+    _daemon_threads, _keep_key_from_expiring, _live_metrics, mark_process_dead,
+    redis_client,
+)
+from prometheus_client.redis_collector import RedisCollector
 from prometheus_client.samples import Exemplar
-from prometheus_client.values import MutexValue, RedisValue, Value
+from prometheus_client.values import (
+    get_value_class, MULTIPROCESS_MODE_T, MutexValue, RedisValue, Value,
+)
 
 pytest.importorskip("redis")
 
@@ -19,9 +30,11 @@ pytest.importorskip("redis")
 class RedisTestCase(unittest.TestCase):
     def setUp(self) -> None:
         os.environ["PROMETHEUS_REDIS_URL"] = "fakeredis://localhost/42"
-        values.ValueClass = RedisValue
+        values.ValueClass = RedisValue(lambda: 123)
 
     def tearDown(self) -> None:
+        for identifier in list(_daemon_threads):
+            mark_process_dead(identifier)
         redis_client().flushdb()
         del os.environ["PROMETHEUS_REDIS_URL"]
         values.ValueClass = MutexValue
@@ -35,6 +48,7 @@ class ValueTestCase(RedisTestCase):
         type_: str = "counter",
         labelnames: list[str] | None = None,
         labelvalues: list[str] | None = None,
+        multiprocess_mode: MULTIPROCESS_MODE_T = "",
     ) -> Value:
         return values.ValueClass(
             type_,
@@ -43,6 +57,7 @@ class ValueTestCase(RedisTestCase):
             labelnames or [],
             labelvalues or [],
             "Help Text",
+            multiprocess_mode=multiprocess_mode,
         )
 
     def test_initializes_value(self) -> None:
@@ -87,8 +102,130 @@ class ValueTestCase(RedisTestCase):
         self.assertEqual(v1.get(), 1.0)
         self.assertEqual(v2.get(), 2.0)
 
+    def test_multiprocess_mode_mostrecent(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            self.create_value(type_="gauge", multiprocess_mode="mostrecent")
 
-class TestRedis(RedisTestCase):
+    def test_multiprocess_mode_counter(self) -> None:
+        with self.assertRaises(AssertionError):
+            self.create_value(type_="counter", multiprocess_mode="liveall")
+
+    def test_multiprocess_mode(self) -> None:
+        value = self.create_value(type_="gauge", multiprocess_mode="all")
+        self.assertEqual(value._labelnames, ["pid"])
+        self.assertEqual(value._labelvalues[-1], "123")
+        self.assertIsNone(value._expiry)
+        self.assertLess(redis_client().expiretime(value._key), 0)
+
+    def test_multiprocess_mode_live(self) -> None:
+        value = self.create_value(type_="gauge", multiprocess_mode="liveall")
+        unixtime = time()
+        self.assertEqual(value._labelnames, ["pid"])
+        self.assertEqual(value._labelvalues[-1], "123")
+        self.assertEqual(value._expiry, timedelta(seconds=20))
+        expiretime = redis_client().expiretime(value._key)
+        self.assertGreater(expiretime, unixtime)
+        self.assertLessEqual(expiretime, unixtime + 20)
+
+        self.assertIn("123", _daemon_threads)
+        self.assertIn("123", _live_metrics)
+        self.assertIn(value._key, _live_metrics["123"])
+
+    def test_live_inc_updates_expiry(self) -> None:
+        value = self.create_value(type_="gauge", multiprocess_mode="liveall")
+        unixtime = time()
+        redis_client().persist(value._key)
+        self.assertLess(redis_client().expiretime(value._key), 0)
+
+        value.inc(1)
+        self.assertGreater(redis_client().expiretime(value._key), unixtime)
+
+    def test_live_set_updates_expiry(self) -> None:
+        value = self.create_value(type_="gauge", multiprocess_mode="liveall")
+        unixtime = time()
+        redis_client().persist(value._key)
+        self.assertLess(redis_client().expiretime(value._key), 0)
+
+        value.set(1)
+        self.assertGreater(redis_client().expiretime(value._key), unixtime)
+
+    def test_multiprocess_pid_change(self) -> None:
+        pid = 1
+        values.ValueClass = RedisValue(lambda: pid)
+
+        value = self.create_value(type_="gauge", multiprocess_mode="all")
+        self.assertEqual(value._labelnames[-1], "pid")
+        self.assertEqual(value._labelvalues[-1], "1")
+        value.inc(1)
+        self.assertEqual(value.get(), 1.0)
+
+        pid = 2
+        value.inc(1)
+        self.assertEqual(value._labelvalues[-1], "2")
+        self.assertEqual(value.get(), 1.0)
+
+
+class KeepMetricsAliveTestCase(RedisTestCase):
+    """Test KeepMetricsAliveThread and friends."""
+
+    def setUp(self):
+        super().setUp()
+        self.stop_event = Event()
+
+    def tearDown(self):
+        super().tearDown()
+        self.stop_event.set()
+
+    def mock_loop(self) -> None:
+        self.loop_event = Event()
+        self.waiting_event = Event()
+        patcher = mock.patch(
+            "prometheus_client.redis.KeepMetricsAliveThread.loop_wait",
+            side_effect=self.loop_wait,
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def loop_wait(self, _timeout: float) -> bool:
+        self.waiting_event.set()
+        self.waiting_event = Event()
+        assert self.loop_event.wait(5) is True
+        return self.stop_event.is_set()
+
+    def run_loop_once(self, stop: bool = False) -> None:
+        if stop:
+            self.stop_event.set()
+        self.loop_event.set()
+        if not stop:
+            self.loop_event = Event()
+            assert self.waiting_event.wait() is True
+
+    def test_mark_unknown_process_dead(self) -> None:
+        mark_process_dead("unknown")
+
+    def test_mark_known_process_dead(self) -> None:
+        client = redis_client()
+        client.set("key", "hello")
+        _keep_key_from_expiring("identifier", "key")
+        self.assertIn("identifier", _daemon_threads)
+        mark_process_dead("identifier")
+        self.assertNotIn("identifier", _daemon_threads)
+
+    def test_live_daemon_updates_expiry(self) -> None:
+        """Exercise the full lifecycle of the daemon thread."""
+        self.mock_loop()
+        client = redis_client()
+        client.set("key", "hello")
+        _keep_key_from_expiring("identifier", "key")
+        self.assertLess(client.expiretime("key"), 0)
+
+        unixtime = time()
+        self.run_loop_once()
+        self.assertGreater(client.expiretime("key"), unixtime)
+        self.run_loop_once(stop=True)
+
+
+class TestRedisCollector(RedisTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.registry = CollectorRegistry(support_collectors_without_names=True)
@@ -104,6 +241,7 @@ class TestRedis(RedisTestCase):
 
     def test_summary_adds(self) -> None:
         s1 = Summary("s", "help", registry=None)
+        values.ValueClass = RedisValue(lambda: 456)
         s2 = Summary("s", "help", registry=None)
         self.assertEqual(0, self.registry.get_sample_value("s_count"))
         self.assertEqual(0, self.registry.get_sample_value("s_sum"))
@@ -114,6 +252,7 @@ class TestRedis(RedisTestCase):
 
     def test_histogram_adds(self) -> None:
         h1 = Histogram("h", "help", registry=None)
+        values.ValueClass = RedisValue(lambda: 456)
         h2 = Histogram("h", "help", registry=None)
         self.assertEqual(0, self.registry.get_sample_value("h_count"))
         self.assertEqual(0, self.registry.get_sample_value("h_sum"))
@@ -124,12 +263,135 @@ class TestRedis(RedisTestCase):
         self.assertEqual(3, self.registry.get_sample_value("h_sum"))
         self.assertEqual(2, self.registry.get_sample_value("h_bucket", {"le": "5.0"}))
 
+    def test_gauge_all(self) -> None:
+        g1 = Gauge("g", "help", registry=None)
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(0, self.registry.get_sample_value("g", {"pid": "456"}))
+        g1.set(1)
+        g2.set(2)
+        mark_process_dead(123)
+        self.assertEqual(1, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(2, self.registry.get_sample_value("g", {"pid": "456"}))
+
+    def test_gauge_liveall(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="liveall")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="liveall")
+        self.assertEqual(0, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(0, self.registry.get_sample_value("g", {"pid": "456"}))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(2, self.registry.get_sample_value("g", {"pid": "456"}))
+        mark_process_dead(123)
+        self.assertEqual(None, self.registry.get_sample_value("g", {"pid": "123"}))
+        self.assertEqual(2, self.registry.get_sample_value("g", {"pid": "456"}))
+
+    def test_gauge_min(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="min")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="min")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+
+    def test_gauge_livemin(self):
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="livemin")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="livemin")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+
+    def test_gauge_max(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="max")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="max")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+
+    def test_gauge_livemax(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="livemax")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="livemax")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(2)
+        g2.set(1)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+
+    def test_gauge_sum(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="sum")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="sum")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(3, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(3, self.registry.get_sample_value("g"))
+
+    def test_gauge_livesum(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="livesum")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="livesum")
+        self.assertEqual(0, self.registry.get_sample_value("g"))
+        g1.set(1)
+        g2.set(2)
+        self.assertEqual(3, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+
+    def xxx_test_gauge_mostrecent(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="mostrecent")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="mostrecent")
+        g2.set(2)
+        g1.set(1)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+
+    def xxx_test_gauge_livemostrecent(self) -> None:
+        g1 = Gauge("g", "help", registry=None, multiprocess_mode="livemostrecent")
+        values.ValueClass = RedisValue(lambda: 456)
+        g2 = Gauge("g", "help", registry=None, multiprocess_mode="livemostrecent")
+        g2.set(2)
+        g1.set(1)
+        self.assertEqual(1, self.registry.get_sample_value("g"))
+        mark_process_dead(123)
+        self.assertEqual(2, self.registry.get_sample_value("g"))
+
     def test_namespace_subsystem(self) -> None:
         c1 = Counter("c", "help", registry=None, namespace="ns", subsystem="ss")
         c1.inc(1)
         self.assertEqual(1, self.registry.get_sample_value("ns_ss_c_total"))
 
+    def test_counter_across_forks(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
+        c1 = Counter("c", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("c_total"))
+        c1.inc(1)
+        c1.inc(1)
+        pid = 1
+        c1.inc(1)
+        self.assertEqual(3, self.registry.get_sample_value("c_total"))
+        # Unlike MultiProcessValue, we don't store any local state
+        self.assertEqual(3, c1._value.get())
+
     def test_collect(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
         labels = {i: i for i in "abcd"}
 
         def add_label(key: str, value: str) -> dict[str, str]:
@@ -145,6 +407,8 @@ class TestRedis(RedisTestCase):
         g.labels(**labels).set(1)
         h.labels(**labels).observe(1)
 
+        pid = 1
+
         c.labels(**labels).inc(1)
         g.labels(**labels).set(1)
         h.labels(**labels).observe(5)
@@ -152,6 +416,14 @@ class TestRedis(RedisTestCase):
         metrics = {m.name: m for m in self.collector.collect()}
 
         self.assertEqual(metrics["c"].samples, [Sample("c_total", labels, 2.0)])
+        metrics["g"].samples.sort(key=lambda x: x[1]["pid"])
+        self.assertEqual(
+            metrics["g"].samples,
+            [
+                Sample("g", add_label("pid", "0"), 1.0),
+                Sample("g", add_label("pid", "1"), 1.0),
+            ],
+        )
 
         expected_histogram = [
             Sample("h_bucket", add_label("le", "0.005"), 0.0),
@@ -176,9 +448,14 @@ class TestRedis(RedisTestCase):
         self.assertEqual(metrics["h"].samples, expected_histogram)
 
     def test_collect_histogram_ordering(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
+
         h = Histogram("h", "help", labelnames=["view"], registry=None)
 
         h.labels(view="view1").observe(1)
+
+        pid = 1
 
         h.labels(view="view1").observe(5)
         h.labels(view="view2").observe(1)
@@ -225,6 +502,8 @@ class TestRedis(RedisTestCase):
         self.assertEqual(metrics["h"].samples, expected_histogram)
 
     def test_restrict(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
         labels = {i: i for i in "abcd"}
 
         c = Counter("c", "help", labelnames=labels.keys(), registry=None)
@@ -232,6 +511,8 @@ class TestRedis(RedisTestCase):
 
         c.labels(**labels).inc(1)
         g.labels(**labels).set(1)
+
+        pid = 1
 
         c.labels(**labels).inc(1)
         g.labels(**labels).set(1)
@@ -245,6 +526,8 @@ class TestRedis(RedisTestCase):
         self.assertEqual(metrics["c"].samples, [Sample("c_total", labels, 2.0)])
 
     def test_collect_preserves_help(self) -> None:
+        pid = 0
+        values.ValueClass = RedisValue(lambda: pid)
         labels = {i: i for i in "abcd"}
 
         c = Counter("c", "c help", labelnames=labels.keys(), registry=None)
@@ -255,6 +538,8 @@ class TestRedis(RedisTestCase):
         g.labels(**labels).set(1)
         h.labels(**labels).observe(1)
 
+        pid = 1
+
         c.labels(**labels).inc(1)
         g.labels(**labels).set(1)
         h.labels(**labels).observe(5)
@@ -264,6 +549,20 @@ class TestRedis(RedisTestCase):
         self.assertEqual(metrics["c"].documentation, "c help")
         self.assertEqual(metrics["g"].documentation, "g help")
         self.assertEqual(metrics["h"].documentation, "h help")
+
+    def test_remove_clear_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as w:
+            values.ValueClass = get_value_class()
+            registry = CollectorRegistry()
+            collector = RedisCollector(registry)
+            counter = Counter("c", "help", labelnames=["label"], registry=None)
+            counter.labels("label").inc()
+            counter.remove("label")
+            counter.clear()
+            assert issubclass(w[0].category, UserWarning)
+            assert "Removal of labels has not been implemented" in str(w[0].message)
+            assert issubclass(w[-1].category, UserWarning)
+            assert "Clearing of labels has not been implemented" in str(w[-1].message)
 
     def test_child_name_is_built_once_with_namespace_subsystem_unit(self) -> None:
         """

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,0 +1,386 @@
+import os
+import unittest
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+from prometheus_client import values
+from prometheus_client.core import (
+    CollectorRegistry, Counter, Gauge, Histogram, Sample, Summary,
+)
+from prometheus_client.redis_collector import RedisCollector, redis_client
+from prometheus_client.samples import Exemplar
+from prometheus_client.values import MutexValue, RedisValue, Value
+
+pytest.importorskip("redis")
+
+
+class RedisTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["PROMETHEUS_REDIS_URL"] = "fakeredis://localhost/42"
+        values.ValueClass = RedisValue
+
+    def tearDown(self) -> None:
+        redis_client().flushdb()
+        del os.environ["PROMETHEUS_REDIS_URL"]
+        values.ValueClass = MutexValue
+
+
+class ValueTestCase(RedisTestCase):
+    def create_value(
+        self,
+        metric_name: str = "test",
+        name: str | None = None,
+        type_: str = "counter",
+        labelnames: list[str] | None = None,
+        labelvalues: list[str] | None = None,
+    ) -> Value:
+        return values.ValueClass(
+            type_,
+            metric_name,
+            name or metric_name + "_total",
+            labelnames or [],
+            labelvalues or [],
+            "Help Text",
+        )
+
+    def test_initializes_value(self) -> None:
+        value = self.create_value()
+        self.assertEqual(value.get(), 0.0)
+
+    def test_sets_and_gets_value(self) -> None:
+        value = self.create_value()
+        value.set(5)
+        self.assertEqual(value.get(), 5.0)
+
+    def test_inc_value(self) -> None:
+        value = self.create_value()
+        value.inc(3)
+        value.inc(5)
+        self.assertEqual(value.get(), 8.0)
+
+    def test_get_missing_value(self) -> None:
+        value = self.create_value()
+        redis_client().delete(value._key)
+        self.assertEqual(value.get(), 0.0)
+
+    def test_exemplars_not_implemented(self) -> None:
+        value = self.create_value("test4")
+        with self.assertRaises(NotImplementedError):
+            value.set_exemplar(Exemplar(labels={}, value=0.0, timestamp=0.0))
+        self.assertIsNone(value.get_exemplar())
+
+    def test_differentiated_by_name(self) -> None:
+        v1 = self.create_value("value1")
+        v2 = self.create_value("value2")
+        v1.set(1)
+        v2.set(2)
+        self.assertEqual(v1.get(), 1.0)
+        self.assertEqual(v2.get(), 2.0)
+
+    def test_differentiated_by_labels(self) -> None:
+        v1 = self.create_value("value3", labelnames=["a"], labelvalues=["1"])
+        v2 = self.create_value("value3", labelnames=["a"], labelvalues=["2"])
+        v1.set(1)
+        v2.set(2)
+        self.assertEqual(v1.get(), 1.0)
+        self.assertEqual(v2.get(), 2.0)
+
+
+class TestRedis(RedisTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.registry = CollectorRegistry(support_collectors_without_names=True)
+        self.collector = RedisCollector(self.registry)
+
+    def test_counter_adds(self) -> None:
+        c1 = Counter("c", "help", registry=None)
+        c2 = Counter("c", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("c_total"))
+        c1.inc(1)
+        c2.inc(2)
+        self.assertEqual(3, self.registry.get_sample_value("c_total"))
+
+    def test_summary_adds(self) -> None:
+        s1 = Summary("s", "help", registry=None)
+        s2 = Summary("s", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("s_count"))
+        self.assertEqual(0, self.registry.get_sample_value("s_sum"))
+        s1.observe(1)
+        s2.observe(2)
+        self.assertEqual(2, self.registry.get_sample_value("s_count"))
+        self.assertEqual(3, self.registry.get_sample_value("s_sum"))
+
+    def test_histogram_adds(self) -> None:
+        h1 = Histogram("h", "help", registry=None)
+        h2 = Histogram("h", "help", registry=None)
+        self.assertEqual(0, self.registry.get_sample_value("h_count"))
+        self.assertEqual(0, self.registry.get_sample_value("h_sum"))
+        self.assertEqual(0, self.registry.get_sample_value("h_bucket", {"le": "5.0"}))
+        h1.observe(1)
+        h2.observe(2)
+        self.assertEqual(2, self.registry.get_sample_value("h_count"))
+        self.assertEqual(3, self.registry.get_sample_value("h_sum"))
+        self.assertEqual(2, self.registry.get_sample_value("h_bucket", {"le": "5.0"}))
+
+    def test_namespace_subsystem(self) -> None:
+        c1 = Counter("c", "help", registry=None, namespace="ns", subsystem="ss")
+        c1.inc(1)
+        self.assertEqual(1, self.registry.get_sample_value("ns_ss_c_total"))
+
+    def test_collect(self) -> None:
+        labels = {i: i for i in "abcd"}
+
+        def add_label(key: str, value: str) -> dict[str, str]:
+            l = labels.copy()
+            l[key] = value
+            return l
+
+        c = Counter("c", "help", labelnames=labels.keys(), registry=None)
+        g = Gauge("g", "help", labelnames=labels.keys(), registry=None)
+        h = Histogram("h", "help", labelnames=labels.keys(), registry=None)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(1)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(5)
+
+        metrics = {m.name: m for m in self.collector.collect()}
+
+        self.assertEqual(metrics["c"].samples, [Sample("c_total", labels, 2.0)])
+
+        expected_histogram = [
+            Sample("h_bucket", add_label("le", "0.005"), 0.0),
+            Sample("h_bucket", add_label("le", "0.01"), 0.0),
+            Sample("h_bucket", add_label("le", "0.025"), 0.0),
+            Sample("h_bucket", add_label("le", "0.05"), 0.0),
+            Sample("h_bucket", add_label("le", "0.075"), 0.0),
+            Sample("h_bucket", add_label("le", "0.1"), 0.0),
+            Sample("h_bucket", add_label("le", "0.25"), 0.0),
+            Sample("h_bucket", add_label("le", "0.5"), 0.0),
+            Sample("h_bucket", add_label("le", "0.75"), 0.0),
+            Sample("h_bucket", add_label("le", "1.0"), 1.0),
+            Sample("h_bucket", add_label("le", "2.5"), 1.0),
+            Sample("h_bucket", add_label("le", "5.0"), 2.0),
+            Sample("h_bucket", add_label("le", "7.5"), 2.0),
+            Sample("h_bucket", add_label("le", "10.0"), 2.0),
+            Sample("h_bucket", add_label("le", "+Inf"), 2.0),
+            Sample("h_count", labels, 2.0),
+            Sample("h_sum", labels, 6.0),
+        ]
+
+        self.assertEqual(metrics["h"].samples, expected_histogram)
+
+    def test_collect_histogram_ordering(self) -> None:
+        h = Histogram("h", "help", labelnames=["view"], registry=None)
+
+        h.labels(view="view1").observe(1)
+
+        h.labels(view="view1").observe(5)
+        h.labels(view="view2").observe(1)
+
+        metrics = {m.name: m for m in self.collector.collect()}
+
+        expected_histogram = [
+            Sample("h_bucket", {"view": "view1", "le": "0.005"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.01"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.025"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.05"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.075"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.1"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.25"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.5"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "0.75"}, 0.0),
+            Sample("h_bucket", {"view": "view1", "le": "1.0"}, 1.0),
+            Sample("h_bucket", {"view": "view1", "le": "2.5"}, 1.0),
+            Sample("h_bucket", {"view": "view1", "le": "5.0"}, 2.0),
+            Sample("h_bucket", {"view": "view1", "le": "7.5"}, 2.0),
+            Sample("h_bucket", {"view": "view1", "le": "10.0"}, 2.0),
+            Sample("h_bucket", {"view": "view1", "le": "+Inf"}, 2.0),
+            Sample("h_count", {"view": "view1"}, 2.0),
+            Sample("h_sum", {"view": "view1"}, 6.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.005"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.01"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.025"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.05"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.075"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.1"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.25"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.5"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "0.75"}, 0.0),
+            Sample("h_bucket", {"view": "view2", "le": "1.0"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "2.5"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "5.0"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "7.5"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "10.0"}, 1.0),
+            Sample("h_bucket", {"view": "view2", "le": "+Inf"}, 1.0),
+            Sample("h_count", {"view": "view2"}, 1.0),
+            Sample("h_sum", {"view": "view2"}, 1.0),
+        ]
+
+        self.assertEqual(metrics["h"].samples, expected_histogram)
+
+    def test_restrict(self) -> None:
+        labels = {i: i for i in "abcd"}
+
+        c = Counter("c", "help", labelnames=labels.keys(), registry=None)
+        g = Gauge("g", "help", labelnames=labels.keys(), registry=None)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+
+        metrics = {
+            m.name: m for m in self.registry.restricted_registry(["c_total"]).collect()
+        }
+
+        self.assertEqual(metrics.keys(), {"c"})
+
+        self.assertEqual(metrics["c"].samples, [Sample("c_total", labels, 2.0)])
+
+    def test_collect_preserves_help(self) -> None:
+        labels = {i: i for i in "abcd"}
+
+        c = Counter("c", "c help", labelnames=labels.keys(), registry=None)
+        g = Gauge("g", "g help", labelnames=labels.keys(), registry=None)
+        h = Histogram("h", "h help", labelnames=labels.keys(), registry=None)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(1)
+
+        c.labels(**labels).inc(1)
+        g.labels(**labels).set(1)
+        h.labels(**labels).observe(5)
+
+        metrics = {m.name: m for m in self.collector.collect()}
+
+        self.assertEqual(metrics["c"].documentation, "c help")
+        self.assertEqual(metrics["g"].documentation, "g help")
+        self.assertEqual(metrics["h"].documentation, "h help")
+
+    def test_child_name_is_built_once_with_namespace_subsystem_unit(self) -> None:
+        """
+        Repro for #1035:
+        In multiprocess mode, child metrics must NOT rebuild the full name
+        (namespace/subsystem/unit) a second time. The exported family name should
+        be built once, and Counter samples should use "<family>_total".
+        """
+        from prometheus_client import Counter
+
+        class CustomCounter(Counter):
+            def __init__(
+                self,
+                name: str,
+                documentation: str,
+                labelnames: Sequence[str] = (),
+                namespace: str = "mydefaultnamespace",
+                subsystem: str = "mydefaultsubsystem",
+                unit: str = "",
+                registry: CollectorRegistry | None = None,
+                _labelvalues: Sequence[str] | None = None,
+            ):
+                # Intentionally provide non-empty defaults to trigger the bug path.
+                super().__init__(
+                    name=name,
+                    documentation=documentation,
+                    labelnames=labelnames,
+                    namespace=namespace,
+                    subsystem=subsystem,
+                    unit=unit,
+                    registry=registry,
+                    _labelvalues=_labelvalues,
+                )
+
+        # Create a Counter with explicit namespace/subsystem/unit
+        c = CustomCounter(
+            name="m",
+            documentation="help",
+            labelnames=("status", "method"),
+            namespace="ns",
+            subsystem="ss",
+            unit="seconds",  # avoid '_total_total' confusion
+            registry=None,  # not registered in local registry in multiprocess mode
+        )
+
+        # Create two labeled children
+        c.labels(status="200", method="GET").inc()
+        c.labels(status="404", method="POST").inc()
+
+        # Collect from the multiprocess collector initialized in setUp()
+        metrics = {m.name: m for m in self.collector.collect()}
+
+        # Family name should be built once (no '_total' in family name)
+        expected_family = "ns_ss_m_seconds"
+        self.assertIn(expected_family, metrics, f"missing family {expected_family}")
+
+        # Counter samples must use '<family>_total'
+        mf = metrics[expected_family]
+        sample_names = {s.name for s in mf.samples}
+        self.assertTrue(
+            all(name == expected_family + "_total" for name in sample_names),
+            f"unexpected sample names: {sample_names}",
+        )
+
+        # Ensure no double-built prefix sneaks in (the original bug)
+        bad_prefix = "mydefaultnamespace_mydefaultsubsystem_"
+        all_names = {mf.name, *sample_names}
+        self.assertTrue(
+            all(not n.startswith(bad_prefix) for n in all_names),
+            f"found double-built name(s): {[n for n in all_names if n.startswith(bad_prefix)]}",
+        )
+
+    def test_child_preserves_parent_context_for_subclasses(self) -> None:
+        """
+        Ensure child metrics preserve parent's namespace/subsystem/unit information
+        so that subclasses can correctly use these parameters in their logic.
+        """
+
+        class ContextAwareCounter(Counter):
+            def __init__(
+                self,
+                name: str,
+                documentation: str,
+                labelnames: Sequence[str] = (),
+                namespace: str = "",
+                subsystem: str = "",
+                unit: str = "",
+                **kwargs: Any,
+            ):
+                self.context = {
+                    "namespace": namespace,
+                    "subsystem": subsystem,
+                    "unit": unit,
+                }
+                super().__init__(
+                    name,
+                    documentation,
+                    labelnames=labelnames,
+                    namespace=namespace,
+                    subsystem=subsystem,
+                    unit=unit,
+                    **kwargs,
+                )
+
+        parent = ContextAwareCounter(
+            "m",
+            "help",
+            labelnames=["status"],
+            namespace="prod",
+            subsystem="api",
+            unit="seconds",
+            registry=None,
+        )
+
+        child = parent.labels(status="200")
+
+        # Verify that child retains parent's context
+        self.assertEqual(child.context["namespace"], "prod")
+        self.assertEqual(child.context["subsystem"], "api")
+        self.assertEqual(child.context["unit"], "seconds")

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ deps =
     pytest
     pytest-benchmark
     attrs
+    fakeredis
+    redis
     {py3.9,pypy3.9}: twisted
     {py3.9,pypy3.9}: aiohttp
     {py3.9,pypy3.9}: django


### PR DESCRIPTION
The multiprocess backend has an issue with database file explosion (#204, #518, etc.)

In the environment that I'm running into this problem, we have a redis database available, so why not take advantage of this?

Here is a fairly naive proof-of-concept example.

Also compatible with Valkey.