### PR TITLE
docs: note WSL filesystem caveat for MultiProcessCollector

### DIFF
--- a/docs/content/multiprocess/_index.md
+++ b/docs/content/multiprocess/_index.md
@@ -35,6 +35,12 @@ between process/Gunicorn runs (before startup is recommended).
 This environment variable should be set from a start-up shell script,
 and not directly from Python (otherwise it may not propagate to child processes).
 
+Note: on Windows Subsystem for Linux (WSL), set `PROMETHEUS_MULTIPROC_DIR` to a
+Linux-native filesystem path (e.g. `/tmp` or `/home/<user>`) rather than a
+Windows-mounted path (e.g. `/mnt/c/...`). On Windows-mounted filesystems the
+per-process metric files can be written with an incorrect internal offset,
+causing the collector to silently read no data.
+
 **2. Metrics collector**:
 
 The application must initialize a new `CollectorRegistry`, and store the


### PR DESCRIPTION
Adds a docs note for the WSL filesystem quirk reported in #1126.

@csmarchbanks - you mentioned being open to a PR for this, so i have done it.