### PR TITLE
docs: follow-up fixes for collect() generator examples (#1169)

### DIFF
--- a/docs/content/collector/custom.md
+++ b/docs/content/collector/custom.md
@@ -241,11 +241,15 @@ InfoMetricFamily(name, documentation, value=None, labels=None)
 | `value` | `Dict[str, str]` | Key-value label pairs that form the info payload. |
 | `timestamp` | `float` or `Timestamp` | Optional Unix timestamp. |
 
-```python
-# single unlabelled info metric
-yield InfoMetricFamily('build', 'Build metadata', value={'version': '1.2.3', 'commit': 'abc123'})
+Single unlabelled info metric:
 
-# labelled: one info metric per service
+```python
+yield InfoMetricFamily('build', 'Build metadata', value={'version': '1.2.3', 'commit': 'abc123'})
+```
+
+Labelled — one info metric per service:
+
+```python
 i = InfoMetricFamily('service_build', 'Per-service build info', labels=['service'])
 i.add_metric(['auth'], {'version': '2.0.1', 'commit': 'def456'})
 i.add_metric(['api'], {'version': '1.9.0', 'commit': 'ghi789'})

--- a/docs/content/collector/custom.md
+++ b/docs/content/collector/custom.md
@@ -47,6 +47,11 @@ can also implement `describe`.
 Returns an iterable of metric family objects (`GaugeMetricFamily`,
 `CounterMetricFamily`, etc.). Called every time the registry is scraped.
 
+Using `yield` is the idiomatic way to implement `collect()` — it turns the method
+into a generator, which the registry iterates lazily without building an intermediate
+list first. Each scrape calls `collect()` fresh, so no state carries over between
+scrapes.
+
 ### `describe()`
 
 Returns an iterable of metric family objects used only to determine the metric
@@ -75,6 +80,10 @@ g.add_metric(['eu-west-1'], 5)
 ```
 
 ## API Reference
+
+The examples below show usage inside a `collect()` method body. Each snippet is
+meant to be placed within a custom collector class as shown in the example at the
+top of this page.
 
 ### GaugeMetricFamily
 


### PR DESCRIPTION
@csmarchbanks

Three issues raised in review of #1169 by @calestyo:

1. The API Reference code examples used bare `yield` statements without
   any surrounding `def collect(self):` context, making it unclear what
   they belonged to. Added a preamble to the API Reference section
   pointing back to the top-level example.

2. The `InfoMetricFamily` example had two `yield` statements in a single
   block, which looked like one `collect()` yielding both patterns rather
   than two alternatives. Split into separate labelled blocks.

3. The `collect()` protocol section gave no explanation for why generators
   are used. Added a note explaining that yield is idiomatic (lazy
   iteration, no intermediate list) and that each scrape gets a fresh call
   with no state carried over.