### PR TITLE
fix: escape colons in metric names when escaping=underscores

### DIFF
--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -181,9 +181,9 @@ def escape_metric_name(s: str, escaping: str = UNDERSCORES) -> str:
             return '"{}"'.format(_escape(s, escaping, _is_legacy_metric_rune))
         return _escape(s, escaping, _is_legacy_metric_rune)
     elif escaping == UNDERSCORES:
-        if _is_valid_legacy_metric_name(s):
+        if _is_valid_legacy_metric_name(s) and ':' not in s:
             return s
-        return _escape(s, escaping, _is_legacy_metric_rune)
+        return _escape(s, escaping, _is_legacy_labelname_rune)
     elif escaping == DOTS:
         return _escape(s, escaping, _is_legacy_metric_rune)
     elif escaping == VALUES:

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -57,6 +57,15 @@ utf8_cc_created 123.456
 # EOF
 """ == generate_latest(self.registry, UNDERSCORES)
 
+    def test_gauge_colon_in_name_escaped_underscores(self):
+        g = Gauge('sglang:token_usage', 'Total token usage.', registry=self.registry)
+        g.set(42.0)
+        assert b"""# HELP sglang_token_usage Total token usage.
+# TYPE sglang_token_usage gauge
+sglang_token_usage 42.0
+# EOF
+""" == generate_latest(self.registry, UNDERSCORES)
+
     def test_counter_total(self) -> None:
         c = Counter('cc_total', 'A counter', registry=self.registry)
         c.inc()
@@ -482,7 +491,7 @@ nh_version {count:5,sum:10,schema:0,zero_threshold:0.01,zero_count:2,negative_sp
     {
         "name": "legacy valid metric name",
         "input": "no:escaping_required",
-        "expectedUnderscores": "no:escaping_required",
+        "expectedUnderscores": "no_escaping_required",
         "expectedDots": "no:escaping__required",
         "expectedValue": "no:escaping_required",
     },
@@ -503,7 +512,7 @@ nh_version {count:5,sum:10,schema:0,zero_threshold:0.01,zero_count:2,negative_sp
     {
         "name": "metric name with dots and colon",
         "input": "http.status:sum",
-        "expectedUnderscores": "http_status:sum",
+        "expectedUnderscores": "http_status_sum",
         "expectedDots": "http_dot_status:sum",
         "expectedValue": "U__http_2e_status:sum",
     },

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -644,7 +644,7 @@ class TestChooseEncoder(unittest.TestCase):
     {
         "name": "legacy valid metric name",
         "input": "no:escaping_required",
-        "expectedUnderscores": "no:escaping_required",
+        "expectedUnderscores": "no_escaping_required",
         "expectedDots": "no:escaping__required",
         "expectedValue": "no:escaping_required",
     },
@@ -665,7 +665,7 @@ class TestChooseEncoder(unittest.TestCase):
     {
         "name": "metric name with dots and colon",
         "input": "http.status:sum",
-        "expectedUnderscores": "http_status:sum",
+        "expectedUnderscores": "http_status_sum",
         "expectedDots": "http_dot_status:sum",
         "expectedValue": "U__http_2e_status:sum",
     },


### PR DESCRIPTION
Fixes #1177

When a metric name contains a colon (e.g. `sglang:token_usage`) and the client negotiates `escaping=underscores`, the `# HELP` and `# TYPE` lines were emitting the raw name while the sample line replaced the colon with an underscore:

```
# HELP sglang:token_usage Total token usage.
# TYPE sglang:token_usage gauge
sglang_token_usage 42.0
```

This violates the OpenMetrics spec and causes strict parsers to treat the metadata and the sample as two separate metrics.

The bug is in `escape_metric_name` in `prometheus_client/openmetrics/exposition.py`. In `UNDERSCORES` mode, the function short-circuits for any name that matches the legacy Prometheus metric name regex. That regex allows colons, so names like `sglang:token_usage` were returned unchanged. The sample line uses `_is_legacy_labelname_rune` which does not allow colons, so it escaped them correctly.

The fix adds a colon check to the short-circuit condition and switches the fallback `_escape` call to use `_is_legacy_labelname_rune`, matching what the sample line already does.

Two existing test expectations that documented the old behavior are updated. A new end-to-end test reproduces the exact scenario from the issue.

@csmarchbanks