### PR TITLE
Add handy tox environment to fix isort errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,12 @@ skip_install = true
 commands =
     isort --check prometheus_client/ tests/
 
+[testenv:isort-fix]
+deps = {[testenv:isort]deps}
+skip_install = true
+commands =
+    isort prometheus_client/ tests/
+
 [testenv:mypy]
 deps =
     pytest


### PR DESCRIPTION
... which can be used during development easily.