### PR TITLE
Drop Python 2 compatibility code from bundled decorator module

### DIFF
--- a/prometheus_client/decorator.py
+++ b/prometheus_client/decorator.py
@@ -31,10 +31,9 @@
 Decorator module, see http://pypi.python.org/pypi/decorator
 for the documentation.
 """
-from __future__ import print_function
-
 import collections
 import inspect
+from inspect import getfullargspec
 import itertools
 import operator
 import re
@@ -42,33 +41,10 @@ import sys
 
 __version__ = '4.0.10'
 
-if sys.version_info >= (3,):
-    from inspect import getfullargspec
 
+def get_init(cls):
+    return cls.__init__
 
-    def get_init(cls):
-        return cls.__init__
-else:
-    class getfullargspec(object):
-        "A quick and dirty replacement for getfullargspec for Python 2.X"
-
-        def __init__(self, f):
-            self.args, self.varargs, self.varkw, self.defaults = \
-                inspect.getargspec(f)
-            self.kwonlyargs = []
-            self.kwonlydefaults = None
-
-        def __iter__(self):
-            yield self.args
-            yield self.varargs
-            yield self.varkw
-            yield self.defaults
-
-        getargspec = inspect.getargspec
-
-
-    def get_init(cls):
-        return cls.__init__.__func__
 
 # getargspec has been deprecated in Python 3.5
 ArgSpec = collections.namedtuple(
@@ -113,26 +89,21 @@ class FunctionMaker(object):
                     setattr(self, a, getattr(argspec, a))
                 for i, arg in enumerate(self.args):
                     setattr(self, 'arg%d' % i, arg)
-                if sys.version_info < (3,):  # easy way
-                    self.shortsignature = self.signature = (
-                        inspect.formatargspec(
-                            formatvalue=lambda val: "", *argspec)[1:-1])
-                else:  # Python 3 way
-                    allargs = list(self.args)
-                    allshortargs = list(self.args)
-                    if self.varargs:
-                        allargs.append('*' + self.varargs)
-                        allshortargs.append('*' + self.varargs)
-                    elif self.kwonlyargs:
-                        allargs.append('*')  # single star syntax
-                    for a in self.kwonlyargs:
-                        allargs.append('%s=None' % a)
-                        allshortargs.append('%s=%s' % (a, a))
-                    if self.varkw:
-                        allargs.append('**' + self.varkw)
-                        allshortargs.append('**' + self.varkw)
-                    self.signature = ', '.join(allargs)
-                    self.shortsignature = ', '.join(allshortargs)
+                allargs = list(self.args)
+                allshortargs = list(self.args)
+                if self.varargs:
+                    allargs.append('*' + self.varargs)
+                    allshortargs.append('*' + self.varargs)
+                elif self.kwonlyargs:
+                    allargs.append('*')  # single star syntax
+                for a in self.kwonlyargs:
+                    allargs.append('%s=None' % a)
+                    allshortargs.append('%s=%s' % (a, a))
+                if self.varkw:
+                    allargs.append('**' + self.varkw)
+                    allshortargs.append('**' + self.varkw)
+                self.signature = ', '.join(allargs)
+                self.shortsignature = ', '.join(allshortargs)
                 self.dict = func.__dict__.copy()
         # func=None happens when decorating a caller
         if name:


### PR DESCRIPTION
## What
Removes the Python 2/3 compatibility branching from the vendored `prometheus_client/decorator.py`: the `getfullargspec` shim class, the `formatargspec`-based signature-building path, and the Python 2-only `get_init` variant.

## Why
`pyproject.toml` requires `python_requires = ">=3.9"`, so these Python 2 code paths have been dead for years. This addresses the "at least upgrade it" part of #1107 by cleaning up the vendored copy in place. A full unbundle to an external `decorator` dependency is a separate call for maintainers to make, so this PR doesn't attempt that.

## Testing
- `tox -e flake8` passes
- `tox -e py310`: 379 passed, 35 failed, 12 skipped, 6 errors -- identical to the pre-change baseline (remaining failures are pre-existing and Windows-specific, in `test_multiprocess.py` / `test_wsgi.py`, unrelated to this change)

Fixes #1107
