### PR TITLE
support clearing of metric objects for custom collectors

### DIFF
--- a/prometheus_client/metrics_core.py
+++ b/prometheus_client/metrics_core.py
@@ -37,6 +37,10 @@ class Metric:
 
         Internal-only, do not use."""
         self.samples.append(Sample(name, labels, value, timestamp, exemplar, native_histogram))
+    
+    def clear(self) -> None:
+        """Clear all samples."""
+        self.samples.clear()
 
     def __eq__(self, other: object) -> bool:
         return (isinstance(other, Metric)


### PR DESCRIPTION
Hey.

This is based on my second point in https://github.com/prometheus/client_python/pull/1173#issuecomment-4436585472.

Please see there and also the commit message which explains the rationale.

I think the biggest open point right now would be whether to use `self.samples.clear()` or rather `self.samples = []`, which would probably be way faster (see commit message for the reasoning).
**If** `.samples` was actually be considered non-public, it should however be renamed (and I think the same goes for e.g. `add_sample`, whose doc-string already says it would be internal only... so just renamed it to `_add_sample`, or maybe warp around it and add a deprecation warning to the public one.

Cheers,
Chris.

PS: @csmarchbanks and @k1chik might want to have a look. For the latter, **if** this PR would be considered worthy to add... it would probably make sense to present that way of use as an alternative to the current schema in the docs (which you've so greatly worked on recently)