### PR TITLE
fix: raise ValueError when clear() called on metric without labels

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -254,6 +254,8 @@ class MetricWrapperBase(Collector):
 
     def clear(self) -> None:
         """Remove all labelsets from the metric"""
+        if not self._labelnames:
+            raise ValueError('No label names were set when constructing %s' % self)
         if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
             warnings.warn(
                 "Clearing labels has not been implemented in multi-process mode yet",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -620,6 +620,12 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertEqual(None, self.registry.get_sample_value('c_total', {'l': 'x'}))
         self.assertEqual(None, self.registry.get_sample_value('c_total', {'l': 'y'}))
 
+    def test_clear_no_labels_raises(self):
+        """clear() on a metric without labels should raise ValueError, not AttributeError."""
+        no_labels = Counter('c_no_labels', 'help', registry=self.registry)
+        no_labels.inc()
+        self.assertRaises(ValueError, no_labels.clear)
+
     def test_incorrect_label_count_raises(self):
         self.assertRaises(ValueError, self.counter.labels)
         self.assertRaises(ValueError, self.counter.labels, 'a', 'b')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -621,10 +621,14 @@ class TestMetricWrapper(unittest.TestCase):
         self.assertEqual(None, self.registry.get_sample_value('c_total', {'l': 'y'}))
 
     def test_clear_no_labels_raises(self):
-        """clear() on a metric without labels should raise ValueError, not AttributeError."""
         no_labels = Counter('c_no_labels', 'help', registry=self.registry)
         no_labels.inc()
         self.assertRaises(ValueError, no_labels.clear)
+
+    def test_remove_no_labels_raises(self):
+        no_labels = Counter('c_no_labels2', 'help', registry=self.registry)
+        no_labels.inc()
+        self.assertRaises(ValueError, no_labels.remove, 'x')
 
     def test_incorrect_label_count_raises(self):
         self.assertRaises(ValueError, self.counter.labels)


### PR DESCRIPTION
## Summary

- Fixes #1140 (also addresses duplicate #949)
- `clear()` on a metric without labels raised `AttributeError: 'Counter' object has no attribute '_lock'` because `_lock` and `_metrics` are only initialized on parent metrics (those with `labelnames` but no `labelvalues`)
- Added the same `ValueError` guard that `remove()` already uses: `if not self._labelnames: raise ValueError(...)`
- Added tests for `clear()` and `remove()` on label-less metrics

## Test plan

- [x] `test_clear_no_labels_raises` -- verifies `clear()` on a label-less metric raises `ValueError`
- [x] `test_remove_no_labels_raises` -- verifies `remove()` on a label-less metric raises `ValueError`
- [x] Existing `test_clear` still passes (labeled metrics work as before)
- [x] Full `test_core.py` suite passes (113 tests)