### PR TITLE
Do not emit a leading zero in floatToGoString exponents >= 10

### DIFF
--- a/prometheus_client/utils.py
+++ b/prometheus_client/utils.py
@@ -21,7 +21,7 @@ def floatToGoString(d):
         # We only need to care about positive values for le/quantile.
         if d > 0 and dot > 6:
             mantissa = f'{s[0]}.{s[1:dot]}{s[dot + 1:]}'.rstrip('0.')
-            return f'{mantissa}e+0{dot - 1}'
+            return f'{mantissa}e+{dot - 1:02d}'
         return s
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import unittest
+
+from prometheus_client.utils import floatToGoString
+
+
+class TestFloatToGoString(unittest.TestCase):
+    def test_exponent_two_digits_has_no_leading_zero(self):
+        # floatToGoString mirrors Go's strconv.FormatFloat(f, 'g', -1, 64),
+        # which pads the exponent to a minimum of two digits. A two-digit
+        # exponent must not gain a spurious leading zero.
+        self.assertEqual('1e+10', floatToGoString(1e10))
+        self.assertEqual('1e+15', floatToGoString(1e15))
+        self.assertEqual('1.234567890123e+12', floatToGoString(1234567890123.0))
+
+    def test_exponent_one_digit_is_zero_padded(self):
+        # Single-digit exponents keep the two-digit zero padding.
+        self.assertEqual('1e+06', floatToGoString(1e6))
+        self.assertEqual('1.234567e+06', floatToGoString(1234567.0))


### PR DESCRIPTION
`floatToGoString` is meant to mirror Go's `strconv.FormatFloat(f, 'g', -1, 64)`, which pads the exponent to a minimum of two digits (`1e+06`, `1e+10`, `1e+15`). The current formatting hard-codes a single `0` in front of the exponent:

```python
return f'{mantissa}e+0{dot - 1}'
```

That is only correct while `dot - 1 < 10`. As soon as the exponent needs two digits, the literal `0` becomes a spurious third digit:

| value | Go / expected | current output |
|-------|---------------|----------------|
| `1e6`  | `1e+06` | `1e+06` |
| `1e10` | `1e+10` | `1e+010` |
| `1e15` | `1e+15` | `1e+015` |
| `1234567890123.0` | `1.234567890123e+12` | `1.234567890123e+012` |

So any histogram/summary whose `le`/quantile boundary is at or above `1e10` serializes a bucket label that doesn't match the value Go/Prometheus would emit for the same float.

Fix: zero-pad the exponent to two digits rather than prepending a literal `0`:

```python
return f'{mantissa}e+{dot - 1:02d}'
```

This keeps the existing two-digit padding for small exponents (`1e+06`) and drops the extra zero for large ones (`1e+10`).

Added `tests/test_utils.py` covering both the single-digit (still zero-padded) and two-digit (no leading zero) cases.
