### PR TITLE
Make clear() a no-op for label-less metrics (fixes #707)

### DIFF
--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -254,6 +254,8 @@ class MetricWrapperBase(Collector):
 
     def clear(self) -> None:
         """Remove all labelsets from the metric"""
+        if not self._labelnames:
+            return
         if 'prometheus_multiproc_dir' in os.environ or 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
             warnings.warn(
                 "Clearing labels has not been implemented in multi-process mode yet",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -59,6 +59,12 @@ class TestCounter(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(repr(self.counter), "prometheus_client.metrics.Counter(c)")
 
+    def test_clear_without_labels_is_noop(self):
+        self.counter.inc()
+        self.assertEqual(1, self.registry.get_sample_value('c_total'))
+        self.counter.clear()  # should not raise
+        self.assertEqual(1, self.registry.get_sample_value('c_total'))
+
     def test_negative_increment_raises(self):
         self.assertRaises(ValueError, self.counter.inc, -1)
 


### PR DESCRIPTION
Fixes #707.

`clear()` unconditionally did `with self._lock:`, but `self._lock`
is only created in `__init__` for metrics with labelnames. Calling
`.clear()` on a label-less metric (e.g. `Counter('c', 'c')`) raised
`AttributeError: 'Counter' object has no attribute '_lock'`.

Per the discussion in the issue, a label-less metric has no
labelsets to clear, so this makes `clear()` a no-op in that case
rather than raising  consistent with the direction @csmarchbanks
and others converged on in the thread.

Added a regression test in `tests/test_core.py::TestCounter`.

@csmarchbanks would appreciate your review on this when you have a chance.