### PR TITLE
docs: add memory benefit and variable-reuse note to collect() section

### DIFF
--- a/docs/content/collector/custom.md
+++ b/docs/content/collector/custom.md
@@ -56,16 +56,15 @@ Memory is a secondary benefit. Yielding an object inline
 (`yield GaugeMetricFamily(...)`) lets Python reclaim it as soon as the registry
 advances past that point. A named variable keeps the object alive until the variable
 is rebound. For most collectors this difference is negligible, but it can matter for
-very large metric sets. When building families in a loop, yield inside the loop and
-reuse the same variable name so the GC can reclaim each object before the next one
-is built:
+very large metric sets. Yielding inside a loop rather than accumulating into a list
+keeps at most one object alive at a time:
 
 ```python
 def collect(self):
     for name in _QUEUE_NAMES:
         m = GaugeMetricFamily('queue_depth', 'Queue depth', labels=['queue'])
         m.add_metric([name], fetch_depth(name))
-        yield m  # m is rebound next iteration; the previous object can be reclaimed
+        yield m
 ```
 
 ### `describe()`

--- a/docs/content/collector/custom.md
+++ b/docs/content/collector/custom.md
@@ -52,6 +52,22 @@ into a generator, which the registry iterates lazily without building an interme
 list first. Each scrape calls `collect()` fresh, so no state carries over between
 scrapes.
 
+Memory is a secondary benefit. Yielding an object inline
+(`yield GaugeMetricFamily(...)`) lets Python reclaim it as soon as the registry
+advances past that point. A named variable keeps the object alive until the variable
+is rebound. For most collectors this difference is negligible, but it can matter for
+very large metric sets. When building families in a loop, yield inside the loop and
+reuse the same variable name so the GC can reclaim each object before the next one
+is built:
+
+```python
+def collect(self):
+    for name in _QUEUE_NAMES:
+        m = GaugeMetricFamily('queue_depth', 'Queue depth', labels=['queue'])
+        m.add_metric([name], fetch_depth(name))
+        yield m  # m is rebound next iteration; the previous object can be reclaimed
+```
+
 ### `describe()`
 
 Returns an iterable of metric family objects used only to determine the metric


### PR DESCRIPTION
Closes points made from comment section in #1169.


**Changes**

- Added a paragraph to the \`collect()\` protocol section noting that memory
  is a secondary benefit of using \`yield\`: yielding inline lets Python
  reclaim the object as soon as the registry advances, while a named variable
  stays alive until it is rebound.
- Added a short loop example showing that yielding inside a loop rather than         
  accumulating into a list keeps at most one object alive at a time.    
- Example verified by running it against the library.

cc @calestyo @csmarchbanks