### PR TITLE
Simplify label boundary detection in sample parser

### DIFF
--- a/prometheus_client/parser.py
+++ b/prometheus_client/parser.py
@@ -244,7 +244,7 @@ def _parse_value(value):
 def _parse_sample(text):
     separator = " # "
     # Detect the labels in the text
-    label_start = _next_unquoted_char(text, '{')
+    label_start = text.find('{')
     if label_start == -1 or separator in text[:label_start]:
         # We don't have labels, but there could be an exemplar.
         name_end = _next_unquoted_char(text, ' \t')
@@ -256,7 +256,7 @@ def _parse_sample(text):
         value, timestamp = _parse_value_and_timestamp(remaining_text)
         return Sample(name, {}, value, timestamp)
     name = text[:label_start].strip()
-    label_end = _next_unquoted_char(text[label_start:], '}') + label_start
+    label_end = text.rfind('}')
     labels = parse_labels(text[label_start + 1:label_end], False)
     if not name:
         # Name might be in the labels


### PR DESCRIPTION
Optimize line parsing by using `str.find()` for locating `{` and `str.rfind()` for location `}`

Since metric names cannnot contain `{` and values are always numeric, escape handling is entirely unnecessary for bounday detection.  This imporvemnt scales with line length.

## benchmark

```
git switch master
pytest tests/test_parser.py  --benchmark-only --benchmark-save master
git switch feature/performe
pytest tests/test_parser.py  --benchmark-only --benchmark-compare 0002_master
```

```
----------------------------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------------------------
Name (time in us)                                                    Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_text_string_to_metric_families (NOW)             115.9000 (1.0)      205.4800 (1.0)      128.7905 (1.0)      13.6625 (1.0)      123.5150 (1.0)       9.7862 (1.0)       438;402        7.7645 (1.0)        3587           1
test_benchmark_text_string_to_metric_families (0002_master)     147.6700 (1.27)     319.5870 (1.56)     168.5964 (1.31)     18.2601 (1.34)     161.9480 (1.31)     14.6172 (1.49)      480;383        5.9313 (0.76)       3373           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


