### PR TITLE
Fix operator precedence allowing exemplars on any metric type

### DIFF
--- a/prometheus_client/openmetrics/exposition.py
+++ b/prometheus_client/openmetrics/exposition.py
@@ -25,9 +25,9 @@ VALUES = 'values'
 def _is_valid_exemplar_metric(metric, sample):
     if metric.type == 'counter' and sample.name.endswith('_total'):
         return True
-    if metric.type in ('gaugehistogram') and sample.name.endswith('_bucket'):
+    if metric.type == 'gaugehistogram' and sample.name.endswith('_bucket'):
         return True
-    if metric.type in ('histogram') and sample.name.endswith('_bucket') or sample.name == metric.name:
+    if metric.type == 'histogram' and (sample.name.endswith('_bucket') or sample.name == metric.name):
         return True
     return False
 

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -347,6 +347,21 @@ cc_created 123.456
         with self.assertRaises(ValueError):
             generate_latest(self.registry)
 
+    def test_gauge_exemplar(self) -> None:
+        class MyCollector:
+            def collect(self):
+                metric = Metric("gg", "A gauge", 'gauge')
+                # A sample whose name equals the metric name must not be
+                # treated as exemplar-eligible just because it matches;
+                # only histogram/gaugehistogram buckets, counter _total, and
+                # native histograms may carry exemplars.
+                metric.add_sample("gg", {}, 1, None, Exemplar({'a': 'b'}, 0.5))
+                yield metric
+
+        self.registry.register(MyCollector())
+        with self.assertRaises(ValueError):
+            generate_latest(self.registry)
+
     def test_gaugehistogram(self) -> None:
         self.custom_collector(
             GaugeHistogramMetricFamily('gh', 'help', buckets=[('1.0', 4), ('+Inf', (5))], gsum_value=7))


### PR DESCRIPTION
`_is_valid_exemplar_metric()` in `openmetrics/exposition.py` guards histograms with:

```python
if metric.type in ('histogram') and sample.name.endswith('_bucket') or sample.name == metric.name:
```

Since `and` binds tighter than `or`, this is evaluated as:

```python
(metric.type in ('histogram') and sample.name.endswith('_bucket')) or (sample.name == metric.name)
```

so the trailing `sample.name == metric.name` clause runs for *every* metric type, not just histograms. As a result the OpenMetrics writer attaches exemplars to gauge/info/stateset/summary/untyped metrics whenever a sample name equals the metric name — output that this library's own OpenMetrics parser then rejects (`only histogram/gaugehistogram buckets and counters can have exemplars`).

Minimal repro:

```python
from prometheus_client.core import Metric
from prometheus_client.registry import CollectorRegistry
from prometheus_client.openmetrics.exposition import generate_latest
from prometheus_client.samples import Exemplar

reg = CollectorRegistry()

class C:
    def collect(self):
        m = Metric("gg", "a gauge", "gauge")
        m.add_sample("gg", {}, 1.0, None, Exemplar({'a': 'b'}, 0.5))
        yield m

reg.register(C())
print(generate_latest(reg).decode())
# emits `gg 1.0 # {a="b"} 0.5` instead of raising ValueError
```

The fix groups the histogram condition so the same-name clause — which exists to allow native-histogram exemplars, whose sample name equals the metric name — only applies to histograms. I also changed the two `metric.type in ('...')` checks to `==`; with a single string argument they were doing substring matching rather than the intended equality.

Added `test_gauge_exemplar` next to the existing untyped/non-bucket exemplar tests. It fails before the change (`ValueError not raised`) and passes after. Full test suite is green and flake8/isort/mypy pass.

@csmarchbanks
